### PR TITLE
Add character codes to regex so that they get parsed properly

### DIFF
--- a/plugins/notify/NormalNotification.vala
+++ b/plugins/notify/NormalNotification.vala
@@ -33,7 +33,7 @@ namespace Gala.Plugins.Notify
 		static construct
 		{
 			try {
-				entity_regex = new Regex ("&(?!amp;|quot;|apos;|lt;|gt;)");
+				entity_regex = new Regex ("&(?!amp;|quot;|apos;|lt;|gt;|nbsp;|#39;)");
 				tag_regex = new Regex ("<(?!\\/?[biu]>)");
 			} catch (Error e) {}
 		}


### PR DESCRIPTION
Second half of the fix for https://github.com/elementary/wingpanel-indicator-notifications/issues/58. (Reference https://github.com/elementary/wingpanel-indicator-notifications/pull/60)

Notifications from some apps (such as Discord and Tootle) have character codes (&#39; and &nbsp;) in the ending message body. This PR ensures that they are properly replaced with the correct characters.

Tested by getting someone on Discord to send me a message with an ' in it to verify that it is displayed properly.