### PR TITLE
Document libxml2-utils as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You'll need the following dependencies:
 * libplank-dev (>= 0.10.9)
 * libtool
 * valac (>= 0.28.0)
+* libxml2-utils
 
 Run `autogen.sh` to configure the build environment and then `make` to build
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ You'll need the following dependencies:
 * libmutter-0-dev (>= 3.23.90) | libmutter-dev (>= 3.14.4)
 * libplank-dev (>= 0.10.9)
 * libtool
-* valac (>= 0.28.0)
 * libxml2-utils
+* valac (>= 0.28.0)
 
 Run `autogen.sh` to configure the build environment and then `make` to build
 


### PR DESCRIPTION
Running `autogen.sh` would result in
```
configure: error: xmllint not found
```
I understood from [pull request #36](https://github.com/elementary/gala/pull/36) that it was missing `libxml2-utils` as dependency