### PR TITLE
gsettings: make window close duration shorter

### DIFF
--- a/data/org.pantheon.desktop.gala.gschema.xml.in
+++ b/data/org.pantheon.desktop.gala.gschema.xml.in
@@ -189,7 +189,7 @@
 			<summary>Duration of the snap animation as used by maximize/unmaximize</summary>
 		</key>
 		<key type="i" name="close-duration">
-			<default>300</default>
+			<default>195</default>
 			<summary>Duration of the close animation</summary>
 		</key>
 		<key type="i" name="minimize-duration">


### PR DESCRIPTION
Decreases window close duration from 300 to 195, which is a little bit faster, we discussed this in #56 and it seems that 195 is a good middleground for this setting.