### PR TITLE
fix for newer vala: you can't use return_if_fail in constructor

### DIFF
--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -47,7 +47,6 @@ namespace Gala
 		construct
 		{
 			var schema = GLib.SettingsSchemaSource.get_default ().lookup ("org.gnome.desktop.input-sources", true);
-			return_if_fail (schema != null);
 			
 			settings = new GLib.Settings.full (schema, null, null);
 			Signal.connect (settings, "changed", (Callback) set_keyboard_layout, this);


### PR DESCRIPTION
TODO: use contracts to check for null there