### PR TITLE
Fix maximize / minimize animations

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -821,7 +821,7 @@ namespace Gala
 
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
-			var window = actor.get_meta_window ();
+			unowned Meta.Window window = actor.get_meta_window ();
 			ulong signal_id = 0U;
 			signal_id = window.size_changed.connect (() => {
 				window.disconnect (signal_id);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -821,22 +821,25 @@ namespace Gala
 
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
-			var new_rect = actor.get_meta_window ().get_frame_rect ();
-			
-			switch (which_change) {
-				case Meta.SizeChange.MAXIMIZE:
-					maximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
-					break;
-				case Meta.SizeChange.UNMAXIMIZE:
-					unmaximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
-					break;
-				case Meta.SizeChange.FULLSCREEN:
-				case Meta.SizeChange.UNFULLSCREEN:
-					handle_fullscreen_window (actor.get_meta_window (), which_change);
-					break;
-			}
+			Idle.add (() => {
+				var new_rect = actor.get_meta_window ().get_frame_rect ();
+				
+				switch (which_change) {
+					case Meta.SizeChange.MAXIMIZE:
+						maximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
+						break;
+					case Meta.SizeChange.UNMAXIMIZE:
+						unmaximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
+						break;
+					case Meta.SizeChange.FULLSCREEN:
+					case Meta.SizeChange.UNFULLSCREEN:
+						handle_fullscreen_window (actor.get_meta_window (), which_change);
+						break;
+				}
 
-			size_change_completed (actor);
+				size_change_completed (actor);
+				return false;
+			});
 		}
 
 		public override void minimize (WindowActor actor)

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -822,6 +822,11 @@ namespace Gala
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
 			unowned Meta.Window window = actor.get_meta_window ();
+			if (window.get_tile_match () != null) {
+				size_change_completed (actor);
+				return;
+			}	
+
 			ulong signal_id = 0U;
 			signal_id = window.size_changed.connect (() => {
 				window.disconnect (signal_id);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -821,8 +821,11 @@ namespace Gala
 
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
-			Idle.add (() => {
-				var new_rect = actor.get_meta_window ().get_frame_rect ();
+			var window = actor.get_meta_window ();
+			ulong signal_id = 0U;
+			signal_id = window.size_changed.connect (() => {
+				window.disconnect (signal_id);
+				var new_rect = window.get_frame_rect ();
 				
 				switch (which_change) {
 					case Meta.SizeChange.MAXIMIZE:
@@ -838,7 +841,6 @@ namespace Gala
 				}
 
 				size_change_completed (actor);
-				return false;
 			});
 		}
 


### PR DESCRIPTION
Fixes #75.

It looks like that some internal changes in mutter caused `get_frame_rect` to return not updated new size of the window resizing. (This is because for some reason the frame size is updated after the actual `size_change` method in the plugin is called: https://github.com/GNOME/mutter/blob/20176d0395294b9eeb7f0e28f1a1a35705fa0888/src/core/window.c#L2866)

That's why the animation happened, but there was no scale animation visible, only opacity. Waiting for the `size_changed` signal works here.