### PR TITLE
Fix visibility glitch

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -312,7 +312,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		var window = window_actor.get_meta_window ();
 		if (window.appears_focused) {
 			hide ();
-		} else {
+		} else if (!window_actor.is_destroyed ()) {
 			show ();
 		}
 


### PR DESCRIPTION
Fixes #422.

Fixes a glitch where the `appears_focused` property would change before the window got unmanaged and therefore show the PiP window for a split second before closing it. We now check if the window actor is still shown and if not, we don't do anything.