### PR TITLE
Implement EndSessionManager

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -54,6 +54,15 @@ namespace Gala
 				() => {},
 				() => {},
 				() => critical ("Could not acquire name") );
+
+			Bus.own_name (BusType.SESSION, "org.gnome.SessionManager.EndSessionDialog", BusNameOwnerFlags.NONE,
+				(connection) => {
+					try {
+						connection.register_object ("/org/gnome/SessionManager/EndSessionDialog", SessionManager.init ());
+					} catch (Error e) { warning (e.message); }
+				},
+				() => {},
+				() => critical ("Could not acquire name") );
 		}
 
 		private DBus ()

--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -31,16 +31,16 @@ namespace Gala {
     
     [DBus (name = "org.gnome.SessionManager.EndSessionDialog")]
     public class SessionManager : Object {
-		static SessionManager? instance;
+        static SessionManager? instance;
 
-		[DBus (visible = false)]
-		public static unowned SessionManager init ()
-		{
-			if (instance == null) {
+        [DBus (visible = false)]
+        public static unowned SessionManager init ()
+        {
+            if (instance == null) {
                 instance = new SessionManager ();
             }
 
-			return instance;
+            return instance;
         }
         
         public signal void confirmed_logout ();

--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -1,0 +1,96 @@
+//
+//  Copyright (C) 2018 Adam Bieńkowski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+// Reference code by the Solus Project: https://github.com/solus-project/budgie-desktop/blob/master/src/wm/shim.vala
+namespace Gala {
+    [DBus (name = "io.elementary.wingpanel.session.enddialog")]
+    public interface WingpanelEndSessionDialog : Object
+    {
+        public signal void confirmed_logout ();
+        public signal void confirmed_reboot ();
+        public signal void confirmed_shutdown ();
+        public signal void canceled ();
+        public signal void closed ();
+
+        public abstract void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error;
+    }
+    
+    [DBus (name = "org.gnome.SessionManager.EndSessionDialog")]
+    public class SessionManager : Object {
+		static SessionManager? instance;
+
+		[DBus (visible = false)]
+		public static unowned SessionManager init ()
+		{
+			if (instance == null) {
+                instance = new SessionManager ();
+            }
+
+			return instance;
+        }
+        
+        public signal void confirmed_logout ();
+        public signal void confirmed_reboot ();
+        public signal void confirmed_shutdown ();
+        public signal void canceled ();
+        public signal void closed ();
+
+        WingpanelEndSessionDialog? proxy = null;
+
+        SessionManager () {
+            Bus.watch_name (BusType.SESSION, "io.elementary.wingpanel.session.EndSessionDialog",
+                        BusNameWatcherFlags.NONE, proxy_appeared, proxy_vanished);
+        }
+
+        void get_proxy_cb (Object? o, AsyncResult? res) {
+            try {
+                proxy = Bus.get_proxy.end (res);
+            } catch (Error e) {
+                warning ("Could not connect to io.elementary.wingpanel.session.EndSessionDialog proxy: %s", e.message);
+                return;
+            }
+
+            proxy.confirmed_logout.connect (() => confirmed_logout ());
+            proxy.confirmed_reboot.connect (() => confirmed_reboot ());
+            proxy.confirmed_shutdown.connect (() => confirmed_shutdown ());
+            proxy.canceled.connect (() => canceled ());
+            proxy.closed.connect (() => closed ());
+        }
+
+        void proxy_appeared () {
+            Bus.get_proxy<WingpanelEndSessionDialog> (BusType.SESSION,
+                "io.elementary.wingpanel.session.EndSessionDialog", "/io/elementary/wingpanel/session/EndSessionDialog",
+                0, null, get_proxy_cb);
+        }
+
+        void proxy_vanished () {
+            proxy = null;
+        }
+
+        public void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error {
+            if (proxy == null) {
+                throw new DBusError.FAILED ("io.elementary.wingpanel.session.EndSessionDialog DBus interface is not registered.");
+            }
+
+            try {
+                proxy.open (type, timestamp, open_length, inhibiters);
+            } catch (Error e) {
+                throw e;
+            }
+        }
+    }
+}

--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -15,82 +15,87 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-// Reference code by the Solus Project: https://github.com/solus-project/budgie-desktop/blob/master/src/wm/shim.vala
-namespace Gala {
-    [DBus (name = "io.elementary.wingpanel.session.EndSessionDialog")]
-    public interface WingpanelEndSessionDialog : Object
-    {
-        public signal void confirmed_logout ();
-        public signal void confirmed_reboot ();
-        public signal void confirmed_shutdown ();
-        public signal void canceled ();
-        public signal void closed ();
+// Reference code by the Solus Project:
+// https://github.com/solus-project/budgie-desktop/blob/master/src/wm/shim.vala
 
-        public abstract void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error;
-    }
-    
-    [DBus (name = "org.gnome.SessionManager.EndSessionDialog")]
-    public class SessionManager : Object {
-        static SessionManager? instance;
+namespace Gala
+{
+	[DBus (name = "io.elementary.wingpanel.session.EndSessionDialog")]
+	public interface WingpanelEndSessionDialog : Object
+	{
+		public signal void confirmed_logout ();
+		public signal void confirmed_reboot ();
+		public signal void confirmed_shutdown ();
+		public signal void canceled ();
+		public signal void closed ();
 
-        [DBus (visible = false)]
-        public static unowned SessionManager init ()
-        {
-            if (instance == null) {
-                instance = new SessionManager ();
-            }
+		public abstract void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError;
+	}
 
-            return instance;
-        }
-        
-        public signal void confirmed_logout ();
-        public signal void confirmed_reboot ();
-        public signal void confirmed_shutdown ();
-        public signal void canceled ();
-        public signal void closed ();
+	[DBus (name = "org.gnome.SessionManager.EndSessionDialog")]
+	public class SessionManager : Object
+	{
+		static SessionManager? instance;
 
-        WingpanelEndSessionDialog? proxy = null;
+		[DBus (visible = false)]
+		public static unowned SessionManager init ()
+		{
+			if (instance == null) {
+				instance = new SessionManager ();
+			}
 
-        SessionManager () {
-            Bus.watch_name (BusType.SESSION, "io.elementary.wingpanel.session.EndSessionDialog",
-                        BusNameWatcherFlags.NONE, proxy_appeared, proxy_vanished);
-        }
+			return instance;
+		}
 
-        void get_proxy_cb (Object? o, AsyncResult? res) {
-            try {
-                proxy = Bus.get_proxy.end (res);
-            } catch (Error e) {
-                warning ("Could not connect to io.elementary.wingpanel.session.EndSessionDialog proxy: %s", e.message);
-                return;
-            }
+		public signal void confirmed_logout ();
+		public signal void confirmed_reboot ();
+		public signal void confirmed_shutdown ();
+		public signal void canceled ();
+		public signal void closed ();
 
-            proxy.confirmed_logout.connect (() => confirmed_logout ());
-            proxy.confirmed_reboot.connect (() => confirmed_reboot ());
-            proxy.confirmed_shutdown.connect (() => confirmed_shutdown ());
-            proxy.canceled.connect (() => canceled ());
-            proxy.closed.connect (() => closed ());
-        }
+		WingpanelEndSessionDialog? proxy = null;
 
-        void proxy_appeared () {
-            Bus.get_proxy<WingpanelEndSessionDialog> (BusType.SESSION,
-                "io.elementary.wingpanel.session.EndSessionDialog", "/io/elementary/wingpanel/session/EndSessionDialog",
-                0, null, get_proxy_cb);
-        }
+		SessionManager ()
+		{
+			Bus.watch_name (BusType.SESSION, "io.elementary.wingpanel.session.EndSessionDialog",
+				BusNameWatcherFlags.NONE, proxy_appeared, proxy_vanished);
+		}
 
-        void proxy_vanished () {
-            proxy = null;
-        }
+		void get_proxy_cb (Object? o, AsyncResult? res)
+		{
+			try {
+				proxy = Bus.get_proxy.end (res);
+			} catch (Error e) {
+				warning ("Could not connect to io.elementary.wingpanel.session.EndSessionDialog proxy: %s", e.message);
+				return;
+			}
 
-        public void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws Error {
-            if (proxy == null) {
-                throw new DBusError.FAILED ("io.elementary.wingpanel.session.EndSessionDialog DBus interface is not registered.");
-            }
+			proxy.confirmed_logout.connect (() => confirmed_logout ());
+			proxy.confirmed_reboot.connect (() => confirmed_reboot ());
+			proxy.confirmed_shutdown.connect (() => confirmed_shutdown ());
+			proxy.canceled.connect (() => canceled ());
+			proxy.closed.connect (() => closed ());
+		}
 
-            try {
-                proxy.open (type, timestamp, open_length, inhibiters);
-            } catch (Error e) {
-                throw e;
-            }
-        }
-    }
+		void proxy_appeared ()
+		{
+			Bus.get_proxy.begin<WingpanelEndSessionDialog> (BusType.SESSION,
+				"io.elementary.wingpanel.session.EndSessionDialog", "/io/elementary/wingpanel/session/EndSessionDialog",
+				0, null, get_proxy_cb);
+		}
+
+		void proxy_vanished ()
+		{
+			proxy = null;
+		}
+
+		public void open (uint type, uint timestamp, uint open_length, ObjectPath[] inhibiters) throws DBusError, IOError
+		{
+			if (proxy == null) {
+				throw new DBusError.FAILED ("io.elementary.wingpanel.session.EndSessionDialog DBus interface is not registered.");
+			}
+
+			proxy.open (type, timestamp, open_length, inhibiters);
+		}
+	}
 }

--- a/src/SessionManager.vala
+++ b/src/SessionManager.vala
@@ -17,7 +17,7 @@
 
 // Reference code by the Solus Project: https://github.com/solus-project/budgie-desktop/blob/master/src/wm/shim.vala
 namespace Gala {
-    [DBus (name = "io.elementary.wingpanel.session.enddialog")]
+    [DBus (name = "io.elementary.wingpanel.session.EndSessionDialog")]
     public interface WingpanelEndSessionDialog : Object
     {
         public signal void confirmed_logout ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,6 @@
 gala_bin_sources = files(
 	'DBus.vala',
 	'DBusAccelerator.vala',
-	'SessionManager.vala',
 	'DockThemeManager.vala',
 	'DragDropAction.vala',
 	'InternalUtils.vala',
@@ -11,6 +10,7 @@ gala_bin_sources = files(
 	'PluginManager.vala',
 	'ScreenSaver.vala',
 	'ScreenshotManager.vala',
+	'SessionManager.vala',
 	'Settings.vala',
 	'ShadowEffect.vala',
 	'TextShadowEffect.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 gala_bin_sources = files(
 	'DBus.vala',
 	'DBusAccelerator.vala',
+	'SessionManager.vala',
 	'DockThemeManager.vala',
 	'DragDropAction.vala',
 	'InternalUtils.vala',


### PR DESCRIPTION
Fixes #324 

- [x] Requires https://github.com/elementary/wingpanel-indicator-session/pull/58 to be merged.

Implements `org.gnome.SessionManager.EndSessionDialog` and forwards DBus calls to the session indicator in wingpanel. This is done so that we have consistency when it comes to owning GNOME specific DBus interfaces.

Worth mentioning is also the original reference implementation of the same interface in Budgie Desktop: https://github.com/solus-project/budgie-desktop/blob/master/src/wm/shim.vala