### PR TITLE
Add org.pantheon.desktop.gala.switching settings, add easing settings…

### DIFF
--- a/data/org.pantheon.desktop.gala.gschema.xml.in
+++ b/data/org.pantheon.desktop.gala.gschema.xml.in
@@ -271,4 +271,17 @@
 			<summary>Only show corner masks on primary monitor</summary>
 		</key>
 	</schema>
+	
+	<schema path="/org/pantheon/desktop/gala/switching/" id="org.pantheon.desktop.gala.switching" gettext-domain="@GETTEXT_PACKAGE@">
+		<key type="i" name="ease-in-switch-speed">
+			<default>250</default>
+			<range min="0" max="10000"/>
+			<summary>Speed of easing in</summary>
+		</key>
+		<key type="i" name="ease-out-switch-speed">
+			<default>150</default>
+			<range min="0" max="10000"/>
+			<summary>Speed of easing out</summary>
+		</key>
+	</schema>
 </schemalist>

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -178,4 +178,25 @@ namespace Gala
 			return instance;
 		}
 	}
+
+	public class SwitchingSettings : Granite.Services.Settings
+	{
+		public int ease_in_switch_speed { get; set; }
+		public int ease_out_switch_speed { get; set; }
+
+		static SwitchingSettings? instance = null;
+
+		private SwitchingSettings ()
+		{
+			base (Config.SCHEMA + ".switching");
+		}
+
+		public static unowned SwitchingSettings get_default ()
+		{
+			if (instance == null)
+				instance = new SwitchingSettings ();
+
+			return instance;
+		}
+	}
 }

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -461,7 +461,7 @@ namespace Gala
 
 				if (!clone.window.minimized) {
 					clone.save_easing_state ();
-					clone.set_easing_duration (150);
+					clone.set_easing_duration (SwitchingSettings.get_default ().ease_out_switch_speed);
 					clone.set_easing_mode (AnimationMode.EASE_OUT_CUBIC);
 					clone.z_position = 0;
 					clone.opacity = 255;
@@ -550,7 +550,7 @@ namespace Gala
 				unowned SafeWindowClone clone = (SafeWindowClone) actor;
 
 				actor.save_easing_state ();
-				actor.set_easing_duration (250);
+				actor.set_easing_duration (SwitchingSettings.get_default ().ease_in_switch_speed);
 				actor.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
 
 				if (clone.window == current_window.window) {


### PR DESCRIPTION
… to them

Hi. I'm a novice linux user getting my toes wet with this. I saw a lot of people complaining about the switcher and not being able to customize it.  
This change removes hardcoded values for the easings when doing alt-tab switching.
I'm open to suggestions/opinions either code, convention, feature wise.  