### PR TITLE
Dont move window from last workspace to another

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -504,7 +504,7 @@ namespace Gala
 			var next = active.get_neighbor (direction);
 
 			//dont allow empty workspaces to be created by moving, if we have dynamic workspaces
-			if (Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1  && next.index () ==  screen.n_workspaces - 1) {
+			if (Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () ==  screen.n_workspaces - 1) {
 				Utils.bell (screen);
 				return;
 			}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -504,7 +504,7 @@ namespace Gala
 			var next = active.get_neighbor (direction);
 
 			//dont allow empty workspaces to be created by moving, if we have dynamic workspaces
-			if (Prefs.get_dynamic_workspaces () && active.n_windows == 1 && next.index () ==  screen.n_workspaces - 1) {
+			if (Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1  && next.index () ==  screen.n_workspaces - 1) {
 				Utils.bell (screen);
 				return;
 			}


### PR DESCRIPTION
This fixes an issue where you could constantly move a window to the next workspace with `Super+Alt+Right`.

This was the case because gala wrongly assumed that `n_windows` returns only normal windows from the workspace while it returns the count of all windows (dock, panel etc.) so this always condition was always false.