### PR TITLE
Use UI scale util in plugins

### DIFF
--- a/plugins/maskcorners/Main.vala
+++ b/plugins/maskcorners/Main.vala
@@ -50,11 +50,7 @@ namespace Gala.Plugins.MaskCorners
 			if (!settings.enable)
 				return;
 
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 
 			int n_monitors = screen.get_n_monitors ();
 			cornermasks = new List<Actor>[n_monitors];

--- a/plugins/notify/NormalNotification.vala
+++ b/plugins/notify/NormalNotification.vala
@@ -101,11 +101,7 @@ namespace Gala.Plugins.Notify
 
 		public override void get_preferred_height (float for_width, out float min_height, out float nat_height)
 		{
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			float label_height;
 			get_allocation_values (null, null, null, null, out label_height, null, scale);
 
@@ -114,11 +110,7 @@ namespace Gala.Plugins.Notify
 
 		public override void allocate (ActorBox box, AllocationFlags flags)
 		{
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			float label_x, label_width, summary_height, body_height, label_height, label_y;
 			get_allocation_values (out label_x, out label_width, out summary_height,
 				out body_height, out label_height, out label_y, scale);

--- a/plugins/notify/Notification.vala
+++ b/plugins/notify/Notification.vala
@@ -86,11 +86,7 @@ namespace Gala.Plugins.Notify
 
 		construct
 		{
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			relevancy_time = new DateTime.now_local ().to_unix ();
 			width = (WIDTH + MARGIN * 2) * scale;
 			reactive = true;

--- a/plugins/notify/NotificationStack.vala
+++ b/plugins/notify/NotificationStack.vala
@@ -38,11 +38,7 @@ namespace Gala.Plugins.Notify
 
 		construct
 		{
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			width = (Notification.WIDTH + 2 * Notification.MARGIN + ADDITIONAL_MARGIN) * scale;
 			clip_to_allocation = true;
 		}
@@ -50,11 +46,7 @@ namespace Gala.Plugins.Notify
 		public void show_notification (Notification notification)
 		{
 			animations_changed (true);
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 
 			// raise ourselves when we got something to show
 			get_parent ().set_child_above_sibling (this, null);
@@ -86,11 +78,7 @@ namespace Gala.Plugins.Notify
 
 		void update_positions (float add_y = 0.0f)
 		{
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			var y = add_y + TOP_OFFSET * scale;
 			var i = get_n_children ();
 			var delay_step = i > 0 ? 150 / i : 0;

--- a/plugins/notify/NotifyServer.vala
+++ b/plugins/notify/NotifyServer.vala
@@ -332,11 +332,7 @@ namespace Gala.Plugins.Notify
 
 			Gdk.Pixbuf? pixbuf = null;
 			Variant? variant = null;
-#if HAS_MUTTER326
-			var scale = Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
-#else
-			var scale = 1;
-#endif
+			var scale = Utils.get_ui_scaling_factor ();
 			var size = Notification.ICON_SIZE * scale;
 			var mask_offset = 4 * scale;
 			var mask_size_offset = mask_offset * 2;
@@ -632,7 +628,7 @@ namespace Gala.Plugins.Notify
 			} catch (ShellError e) {
 				warning ("%s", e.message);
  			}
- 
+
 			return (app_name.down () == token
 				|| token_executable == app_executable
 				|| (args.length > 0 && args[0] == token)


### PR DESCRIPTION
In the plugins code we repeat the following code a lot:
```
#if HAS_MUTTER326
			return Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
#else
			return 1;
#endif
```
even though we have a `Utils.get_ui_scaling_factor ()` function. When the code is compiled on systems that don't have mutter 326, this will mean an extra function call, but that seems worth it?

The `gala/src` uses `InternalUtils.get_ui_scaling_factor ()`, but I took that "internal" as something that I shouldn't use for plugins? Maybe the `gala/src/` code should also use `Utils.get_ui_scaling_factor ()`?