### PR TITLE
Fix adding last workspace animation

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -284,7 +284,7 @@ namespace Gala
 			workspaces.insert_child_at_index (workspace, num);
 			icon_groups.add_group (workspace.icon_group);
 
-			update_positions (opened);
+			update_positions (false);
 
 			if (opened)
 				workspace.open ();


### PR DESCRIPTION
Fixes #142 (see https://youtu.be/3ajzLyfizZU by @alex285)

Fixes a weird animation when moving an app from one workspace to the last one caused by initially not positioned new workspace clone that's being added. 
This is actually an easy fix that just tells that `update_position` should not animate the position of the workspace when a workspace is added.