### PR TITLE
pip: Fix Gtk+3 windows having an incorrect allocation size

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -378,7 +378,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		if (container_clip != null) {
 			width = container_clip.get_width ();
 			height = container_clip.get_height ();
-		} else if (clone.has_clip){
+		} else if (clone.has_clip) {
 			float clone_clip_width = 0.0f, clone_clip_height = 0.0f;
 			clone.get_clip (null, null, out clone_clip_width, out clone_clip_height);
 			width = clone_clip_width;

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -96,9 +96,9 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		if (container_clip == null) {
 			window_actor.notify["allocation"].connect (on_allocation_changed);
 			container.set_position (CONTAINER_MARGIN, CONTAINER_MARGIN);
+			update_clone_clip ();
 		}
 
-		update_clone_window_frame ();
 		update_size ();
 		update_container_position ();
 
@@ -247,7 +247,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 
 	private void on_allocation_changed ()
 	{
-		update_clone_window_frame ();
+		update_clone_clip ();
 		update_size ();
 		reposition_resize_button ();
 		reposition_resize_handle ();
@@ -276,19 +276,16 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		}
 	}
 
-	private void update_clone_window_frame ()
+	private void update_clone_clip ()
 	{
-		if (container_clip == null) {
-			var rect = window_actor.get_meta_window ().get_frame_rect ();
+		var rect = window_actor.get_meta_window ().get_frame_rect ();
 
-			float x_offset = rect.x - window_actor.x;
-			float y_offset = rect.y - window_actor.y;
-			clone.set_clip (x_offset, y_offset, rect.width, rect.height);
-			clone.x = -x_offset;
-			clone.y = -y_offset;
+		float x_offset = rect.x - window_actor.x;
+		float y_offset = rect.y - window_actor.y;
+		clone.set_clip (x_offset, y_offset, rect.width, rect.height);
+		clone.set_position (-x_offset, -y_offset);
 
-			container.set_size (rect.width, rect.height);
-		}
+		container.set_size (rect.width, rect.height);
 	}
 
 	private void update_container_scale ()
@@ -381,15 +378,14 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		if (container_clip != null) {
 			width = container_clip.get_width ();
 			height = container_clip.get_height ();
+		} else if (clone.has_clip){
+			float clone_clip_width = 0.0f, clone_clip_height = 0.0f;
+			clone.get_clip (null, null, out clone_clip_width, out clone_clip_height);
+			width = clone_clip_width;
+			height = clone_clip_height;
 		} else {
-			var clip = clone.clip_rect; 
-			if (clip != null) {
-				width = clip.get_width ();
-				height = clip.get_height ();
-			} else {
-				width = clone.width;
-				height = clone.height;
-			}
+			width = clone.width;
+			height = clone.height;
 		}
 	}
 

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -98,6 +98,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 			container.set_position (CONTAINER_MARGIN, CONTAINER_MARGIN);
 		}
 
+		update_clone_window_frame ();
 		update_size ();
 		update_container_position ();
 
@@ -246,6 +247,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 
 	private void on_allocation_changed ()
 	{
+		update_clone_window_frame ();
 		update_size ();
 		reposition_resize_button ();
 		reposition_resize_handle ();
@@ -271,6 +273,21 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		} else {
 			width = (int)(container.width * container.scale_x + BUTTON_SIZE);
 			height = (int)(container.height * container.scale_y + BUTTON_SIZE);
+		}
+	}
+
+	private void update_clone_window_frame ()
+	{
+		if (container_clip == null) {
+			var rect = window_actor.get_meta_window ().get_frame_rect ();
+
+			float x_offset = rect.x - window_actor.x;
+			float y_offset = rect.y - window_actor.y;
+			clone.set_clip (x_offset, y_offset, rect.width, rect.height);
+			clone.x = -x_offset;
+			clone.y = -y_offset;
+
+			container.set_size (rect.width, rect.height);
 		}
 	}
 
@@ -365,8 +382,14 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 			width = container_clip.get_width ();
 			height = container_clip.get_height ();
 		} else {
-			width = window_actor.width;
-			height = window_actor.height;
+			var clip = clone.clip_rect; 
+			if (clip != null) {
+				width = clip.get_width ();
+				height = clip.get_height ();
+			} else {
+				width = clone.width;
+				height = clone.height;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #35.

This fixes an incorrect shadow size appearing for Gtk+3 windows by getting the right window frame instead of the entire window actor. To accompansate for the top and left edge, the clone is shifted to `x_offset` and `y_offset` and a new size is set for the clone container, since the clone now has a clip that is the actual size of the clone, rather than it's original window actor size.