### PR TITLE
Disallow translating icon name

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -8,22 +8,42 @@ gala_gschema = configure_file(
 
 gala_gschema_compile = gnome.compile_schemas()
 
-i18n.merge_file(
-	input: 'gala-multitaskingview.desktop.in',
-	output: 'gala-multitaskingview.desktop',
-	po_dir: join_paths(meson.source_root (), 'po'),
-	type: 'desktop',
-	install: true,
-	install_dir: join_paths(data_dir, 'applications')
+msgfmt = find_program('msgfmt')
+
+custom_target('gala-multitaskingview.desktop_merge',
+    input: 'gala-multitaskingview.desktop.in',
+    output: 'gala-multitaskingview.desktop',
+    command : [msgfmt,
+               '--desktop',
+               '--keyword=Comment',
+               '--keyword=Name',
+               '--keyword=Keywords',
+               '--keyword=GenericName',
+               '-d' + join_paths(meson.source_root (), 'po'),
+               '--template=@INPUT@',
+               '-o@OUTPUT@',
+               ],
+    install : true,
+    install_dir: join_paths(data_dir, 'applications')
 )
-i18n.merge_file(
-	input: 'gala-other.desktop.in',
-	output: 'gala-other.desktop',
-	po_dir: join_paths(meson.source_root (), 'po'),
-	type: 'desktop',
-	install: true,
-	install_dir: join_paths(data_dir, 'applications')
+
+custom_target('gala-other.desktop_merge',
+    input: 'gala-other.desktop.in',
+    output: 'gala-other.desktop',
+    command : [msgfmt,
+               '--desktop',
+               '--keyword=Comment',
+               '--keyword=Name',
+               '--keyword=Keywords',
+               '--keyword=GenericName',
+               '-d' + join_paths(meson.source_root (), 'po'),
+               '--template=@INPUT@',
+               '-o@OUTPUT@',
+               ],
+    install : true,
+    install_dir: join_paths(data_dir, 'applications')
 )
+
 install_data(['gala.desktop', 'gala-wayland.desktop'], install_dir: join_paths(data_dir, 'applications'))
 
 icons_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')


### PR DESCRIPTION
Fixes #254 

I think this is the best way to fix this, due to the fact that I don't think we can pass args to `msgfmt` in meson (yet?). But it would be good for @tintou to confirm.