### PR TITLE
Don't remove workspaces for sticky windows

### DIFF
--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -138,7 +138,7 @@ namespace Gala
 
 		void window_removed (Workspace? workspace, Window window)
 		{
-			if (workspace == null || !Prefs.get_dynamic_workspaces ())
+			if (workspace == null || !Prefs.get_dynamic_workspaces () || window.on_all_workspaces)
 				return;
 
 			unowned Screen screen = workspace.get_screen ();
@@ -227,7 +227,7 @@ namespace Gala
 
 			workspace.window_added.disconnect (window_added);
 			workspace.window_removed.disconnect (window_removed);
-			
+
 			workspaces_marked_removed.add (workspace);
 
 			screen.remove_workspace (workspace, time);


### PR DESCRIPTION
Fixes #274 
Fixes #293 

Something about pulling workspaces out from under mutter while it was trying to assert there wasn't a sticky window left behind on one of them was what was causing the crash.

You can reproduce the gala crash in master with any window if you mark it as always on all workspaces and then close it. It just so happened that the logout dialog and onboard are sticky by default.