### PR TITLE
Fix multi-monitor windows preventing workspaces from closing automatically 

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -209,7 +209,7 @@ namespace Gala
 		{
 			var n = 0;
 			foreach (weak Meta.Window window in workspace.list_windows ()) {
-				if (window.is_always_on_all_workspaces ())
+				if (window.on_all_workspaces)
 					continue;
 				if (window.window_type == Meta.WindowType.NORMAL ||
 					window.window_type == Meta.WindowType.DIALOG ||


### PR DESCRIPTION
In juno, it appears that windows on the non-primary monitors now return `false` on `window.is_always_on_all_workspaces ()`, this made it so gala thought that there was always a window on in this function. I've modified the code to use the property `on_all_workspaces` instead of the function. This works even if making false the property on `gsettings org/gnome/mutter/workspaces-only-on-primary`



fixes #347 

