### PR TITLE
Make alt-tab switcher customizable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ po/POTFILES
 po/Rules-quot
 po/stamp-po
 src/gala
+src/**/*.o
 build

--- a/data/org.pantheon.desktop.gala.gschema.xml.in
+++ b/data/org.pantheon.desktop.gala.gschema.xml.in
@@ -271,4 +271,51 @@
 			<summary>Only show corner masks on primary monitor</summary>
 		</key>
 	</schema>
+	
+	<schema path="/org/pantheon/desktop/gala/switcher/" id="org.pantheon.desktop.gala.switcher" gettext-domain="@GETTEXT_PACKAGE@">
+		<key type="i" name="window-switch-ease-duration">
+			<default>250</default>
+			<range min="0" max="10000"/>
+			<summary>Duration of  easing for windows when switching in</summary>
+		</key>
+		<key type="i" name="window-switch-out-opacity">
+			<default>0</default>
+			<range min="0" max="255"/>
+			<summary>Opacity of switched out windows</summary>
+		</key>
+		<key type="i" name="window-switch-out-zoom-out">
+			<default>200</default>
+			<range min="0" max="10000"/>
+			<summary>Zoom out amount of switched out windows</summary>
+		</key>
+		<key type="i" name="icons-bar-ease-in-duration">
+			<default>250</default>
+			<range min="0" max="10000"/>
+			<summary>Duration of easings for windows when switching in</summary>
+		</key>
+		<key type="i" name="icons-bar-ease-out-duration">
+			<default>150</default>
+			<range min="0" max="10000"/>
+			<summary>Duration of easings for windows when switching out</summary>
+		</key>
+		<key type="b" name="icons-bar-center">
+			<default>false</default>
+			<summary>Center the icons bar</summary>
+		</key>
+		<key type="i" name="icon-size">
+			<default>56</default>
+			<range min="0" max="10000"/>
+			<summary>Size of icons in the switch bar</summary>
+		</key>
+		<key type="i" name="icon-switch-ease-duration">
+			<default>100</default>
+			<range min="0" max="10000"/>
+			<summary>Duration of easings for icons switch</summary>
+		</key>
+		<key type="i" name="icon-switch-out-opacity">
+			<default>100</default>
+			<range min="0" max="255"/>
+			<summary>Opacity of switched out icons (as in, not selected in the switcher)</summary>
+		</key>
+	</schema>
 </schemalist>

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -178,4 +178,32 @@ namespace Gala
 			return instance;
 		}
 	}
+
+	public class SwitcherSettings : Granite.Services.Settings
+	{
+		public int window_switch_ease_duration { get; set; }
+		public int window_switch_out_opacity { get; set; }
+		public int window_switch_out_zoom_out { get; set; }
+		public int icons_bar_ease_in_duration { get; set; }
+		public int icons_bar_ease_out_duration { get; set; }
+		public bool icons_bar_center { get; set; }
+		public int icon_size { get; set; }
+		public int icon_switch_ease_duration { get; set; }
+		public int icon_switch_out_opacity { get; set; }
+
+		static SwitcherSettings? instance = null;
+
+		private SwitcherSettings ()
+		{
+			base (Config.SCHEMA + ".switcher");
+		}
+
+		public static unowned SwitcherSettings get_default ()
+		{
+			if (instance == null)
+				instance = new SwitcherSettings ();
+
+			return instance;
+		}
+	}
 }

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -145,7 +145,7 @@ namespace Gala
 			var layout = (BoxLayout) dock.layout_manager;
 
 			var position = dock_settings.Position;
-			var icon_size = dock_settings.IconSize;
+			var icon_size = SwitcherSettings.get_default ().icon_size;
 			var scaled_icon_size = icon_size / 10.0f;
 			var horizontal = dock_settings.is_horizontal_dock ();
 
