### PR TITLE
Fix app switcher left and right padding

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -267,7 +267,7 @@ namespace Gala
 			var line_width = dock_theme.LineWidth * ui_scale_factor;
 			var horiz_padding = dock_theme.HorizPadding * scaled_icon_size;
 			var item_padding = (float) dock_theme.ItemPadding * scaled_icon_size;
-			var items_offset = (int) (2 * line_width + (horiz_padding > 0 ? horiz_padding : 0));
+			var items_offset = (int) (2 * line_width + (horiz_padding > 0 ? horiz_padding : 0) + item_padding / 2);
 
 			if (n_dock_items > 0)
 				dock_width = n_dock_items * (item_padding + icon_size) + items_offset * 2;


### PR DESCRIPTION
Fixes: #447 
The app switcher doesn't properly use the item padding from plank themes:

Example with a increased `ItemPadding`, the normal Plank:
![screenshot from 2019-03-01 11-30-03](https://user-images.githubusercontent.com/523210/53632746-fe4dc480-3c15-11e9-800a-1b7c028b64c7.png)
The app switcher plank:
![screenshot from 2019-03-01 11 30 33 2x](https://user-images.githubusercontent.com/523210/53632745-fe4dc480-3c15-11e9-975c-ded5f78daee5.png)

This PR attempts to properly use it, resulting in:
![plank vs app switcher](https://user-images.githubusercontent.com/523210/53633785-c005d480-3c18-11e9-9b8c-f44cea15cbe5.png)
![plank vs app switcher2](https://user-images.githubusercontent.com/523210/53633784-bf6d3e00-3c18-11e9-9468-e0ca98bc80ff.png)