### PR TITLE
Change PIP Default Location to Bottom Right

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -128,7 +128,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		var x_position = monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width;
 		var y_position = monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height;
 
-		if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
+		if (Clutter.get_default_text_direction () == Clutter.TextDirection.RTL) {
 			x_position = SCREEN_MARGIN + monitor_rect.x;
 		}
 

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -132,7 +132,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 			x_position = SCREEN_MARGIN + monitor_rect.x;
 		}
 
-		set_position(x_position, y_position);
+		set_position (x_position, y_position);
 
 		close_action = new Clutter.ClickAction ();
 		close_action.clicked.connect (on_close_click_clicked);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -125,7 +125,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		Meta.Rectangle monitor_rect;
 		get_current_monitor_rect (out monitor_rect);
 
-		set_position (SCREEN_MARGIN + monitor_rect.x, monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height);
+		set_position (monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width, monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height);
 
 		close_action = new Clutter.ClickAction ();
 		close_action.clicked.connect (on_close_click_clicked);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -125,11 +125,14 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		Meta.Rectangle monitor_rect;
 		get_current_monitor_rect (out monitor_rect);
 
-		var x_position = monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width;
+		var x_position = 0.0f;
 		var y_position = monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height;
 
 		if (Clutter.get_default_text_direction () == Clutter.TextDirection.RTL) {
 			x_position = SCREEN_MARGIN + monitor_rect.x;
+		}
+		else {
+			x_position = monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width;
 		}
 
 		set_position (x_position, y_position);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -125,8 +125,14 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		Meta.Rectangle monitor_rect;
 		get_current_monitor_rect (out monitor_rect);
 
-		set_position (monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width,
-			monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height);
+		var x_position = monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width;
+		var y_position = monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height;
+
+		if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL) {
+			x_position = SCREEN_MARGIN + monitor_rect.x;
+		}
+
+		set_position(x_position, y_position);
 
 		close_action = new Clutter.ClickAction ();
 		close_action.clicked.connect (on_close_click_clicked);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -125,7 +125,8 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor
 		Meta.Rectangle monitor_rect;
 		get_current_monitor_rect (out monitor_rect);
 
-		set_position (monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width, monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height);
+		set_position (monitor_rect.width + monitor_rect.x - SCREEN_MARGIN - width,
+			monitor_rect.height + monitor_rect.y - SCREEN_MARGIN - height);
 
 		close_action = new Clutter.ClickAction ();
 		close_action.clicked.connect (on_close_click_clicked);


### PR DESCRIPTION
Most apps will render content top to bottom, left to right. Putting the popup window on the bottom right by default (instead of left) makes sense to have it less likely to cover up content.

![screenshot from 2019-01-04 02-17-18](https://user-images.githubusercontent.com/10735142/50645142-ec112a80-0fc6-11e9-921d-293294f350c6.png)
