### PR TITLE
pip: Hide the preview when the target window is focused

### DIFF
--- a/plugins/pip/Main.vala
+++ b/plugins/pip/Main.vala
@@ -91,9 +91,23 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin
 				var clip = rect.init (point_x, point_y, width, height);
 
 				var popup_window = new PopupWindow (wm, active, clip);
+				popup_window.show.connect (on_popup_window_show);
+				popup_window.hide.connect (on_popup_window_hide);
 				add_window (popup_window);
 			}
 		}
+	}
+
+	private void on_popup_window_show (Clutter.Actor popup_window)
+	{
+		track_actor (popup_window);
+		update_region ();
+	}
+
+	private void on_popup_window_hide (Clutter.Actor popup_window)
+	{
+		untrack_actor (popup_window);
+		update_region ();
 	}
 
 	private void select_window_at (int x, int y)
@@ -101,6 +115,8 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin
 		var selected = get_window_actor_at (x, y);
 		if (selected != null) {
 			var popup_window = new PopupWindow (wm, selected, null);
+			popup_window.show.connect (on_popup_window_show);
+			popup_window.hide.connect (on_popup_window_hide);
 			add_window (popup_window);
 		}
 	}
@@ -167,7 +183,6 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin
 	{
 		popup_window.closed.connect (() => remove_window (popup_window));
 		windows.add (popup_window);
-		track_actor (popup_window);
 		wm.ui_group.add_child (popup_window);
 	}
 

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -77,6 +77,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 
 		var window = window_actor.get_meta_window ();
 		window.unmanaged.connect (on_close_click_clicked);
+		window.notify["appears-focused"].connect (on_appears_focused_changed);
 
 		clone = new Clutter.Clone (window_actor.get_texture ());
 
@@ -151,6 +152,22 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		opacity = 255;
 
 		set_easing_duration (0);
+	}
+
+	public override void hide ()
+	{
+		opacity = 255;
+		
+		set_easing_duration (200);
+		opacity = 0;
+
+		set_easing_duration (0);
+
+		ulong completed_id = 0UL;
+		completed_id = transitions_completed.connect (() => {
+			disconnect (completed_id);
+			base.hide ();
+		});
 	}
 
 	public override bool enter_event (Clutter.CrossingEvent event)
@@ -263,6 +280,16 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 			closed ();
 			return false;
 		});
+	}
+
+	private void on_appears_focused_changed ()
+	{
+		var window = window_actor.get_meta_window ();
+		if (window.appears_focused) {
+			hide ();
+		} else {
+			show ();
+		}
 	}
 
 	private void update_size ()


### PR DESCRIPTION
Fixes #99.

Hides the preview when the choosen window is currently focused.