@@ -251,7 +251,10 @@ namespace Gala
 
 		void place_dock ()
 		{
-			var icon_size = dock_settings.IconSize;
+			int screen_width = 0;
+			int screen_height = 0;
+			wm.get_screen().get_size(out screen_width, out screen_height);
+			var icon_size = SwitcherSettings.get_default ().icon_size;
 			var scaled_icon_size = icon_size / 10.0f;
 			var line_width = dock_theme.LineWidth;
 			var horiz_padding = dock_theme.HorizPadding * scaled_icon_size;
@@ -266,11 +269,23 @@ namespace Gala
 			if (dock_settings.is_horizontal_dock ()) {
 				dock.width = dock_width;
 				dock.translation_x = Math.ceilf (-dock_width / 2.0f);
+				if (SwitcherSettings.get_default ().icons_bar_center) {
+					dock.translation_y = -(screen_height/2);	
+				}
+				else {
+					dock.translation_y = 0;
+				}
 				dock.get_first_child ().margin_left = items_offset;
 				dock.get_last_child ().margin_right = items_offset;
 			} else {
 				dock.height = dock_width;
 				dock.translation_y = Math.ceilf (-dock_width / 2.0f);
+				if (SwitcherSettings.get_default ().icons_bar_center) {
+					dock.translation_x = -(screen_width/2);	
+				}
+				else {
+					dock.translation_x = 0;
+				}
 				dock.get_first_child ().margin_top = items_offset;
 				dock.get_last_child ().margin_bottom = items_offset;
 			}
@@ -281,7 +296,7 @@ namespace Gala
 		void animate_dock_width ()
 		{
 			dock.save_easing_state ();
-			dock.set_easing_duration (250);
+			dock.set_easing_duration (SwitcherSettings.get_default ().icons_bar_ease_in_duration);
 			dock.set_easing_mode (AnimationMode.EASE_OUT_CUBIC);
 
 			float dest_width;
@@ -461,7 +476,7 @@ namespace Gala
 
 				if (!clone.window.minimized) {
 					clone.save_easing_state ();
-					clone.set_easing_duration (150);
+					clone.set_easing_duration (SwitcherSettings.get_default ().icons_bar_ease_out_duration);
 					clone.set_easing_mode (AnimationMode.EASE_OUT_CUBIC);
 					clone.z_position = 0;
 					clone.opacity = 255;
@@ -493,7 +508,7 @@ namespace Gala
 			}
 
 			dock.save_easing_state ();
-			dock.set_easing_duration (250);
+			dock.set_easing_duration (SwitcherSettings.get_default ().icons_bar_ease_out_duration);
 			dock.set_easing_mode (AnimationMode.EASE_OUT_CUBIC);
 
 			if (dock_settings.is_horizontal_dock ()) {
@@ -528,7 +543,7 @@ namespace Gala
 
 			window_clones.add_child (clone);
 
-			var icon = new WindowIcon (window, dock_settings.IconSize, true);
+			var icon = new WindowIcon (window, SwitcherSettings.get_default ().icon_size, true);
 			icon.reactive = true;
 			icon.opacity = 100;
 			icon.x_expand = true;
@@ -550,7 +565,7 @@ namespace Gala
 				unowned SafeWindowClone clone = (SafeWindowClone) actor;
 
 				actor.save_easing_state ();
-				actor.set_easing_duration (250);
+				actor.set_easing_duration (SwitcherSettings.get_default ().window_switch_ease_duration);
 				actor.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
 
 				if (clone.window == current_window.window) {
@@ -558,8 +573,8 @@ namespace Gala
 					actor.z_position = 0;
 					actor.opacity = 255;
 				} else {
-					actor.z_position = -200;
-					actor.opacity = window_opacity;
+					actor.z_position = -(SwitcherSettings.get_default ().window_switch_out_zoom_out);
+					actor.opacity = SwitcherSettings.get_default ().window_switch_out_opacity;
 				}
 
 				actor.restore_easing_state ();
@@ -568,13 +583,13 @@ namespace Gala
 			foreach (var actor in dock.get_children ()) {
 				unowned WindowIcon icon = (WindowIcon) actor;
 				icon.save_easing_state ();
-				icon.set_easing_duration (100);
+				icon.set_easing_duration (SwitcherSettings.get_default ().icon_switch_ease_duration);
 				icon.set_easing_mode (AnimationMode.LINEAR);
 
 				if (icon == current_window)
 					icon.opacity = 255;
 				else
-					icon.opacity = 100;
+					icon.opacity = SwitcherSettings.get_default ().icon_switch_out_opacity;
 
 				icon.restore_easing_state ();
 			}


### PR DESCRIPTION
This adds a couple of dconf keys to customize the switcher:
* **icon-size**: Size of icons in the switch bar
* **icon-switch-ease-duration**: Duration of easings for icons switch
* **icon-switch-out-opacity**: Opacity of switched out icons (as in, not selected in the switcher)
* **icon-bar-center**: Center the icons bar
* **icons-bar-ease-in-duration**: Duration of easings for icons when switching in
* **icons-bar-ease-out-duration**: Duration of easings for icons when switching out
* **window-switch-ease-duration**: Duration of  easing for windows when switching in
* **window-switch-out-opacity**: Opacity of switched out windows
* **window-switch-out-zoom**: Zoom out amount of switched out windows

Keep in mind that after changing the icon size, it needs to restart to look correctly. To make it work on the fly, the code needs to be refactored.  
I'm open to suggestions.