### PR TITLE
Move the fullscreened window to the next workspace

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -142,24 +142,24 @@ namespace Gala
 		 */
 		public static void insert_workspace_with_window (int index, Window new_window)
 		{
-			unowned List<WindowActor> actors = Compositor.get_window_actors (new_window.get_screen ());
-
-			var workspace_manager = WorkspaceManager.get_default ();
+			unowned WorkspaceManager workspace_manager = WorkspaceManager.get_default ();
 			workspace_manager.freeze_remove ();
 
 			new_window.change_workspace_by_index (index, false);
 
+			unowned List<WindowActor> actors = Compositor.get_window_actors (new_window.get_screen ());
 			foreach (unowned Meta.WindowActor actor in actors) {
-				unowned Meta.Window window = actor.get_meta_window ();
 				if (actor.is_destroyed ())
 					continue;
 
-				var window_index = window.get_workspace ().index ();
+				unowned Meta.Window window = actor.get_meta_window ();
+				if (window == new_window)
+					continue;
 
-				if (!window.on_all_workspaces
-					&& window != new_window
-					&& window_index >= index) {
-					window.change_workspace_by_index (window_index + 1, true);
+				var current_index = window.get_workspace ().index ();
+				if (current_index >= index
+					&& !window.on_all_workspaces) {
+					window.change_workspace_by_index (current_index + 1, true);
 				}
 			}
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -796,8 +796,10 @@ namespace Gala
 				if (Utils.get_n_windows (win_ws) <= 1)
 					return;
 
-				var new_ws_index = screen.get_n_workspaces () - 1;
 				var old_ws_index = win_ws.index ();
+				var new_ws_index = old_ws_index + 1;
+				InternalUtils.insert_workspace_with_window (new_ws_index, window);
+
 				var new_ws_obj = screen.get_workspace_by_index (new_ws_index);
 				window.change_workspace (new_ws_obj);
 				new_ws_obj.activate_with_focus (window, time);


### PR DESCRIPTION
Fixes #116.

When a window is fullscreened, shift all the workspaces and their windows by 1 to make space for a new workspace next to the workspace that the window was originally fullscreened on.

That means if you fullscreen a window on the first workspace, it'll go to new a second one and all other workspaces will be shifted to the right to make space for that second workspace.