### PR TITLE
Cancel area screenshot when pressing esc

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -86,6 +86,11 @@ namespace Gala
 		public async void screenshot_area (int x, int y, int width, int height, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
 		{
 			debug ("Taking area screenshot");
+			if (width == -1 && height == -1) {
+				success = false;
+				filename_used = "";
+				return;
+			}
 
 			yield wait_stage_repaint ();
 

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -132,7 +132,8 @@ namespace Gala
 		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError, IOError
 		{
 			var selection_area = new SelectionArea (wm);
-			selection_area.closed.connect (() => Idle.add (select_area.callback));
+			selection_area.captured.connect (() => Idle.add (select_area.callback));
+			selection_area.cancelled.connect (() => selection_area.destroy ());
 			wm.ui_group.add (selection_area);
 			selection_area.start_selection ();
 

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -136,25 +136,21 @@ namespace Gala
 
 		public async void select_area (out int x, out int y, out int width, out int height) throws DBusError, IOError
 		{
-			bool cancelled = false;
 			var selection_area = new SelectionArea (wm);
-			selection_area.captured.connect (() => Idle.add (select_area.callback));
-			selection_area.cancelled.connect (() => {
-				cancelled = true;
-				Idle.add (select_area.callback);
-			});
+			selection_area.closed.connect (() => Idle.add (select_area.callback));
 			wm.ui_group.add (selection_area);
 			selection_area.start_selection ();
 
 			yield;
 			selection_area.destroy ();
 
-			if (cancelled) {
+			if (selection_area.cancelled) {
 				x = y = width = height = -1;
-			} else {
-				yield wait_stage_repaint ();
-				selection_area.get_selection_rectangle (out x, out y, out width, out height);
+				return;
 			}
+
+			yield wait_stage_repaint ();
+			selection_area.get_selection_rectangle (out x, out y, out width, out height);
 		}
 
 		static string find_target_path ()

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -86,11 +86,6 @@ namespace Gala
 		public async void screenshot_area (int x, int y, int width, int height, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError
 		{
 			debug ("Taking area screenshot");
-			if (width == -1 && height == -1) {
-				success = false;
-				filename_used = "";
-				return;
-			}
 
 			yield wait_stage_repaint ();
 
@@ -145,8 +140,7 @@ namespace Gala
 			selection_area.destroy ();
 
 			if (selection_area.cancelled) {
-				x = y = width = height = -1;
-				return;
+				throw new GLib.IOError.CANCELLED ("Operation was cancelled");
 			}
 
 			yield wait_stage_repaint ();

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -19,7 +19,8 @@ namespace Gala
 {
     public class SelectionArea : Clutter.Actor
     {
-        public signal void closed (bool captured);
+        public signal void captured ();
+        public signal void cancelled ();
 
         public WindowManager wm { get; construct; }
 
@@ -58,7 +59,7 @@ namespace Gala
         {
             if (e.keyval == Clutter.Key.Escape) {
                 close ();
-                closed (false);
+                cancelled ();
                 return true;
             }
 
@@ -87,7 +88,7 @@ namespace Gala
 
             if (!dragging) {
                 close ();
-                closed (false);
+                cancelled ();
                 return true;
             }
 
@@ -98,7 +99,7 @@ namespace Gala
             this.hide ();
             content.invalidate ();
 
-            closed (true);
+            captured ();
             return true;
         }
 

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -19,8 +19,7 @@ namespace Gala
 {
     public class SelectionArea : Clutter.Actor
     {
-        public signal void captured ();
-        public signal void cancelled ();
+        public signal void closed (bool captured);
 
         public WindowManager wm { get; construct; }
 
@@ -59,7 +58,7 @@ namespace Gala
         {
             if (e.keyval == Clutter.Key.Escape) {
                 close ();
-                cancelled ();
+                closed (false);
                 return true;
             }
 
@@ -88,7 +87,7 @@ namespace Gala
 
             if (!dragging) {
                 close ();
-                cancelled ();
+                closed (false);
                 return true;
             }
 
@@ -99,7 +98,7 @@ namespace Gala
             this.hide ();
             content.invalidate ();
 
-            captured ();
+            closed (true);
             return true;
         }
 

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -19,10 +19,11 @@ namespace Gala
 {
     public class SelectionArea : Clutter.Actor
     {
-        public signal void captured ();
-        public signal void cancelled ();
+        public signal void closed ();
 
         public WindowManager wm { get; construct; }
+
+        public bool cancelled { get; private set; }
 
         private ModalProxy? modal_proxy;
         private Gdk.Point start_point;
@@ -59,7 +60,8 @@ namespace Gala
         {
             if (e.keyval == Clutter.Key.Escape) {
                 close ();
-                cancelled ();
+                cancelled = true;
+                closed ();
                 return true;
             }
 
@@ -88,7 +90,8 @@ namespace Gala
 
             if (!dragging) {
                 close ();
-                cancelled ();
+                cancelled = true;
+                closed ();
                 return true;
             }
 
@@ -99,7 +102,7 @@ namespace Gala
             this.hide ();
             content.invalidate ();
 
-            captured ();
+            closed ();
             return true;
         }
 

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -16,10 +16,11 @@
 //
 
 namespace Gala
-{ 
+{
     public class SelectionArea : Clutter.Actor
     {
-        public signal void closed ();
+        public signal void captured ();
+        public signal void cancelled ();
 
         public WindowManager wm { get; construct; }
 
@@ -58,7 +59,7 @@ namespace Gala
         {
             if (e.keyval == Clutter.Key.Escape) {
                 close ();
-                closed ();
+                cancelled ();
                 return true;
             }
 
@@ -87,7 +88,7 @@ namespace Gala
 
             if (!dragging) {
                 close ();
-                closed ();
+                cancelled ();
                 return true;
             }
 
@@ -98,7 +99,7 @@ namespace Gala
             this.hide ();
             content.invalidate ();
 
-            closed ();
+            captured ();
             return true;
         }
 


### PR DESCRIPTION
Fixing: #311 
Using 2 signals to differentiate between captured and cancelled just like the [SelectionArea in Screenshot](https://github.com/elementary/screenshot/blob/master/src/Widgets/SelectionArea.vala). 
