### PR TITLE
WindowListener: Don't bail out of window_maximized_changed

### DIFF
--- a/src/WindowListener.vala
+++ b/src/WindowListener.vala
@@ -99,10 +99,6 @@ namespace Gala
 
 		void window_maximized_changed (Window window)
 		{
-			// we only need to save when we were unmaximized and now go maximized
-			if (!window.maximized_vertically || !window.maximized_horizontally)
-				return;
-
 			WindowGeometry window_geometry = {};
 			window_geometry.inner = window.get_frame_rect ();
 			window_geometry.outer = window.get_buffer_rect ();


### PR DESCRIPTION
The unmaximized_state_geometry isn't being reset when a window is
unmaximized. This causes the tile animation to break when it
follows a maximize/unmaximize because the old information is
being used.

Fixes: https://github.com/elementary/gala/issues/196