### PR TITLE
pip: Fix ShadowEffect namespace

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -112,7 +112,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		container.reactive = true;
 		container.set_scale (0.35f, 0.35f);
 		container.clip_rect = container_clip;
-		container.add_effect (new Gala.ShadowEffect (SHADOW_SIZE, 2));
+		container.add_effect (new ShadowEffect (SHADOW_SIZE, 2));
 		container.add_child (clone);
 		container.add_action (move_action);
 

--- a/plugins/pip/ShadowEffect.vala
+++ b/plugins/pip/ShadowEffect.vala
@@ -17,7 +17,7 @@
 
 using Clutter;
 
-namespace Gala
+namespace Gala.Plugins.PIP
 {
 	public class ShadowEffect : Effect
 	{


### PR DESCRIPTION
Fixes GObject registration of the `ShadowEffect` class. The class was having the same signature as it's original one in Gala itself and could not be registered as a valid class.