### PR TITLE
Fixed: Window menu applies previous settings to new window

### DIFF
--- a/src/Widgets/WindowMenu.vala
+++ b/src/Widgets/WindowMenu.vala
@@ -25,13 +25,18 @@ namespace Gala
 	 */
 	public class WindowMenu : Gtk.Menu
 	{
+
+		private bool setting_current_window = false;
+
 		public Meta.Window current_window {
 			get {
 				return _current_window;
 			}
 			set {
+				setting_current_window = true;
 				_current_window = value;
 				update_window ();
+				setting_current_window = false;
 			}
 		}
 
@@ -84,6 +89,8 @@ namespace Gala
 
 			always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
 			always_on_top.activate.connect (() => {
+				if (setting_current_window) return;
+
 				if (current_window.is_above ())
 					current_window.unmake_above ();
 				else
@@ -93,6 +100,8 @@ namespace Gala
 
 			on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
 			on_visible_workspace.activate.connect (() => {
+				if (setting_current_window) return;
+
 				if (current_window.on_all_workspaces)
 					current_window.unstick ();
 				else

--- a/src/Widgets/WindowMenu.vala
+++ b/src/Widgets/WindowMenu.vala
@@ -25,18 +25,22 @@ namespace Gala
 	 */
 	public class WindowMenu : Gtk.Menu
 	{
-
-		private bool setting_current_window = false;
+		ulong always_on_top_handler;
+		ulong on_visible_workspace_handler;
 
 		public Meta.Window current_window {
 			get {
 				return _current_window;
 			}
 			set {
-				setting_current_window = true;
+				SignalHandler.block (always_on_top, always_on_top_handler);
+				SignalHandler.block (on_visible_workspace, on_visible_workspace_handler);
+
 				_current_window = value;
 				update_window ();
-				setting_current_window = false;
+
+				SignalHandler.unblock (always_on_top, always_on_top_handler);
+				SignalHandler.unblock (on_visible_workspace, on_visible_workspace_handler);
 			}
 		}
 
@@ -88,9 +92,7 @@ namespace Gala
 			append (resize);
 
 			always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
-			always_on_top.activate.connect (() => {
-				if (setting_current_window) return;
-
+			always_on_top_handler = always_on_top.activate.connect (() => {
 				if (current_window.is_above ())
 					current_window.unmake_above ();
 				else
@@ -99,9 +101,7 @@ namespace Gala
 			append (always_on_top);
 
 			on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
-			on_visible_workspace.activate.connect (() => {
-				if (setting_current_window) return;
-
+			on_visible_workspace_handler = on_visible_workspace.activate.connect (() => {
 				if (current_window.on_all_workspaces)
 					current_window.unstick ();
 				else

--- a/src/Widgets/WindowMenu.vala
+++ b/src/Widgets/WindowMenu.vala
@@ -25,22 +25,22 @@ namespace Gala
 	 */
 	public class WindowMenu : Gtk.Menu
 	{
-		ulong always_on_top_handler;
-		ulong on_visible_workspace_handler;
+		ulong always_on_top_handler_id;
+		ulong on_visible_workspace_handler_id;
 
 		public Meta.Window current_window {
 			get {
 				return _current_window;
 			}
 			set {
-				SignalHandler.block (always_on_top, always_on_top_handler);
-				SignalHandler.block (on_visible_workspace, on_visible_workspace_handler);
+				SignalHandler.block (always_on_top, always_on_top_handler_id);
+				SignalHandler.block (on_visible_workspace, on_visible_workspace_handler_id);
 
 				_current_window = value;
 				update_window ();
 
-				SignalHandler.unblock (always_on_top, always_on_top_handler);
-				SignalHandler.unblock (on_visible_workspace, on_visible_workspace_handler);
+				SignalHandler.unblock (always_on_top, always_on_top_handler_id);
+				SignalHandler.unblock (on_visible_workspace, on_visible_workspace_handler_id);
 			}
 		}
 
@@ -92,7 +92,7 @@ namespace Gala
 			append (resize);
 
 			always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
-			always_on_top_handler = always_on_top.activate.connect (() => {
+			always_on_top_handler_id = always_on_top.activate.connect (() => {
 				if (current_window.is_above ())
 					current_window.unmake_above ();
 				else
@@ -101,7 +101,7 @@ namespace Gala
 			append (always_on_top);
 
 			on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
-			on_visible_workspace_handler = on_visible_workspace.activate.connect (() => {
+			on_visible_workspace_handler_id = on_visible_workspace.activate.connect (() => {
 				if (current_window.on_all_workspaces)
 					current_window.unstick ();
 				else


### PR DESCRIPTION
There is only one menu made that is shared across all windows. Setting `always_on_top.active` caused the `activate` (and `toggled` as well) signal to execute, causing the current window to get the results of the previous window. 

Fixes: #17