### PR TITLE
Do not block drawing the stage when saving the image

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -67,7 +67,7 @@ namespace Gala
 			flash_actor.add_transition ("flash", transition);
 		}
 
-		public void screenshot (bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
+		public async void screenshot (bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
 		{
 			debug ("Taking screenshot");
 
@@ -80,7 +80,7 @@ namespace Gala
 				flash_area (0, 0, width, height);
 			}
 
-			success = save_image (image, filename, out filename_used);
+			success = yield save_image (image, filename, out filename_used);
 		}
 
 		public async void screenshot_area (int x, int y, int width, int height, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
@@ -95,12 +95,12 @@ namespace Gala
 				flash_area (x, y, width, height);
 			}
 
-			success = save_image (image, filename, out filename_used);
+			success = yield save_image (image, filename, out filename_used);
 			if (!success)
 				throw new DBusError.FAILED ("Failed to save image");
 		}
 
-		public void screenshot_window (bool include_frame, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
+		public async void screenshot_window (bool include_frame, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
 		{
 			debug ("Taking window screenshot");
 
@@ -126,7 +126,7 @@ namespace Gala
 				flash_area (rect.x, rect.y, rect.width, rect.height);
 			}
 
-			success = save_image (image, filename, out filename_used);
+			success = yield save_image (image, filename, out filename_used);
 		}
 
 		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError, IOError
@@ -143,7 +143,7 @@ namespace Gala
 			selection_area.get_selection_rectangle (out x, out y, out width, out height);
 		}
 
-		static bool save_image (Cairo.ImageSurface image, string filename, out string used_filename)
+		static async bool save_image (Cairo.ImageSurface image, string filename, out string used_filename)
 		{
 			if (!Path.is_absolute (filename)) {
 				string path = Environment.get_user_special_dir (UserDirectory.PICTURES);
@@ -162,7 +162,9 @@ namespace Gala
 
 			try {
 				var screenshot = Gdk.pixbuf_get_from_surface (image, 0, 0, image.get_width (), image.get_height ());
-				screenshot.save (used_filename, "png");
+				var file = File.new_for_path (used_filename);
+				var stream = yield file.create_readwrite_async (FileCreateFlags.NONE);
+				yield screenshot.save_to_stream_async (stream.output_stream, "png");
 				return true;
 			} catch (GLib.Error e) {
 				return false;


### PR DESCRIPTION
This fixes a large lag when the image is being saved into a file when taking a screenshot. Mostly noticeable on HDD's. This changes all exposed method signatures to async but doesn't affect callers in any way.