### PR TITLE
pip: only update focus changes when switching from a normal window

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -49,6 +49,8 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 	private float begin_resize_width = 0.0f;
 	private float begin_resize_height = 0.0f;
 
+	static unowned Meta.Window? previous_focus = null;
+
 	// From https://opensourcehacker.com/2011/12/01/calculate-aspect-ratio-conserving-resize-for-images-in-javascript/
 	static void calculate_aspect_ratio_size_fit (float src_width, float src_height, float max_width, float max_height,
 		out float width, out float height)
@@ -56,6 +58,14 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		float ratio = float.min (max_width / src_width, max_height / src_height);
 		width = src_width * ratio;
 		height = src_height * ratio;
+	}
+
+	static bool get_window_is_normal (Meta.Window window)
+	{
+		var window_type = window.get_window_type ();
+		return window_type == Meta.WindowType.NORMAL
+			|| window_type == Meta.WindowType.DIALOG
+			|| window_type == Meta.WindowType.MODAL_DIALOG;
 	}
 
 	static void get_current_cursor_position (out int x, out int y)
@@ -77,7 +87,12 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 
 		var window = window_actor.get_meta_window ();
 		window.unmanaged.connect (on_close_click_clicked);
-		window.notify["appears-focused"].connect (on_appears_focused_changed);
+		window.notify["appears-focused"].connect (() => {
+			Idle.add (() => {
+				update_window_focus ();
+				return false;
+			});
+		});
 
 		clone = new Clutter.Clone (window_actor.get_texture ());
 
@@ -282,14 +297,23 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		});
 	}
 
-	private void on_appears_focused_changed ()
+	private void update_window_focus ()
 	{
+		unowned Meta.Window focus_window = wm.get_screen ().get_display ().get_focus_window ();
+		if ((focus_window != null && !get_window_is_normal (focus_window))
+			|| (previous_focus != null && !get_window_is_normal (previous_focus))) {
+			previous_focus = focus_window;
+			return;
+		}
+
 		var window = window_actor.get_meta_window ();
 		if (window.appears_focused) {
 			hide ();
 		} else {
 			show ();
 		}
+
+		previous_focus = focus_window;
 	}
 
 	private void update_size ()


### PR DESCRIPTION
Fixes #169.

Do not update PiP window visibility when switching from a non-normal window, that is docks, desktop windows etc. This prevents hiding the PiP window when e.g: showing a popover from wingpanel.