### PR TITLE
MultitaskingView: Don't allow scrolling though workspaces while closing

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -164,6 +164,9 @@ namespace Gala
 		 */
 		public override bool scroll_event (ScrollEvent scroll_event)
 		{
+			if (!opened)
+				return true;
+
 			if (scroll_event.direction != ScrollDirection.SMOOTH)
 				return false;
 
@@ -337,10 +340,12 @@ namespace Gala
 		 */
 		public override bool key_press_event (Clutter.KeyEvent event)
 		{
+			if (!opened)
+				return true;
+
 			switch (event.keyval) {
 				case Clutter.Key.Escape:
-					if (opened)
-						toggle ();
+					toggle ();
 					break;
 				case Clutter.Key.Down:
 					select_window (MotionDirection.DOWN);


### PR DESCRIPTION
Currently, scrolling during the closing animation changes the workspace, up to the last second of the animation. This makes you have to wait until the animation stops before you can start scrolling on a web page for example

Just added a check to see if it was opened, and returns if it's not :) 