### PR TITLE
Restore daemon watch

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -98,6 +98,8 @@ namespace Gala
 		{
 			Util.later_add (LaterType.BEFORE_REDRAW, show_stage);
 
+			Bus.watch_name (BusType.SESSION, DAEMON_DBUS_NAME, BusNameWatcherFlags.NONE, daemon_appeared, lost_daemon);
+
 #if HAS_MUTTER322
 			get_screen ().get_display ().gl_video_memory_purged.connect (() => {
 				Meta.Background.refresh_all ();


### PR DESCRIPTION
This was accidentally removed in #330 and is the major reason why window menus aren't appearing.