### PR TITLE
Implement select_area

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -69,6 +69,7 @@ gala_VALASOURCES = \
 	Widgets/WindowSwitcher.vala \
 	Widgets/WorkspaceClone.vala \
 	Widgets/WorkspaceInsertThumb.vala \
+	Widgets/SelectionArea.vala \
 	$(NULL)
 
 nodist_gala_SOURCES = \

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -85,7 +85,7 @@ namespace Gala
 			success = save_image (image, filename, out filename_used);
 		}
 
-		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError
+		public async void select_area (out int x, out int y, out int width, out int height)
 		{
 			var selection_area = new SelectionArea (wm);
 			selection_area.closed.connect (() => Idle.add (select_area.callback));

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -85,12 +85,18 @@ namespace Gala
 			success = save_image (image, filename, out filename_used);
 		}
 
-		public void select_area (out int x, out int y, out int width, out int height) throws DBusError
+		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError
 		{
-			warning ("SelectArea not implemented");
 			x = y = width = height = 0;
 
-			throw new DBusError.FAILED ("SelectArea not implemented");
+			var selection_area = new SelectionArea (wm);
+			selection_area.closed.connect (() => Idle.add (select_area.callback));
+			wm.ui_group.add (selection_area);
+			selection_area.start_selection ();
+
+			yield;
+			selection_area.get_selection_rectangle (out x, out y, out width, out height);
+			wm.ui_group.remove (selection_area);
 		}
 
 		static bool save_image (Cairo.ImageSurface image, string filename, out string used_filename)

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -87,8 +87,6 @@ namespace Gala
 
 		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError
 		{
-			x = y = width = height = 0;
-
 			var selection_area = new SelectionArea (wm);
 			selection_area.closed.connect (() => Idle.add (select_area.callback));
 			wm.ui_group.add (selection_area);

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -1,0 +1,169 @@
+//
+//  Copyright (C) 2017 Santiago León O., Adam Bieńkowski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Gala
+{ 
+    public class SelectionArea : Clutter.Actor
+    {
+        public signal void closed ();
+
+        public WindowManager wm { get; construct; }
+
+        private ModalProxy? modal_proxy;
+        private Gdk.Point start_point;
+        private Gdk.Point end_point;
+        private bool dragging = false;
+        private bool clicked = false;
+
+        public SelectionArea (WindowManager wm)
+        {
+            Object (wm: wm);
+        }
+
+        construct
+        {
+            start_point = { 0, 0 };
+            end_point = { 0, 0 };
+            visible = true;
+            reactive = true;
+
+            int screen_width, screen_height;
+            wm.get_screen ().get_size (out screen_width, out screen_height);
+            width = screen_width;
+            height = screen_height;
+
+            var canvas = new Clutter.Canvas ();
+            canvas.set_size (screen_width, screen_height);
+            canvas.draw.connect (draw_area);
+            set_content (canvas);
+
+            canvas.invalidate ();
+        }
+
+        public override bool key_press_event (Clutter.KeyEvent e)
+        {
+            if (e.keyval == Clutter.Key.Escape) {
+                close ();
+                closed ();
+                return true;
+            }
+
+            return false;
+        }
+
+        public override bool button_press_event (Clutter.ButtonEvent e)
+        {
+            if (dragging || e.button != 1) {
+                return true;
+            }
+
+            clicked = true;
+
+            start_point.x = (int) e.x;
+            start_point.y = (int) e.y;
+
+            return true;
+        }
+
+        public override bool button_release_event (Clutter.ButtonEvent e)
+        {
+            if (e.button != 1) {
+                return true;
+            }
+
+            if (!dragging) {
+                close ();
+                return true;
+            }
+
+            dragging = false;
+            clicked = false;
+
+            close ();
+            this.hide ();
+            content.invalidate ();
+
+            closed ();
+            return true;
+        }
+
+        public override bool motion_event (Clutter.MotionEvent e)
+        {
+            if (!clicked) {
+                return true;
+            }
+
+            end_point.x = (int) e.x;
+            end_point.y = (int) e.y;
+            content.invalidate ();
+
+            if (!dragging) {
+                dragging = true;
+            }
+
+            return true;
+        }
+
+        public void close ()
+        {
+            wm.get_screen ().set_cursor (Meta.Cursor.DEFAULT);
+
+            if (modal_proxy != null) {
+                wm.pop_modal (modal_proxy);
+            }
+        }
+
+        public void start_selection ()
+        {
+            wm.get_screen ().set_cursor (Meta.Cursor.CROSSHAIR);
+            grab_key_focus ();
+
+            modal_proxy = wm.push_modal ();
+        }
+
+        public void get_selection_rectangle (out int x, out int y, out int width, out int height)
+        {
+            x = int.min (start_point.x, end_point.x);
+            y = int.min (start_point.y, end_point.y);
+            width = (start_point.x - end_point.x).abs ();
+            height = (start_point.y - end_point.y).abs ();
+        }
+
+        private bool draw_area (Cairo.Context ctx)
+        {
+            Clutter.cairo_clear (ctx);
+
+            if (!dragging) {
+                return true;
+            }
+
+            int x, y, w, h;
+            get_selection_rectangle (out x, out y, out w, out h);
+
+            ctx.rectangle (x, y, w, h);
+            ctx.set_source_rgba (0.1, 0.1, 0.1, 0.2);
+            ctx.fill ();
+
+            ctx.rectangle (x, y, w, h);
+            ctx.set_source_rgb (0.7, 0.7, 0.7);
+            ctx.set_line_width (1.0);
+            ctx.stroke ();
+
+            return true;
+        }
+    }
+}

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -87,6 +87,7 @@ namespace Gala
 
             if (!dragging) {
                 close ();
+                closed ();
                 return true;
             }
 


### PR DESCRIPTION
This branch implements `select_area` in `org.gnome.Shell.Screenshot` DBus interface. The SelectionArea.vala file is copied from PIP plugin and has been a little bit modified to fit the requirements of selecting an area of a screenshot.

I changed the signature of the `select_area` method has been changed to be async since we need to wait for the user to select the area and then return results.