### PR TITLE
PiP: Fix wrong size close button on HiDPI

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -127,7 +127,6 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		close_action.clicked.connect (on_close_click_clicked);
 
 		close_button = Gala.Utils.create_close_button ();
-		close_button.set_size (BUTTON_SIZE, BUTTON_SIZE);
 		close_button.opacity = 0;
 		close_button.reactive = true;
 		close_button.set_easing_duration (300);


### PR DESCRIPTION
Don't resize the button returned by create_close_button (). It's
already scaled properly for HiDPI.

Fixes: https://github.com/elementary/gala/issues/280