### PR TITLE
Remove duration settings

### DIFF
--- a/data/org.pantheon.desktop.gala.gschema.xml.in
+++ b/data/org.pantheon.desktop.gala.gschema.xml.in
@@ -184,26 +184,27 @@
 		</key>
 		<key type="i" name="open-duration">
 			<default>350</default>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 		<key type="i" name="snap-duration">
 			<default>250</default>
-			<summary>Duration of the snap animation as used by maximize/unmaximize</summary>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 		<key type="i" name="close-duration">
 			<default>195</default>
-			<summary>Duration of the close animation</summary>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 		<key type="i" name="minimize-duration">
 			<default>200</default>
-			<summary>Duration of the minimize animation</summary>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 		<key type="i" name="workspace-switch-duration">
 			<default>300</default>
-			<summary>Duration of the workspace switch animation</summary>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 		<key type="i" name="menu-duration">
 			<default>150</default>
-			<summary>Duration of the menu mapping animation</summary>
+			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
 		</key>
 	</schema>
 	

--- a/data/org.pantheon.desktop.gala.gschema.xml.in
+++ b/data/org.pantheon.desktop.gala.gschema.xml.in
@@ -184,27 +184,33 @@
 		</key>
 		<key type="i" name="open-duration">
 			<default>350</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the open animation</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 		<key type="i" name="snap-duration">
 			<default>250</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the snap animation as used by maximize/unmaximize</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 		<key type="i" name="close-duration">
 			<default>195</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the close animation</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 		<key type="i" name="minimize-duration">
 			<default>200</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the minimize animation</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 		<key type="i" name="workspace-switch-duration">
 			<default>300</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the workspace switch animation</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 		<key type="i" name="menu-duration">
 			<default>150</default>
-			<summary>DEPRECATED: This key is deprecated and ignored.</summary>
+			<summary>Duration of the menu mapping animation</summary>
+			<description>DEPRECATED: This key is deprecated and ignored.</description>
 		</key>
 	</schema>
 	

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -17,15 +17,19 @@
 
 namespace Gala
 {
-	public const int OPEN_DURATION = 350;
-	// Duration of the snap animation as used by maximize/unmaximize
-	public const int SNAP_DURATION = 250;
-	// Duration of the close animation
-	public const int CLOSE_DURATION = 195;
-	// Duration of the minimize animation
-	public const int MINIMIZE_DURATION = 200;
-	// Duration of the workspace switch animation
-	public const int WORKSPACE_SWITCH_DURATION = 300;
-	// Duration of the menu mapping animation
-	public const int MENU_DURATION = 150;
+	[CCode (has_type_id = false)]
+	public enum AnimationDuration {
+		// Duration of the open animation
+		OPEN = 350,
+		// Duration of the close animation
+		CLOSE = 195,
+		// Duration of the minimize animation
+		MINIMIZE = 200,
+		// Duration of the menu mapping animation
+		MENU_MAP = 150,
+		// Duration of the snap animation as used by maximize/unmaximize
+		SNAP = 250,
+		// Duration of the workspace switch animation
+		WORKSPACE_SWITCH = 300,
+	}
 }

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -1,0 +1,31 @@
+//
+//  Copyright 2019 elementary, Inc. (https://elementary.io)
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+namespace Gala
+{
+	public const int OPEN_DURATION = 350;
+	// Duration of the snap animation as used by maximize/unmaximize
+	public const int SNAP_DURATION = 250;
+	// Duration of the close animation
+	public const int CLOSE_DURATION = 195;
+	// Duration of the minimize animation
+	public const int MINIMIZE_DURATION = 200;
+	// Duration of the workspace switch animation
+	public const int WORKSPACE_SWITCH_DURATION = 300;
+	// Duration of the menu mapping animation
+	public const int MENU_DURATION = 150;
+}

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -114,6 +114,11 @@ namespace Gala
 		public abstract Meta.BackgroundGroup background_group { get; protected set; }
 
 		/**
+		 * Whether animations should be displayed.
+		 */
+		public abstract bool enable_animations { get; protected set; }
+
+		/**
 		 * Enters the modal mode, which means that all events are directed to the stage instead
 		 * of the windows. This is the only way to receive keyboard events besides shortcut listeners.
 		 *

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,5 +1,6 @@
 gala_lib_sources = files(
 	'ActivatableComponent.vala',
+	'Constants.vala',
 	'Plugin.vala',
 	'Utils.vala',
 	'WindowIcon.vala',

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -127,32 +127,6 @@ namespace Gala
 		}
 	}
 
-	public class AnimationSettings : Granite.Services.Settings
-	{
-		public bool enable_animations { get; set; }
-		public int open_duration { get; set; }
-		public int snap_duration { get; set; }
-		public int close_duration { get; set; }
-		public int minimize_duration { get; set; }
-		public int workspace_switch_duration { get; set; }
-		public int menu_duration { get; set; }
-
-		static AnimationSettings? instance = null;
-
-		private AnimationSettings ()
-		{
-			base (Config.SCHEMA + ".animations");
-		}
-
-		public static unowned AnimationSettings get_default ()
-		{
-			if (instance == null)
-				instance = new AnimationSettings ();
-
-			return instance;
-		}
-	}
-
 	public class BackgroundSettings : Granite.Services.Settings
 	{
 		public string picture_options { get; set; }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -245,7 +245,7 @@ namespace Gala
 				workspace_clone.restore_easing_state ();
 			}
 
-			workspaces.set_easing_duration (animate ? WORKSPACE_SWITCH_DURATION : 0);
+			workspaces.set_easing_duration (animate ? AnimationDuration.WORKSPACE_SWITCH : 0);
 			workspaces.x = -active_x;
 
 			reposition_icon_groups (animate);

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -245,8 +245,7 @@ namespace Gala
 				workspace_clone.restore_easing_state ();
 			}
 
-			workspaces.set_easing_duration (animate ?
-				AnimationSettings.get_default ().workspace_switch_duration : 0);
+			workspaces.set_easing_duration (animate ? WORKSPACE_SWITCH_DURATION : 0);
 			workspaces.x = -active_x;
 
 			reposition_icon_groups (animate);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -55,6 +55,11 @@ namespace Gala
 		 */
 		public Meta.BackgroundGroup background_group { get; protected set; }
 
+		/**
+		 * {@inheritDoc}
+		 */
+		public bool enable_animations { get; protected set; }
+
 		Meta.PluginInfo info;
 
 		WindowSwitcher? winswitcher = null;
@@ -81,6 +86,8 @@ namespace Gala
 		Gee.HashSet<Meta.WindowActor> unminimizing = new Gee.HashSet<Meta.WindowActor> ();
 		GLib.HashTable<Meta.Window, int> ws_assoc = new GLib.HashTable<Meta.Window, int> (direct_hash, direct_equal);
 
+		GLib.Settings animations_settings;
+
 		public WindowManagerGala ()
 		{
 			info = Meta.PluginInfo () {name = "Gala", version = Config.VERSION, author = "Gala Developers",
@@ -92,6 +99,12 @@ namespace Gala
 			Prefs.override_preference_schema ("button-layout", Config.SCHEMA + ".appearance");
 			Prefs.override_preference_schema ("edge-tiling", Config.SCHEMA + ".behavior");
 			Prefs.override_preference_schema ("enable-animations", Config.SCHEMA + ".animations");
+		}
+
+		construct {
+			animations_settings = new GLib.Settings (Config.SCHEMA + ".animations");
+			animations_settings.bind ("enable-animations", this, "enable-animations", GLib.SettingsBindFlags.GET);
+			enable_animations = animations_settings.get_boolean ("enable-animations");
 		}
 
 		public override void start ()
@@ -481,8 +494,6 @@ namespace Gala
 			if (Utils.get_n_windows (workspace) == 0) {
 				return;
 			}
-
-			bool enable_animations = AnimationSettings.get_default ().enable_animations;
 
 			var bottom_actor = bottom_window.get_compositor_private () as Meta.WindowActor;
 			if (enable_animations) {
@@ -877,15 +888,14 @@ namespace Gala
 			unowned Meta.WindowActor window_actor = window.get_compositor_private () as Meta.WindowActor;
 			window_group.set_child_below_sibling (tile_preview, window_actor);
 
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-			var duration = animation_settings.snap_duration / 2U;
+			var duration = SNAP_DURATION / 2U;
 
 			var rect = window.get_frame_rect ();
 			tile_preview.set_position (rect.x, rect.y);
 			tile_preview.set_size (rect.width, rect.height);
 			tile_preview.show ();
 
-			if (animation_settings.enable_animations) {
+			if (enable_animations) {
 				tile_preview.save_easing_state ();
 				tile_preview.set_easing_mode (Clutter.AnimationMode.EASE_IN_OUT_QUAD);
 				tile_preview.set_easing_duration (duration);
@@ -1000,10 +1010,9 @@ namespace Gala
 
 		public override void minimize (WindowActor actor)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-			var duration = animation_settings.minimize_duration;
+			const int duration = MINIMIZE_DURATION;
 
-			if (!animation_settings.enable_animations
+			if (!enable_animations
 				|| duration == 0
 				|| actor.get_meta_window ().window_type != WindowType.NORMAL) {
 				minimize_completed (actor);
@@ -1066,10 +1075,9 @@ namespace Gala
 
 		void maximize (WindowActor actor, int ex, int ey, int ew, int eh)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-			var duration = animation_settings.snap_duration;
+			const int duration = SNAP_DURATION;
 
-			if (!animation_settings.enable_animations
+			if (!enable_animations
 				|| duration == 0) {
 				return;
 			}
@@ -1159,9 +1167,7 @@ namespace Gala
 
 		public override void unminimize (WindowActor actor)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-
-			if (!animation_settings.enable_animations) {
+			if (!enable_animations) {
 				actor.show ();
 				unminimize_completed (actor);
 				return;
@@ -1174,7 +1180,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					var duration = animation_settings.minimize_duration;
+					var duration = MINIMIZE_DURATION;
 					if (duration == 0) {
 						unminimize_completed (actor);
 						return;
@@ -1209,10 +1215,8 @@ namespace Gala
 
 		public override void map (WindowActor actor)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-
 			var window = actor.get_meta_window ();
-			if (!animation_settings.enable_animations) {
+			if (!enable_animations) {
 				actor.show ();
 				map_completed (actor);
 
@@ -1228,7 +1232,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					var duration = animation_settings.open_duration;
+					var duration = MINIMIZE_DURATION;
 					if (duration == 0) {
 						map_completed (actor);
 						return;
@@ -1266,7 +1270,7 @@ namespace Gala
 				case WindowType.MENU:
 				case WindowType.DROPDOWN_MENU:
 				case WindowType.POPUP_MENU:
-					var duration = animation_settings.menu_duration;
+					var duration = MENU_DURATION;
 					if (duration == 0) {
 						map_completed (actor);
 						return;
@@ -1334,12 +1338,11 @@ namespace Gala
 
 		public override void destroy (WindowActor actor)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
 			var window = actor.get_meta_window ();
 
 			ws_assoc.remove (window);
 
-			if (!animation_settings.enable_animations) {
+			if (!enable_animations) {
 				destroy_completed (actor);
 
 				// only NORMAL windows have icons
@@ -1353,7 +1356,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					var duration = animation_settings.close_duration;
+					const int duration = CLOSE_DURATION;
 					if (duration == 0) {
 						destroy_completed (actor);
 						return;
@@ -1404,7 +1407,7 @@ namespace Gala
 				case WindowType.MENU:
 				case WindowType.DROPDOWN_MENU:
 				case WindowType.POPUP_MENU:
-					var duration = animation_settings.menu_duration;
+					var duration = MENU_DURATION;
 					if (duration == 0) {
 						destroy_completed (actor);
 						return;
@@ -1433,10 +1436,8 @@ namespace Gala
 
 		void unmaximize (Meta.WindowActor actor, int ex, int ey, int ew, int eh)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-			var duration = animation_settings.snap_duration;
-
-			if (!animation_settings.enable_animations
+			const int duration = SNAP_DURATION;
+			if (!enable_animations
 				|| duration == 0) {
 				return;
 			}
@@ -1555,10 +1556,9 @@ namespace Gala
 
 		public override void switch_workspace (int from, int to, MotionDirection direction)
 		{
-			unowned AnimationSettings animation_settings = AnimationSettings.get_default ();
-			var animation_duration = animation_settings.workspace_switch_duration;
+			const int animation_duration = WORKSPACE_SWITCH_DURATION;
 
-			if (!animation_settings.enable_animations
+			if (!enable_animations
 				|| animation_duration == 0
 				|| (direction != MotionDirection.LEFT && direction != MotionDirection.RIGHT)) {
 				switch_workspace_completed ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -888,7 +888,7 @@ namespace Gala
 			unowned Meta.WindowActor window_actor = window.get_compositor_private () as Meta.WindowActor;
 			window_group.set_child_below_sibling (tile_preview, window_actor);
 
-			var duration = SNAP_DURATION / 2U;
+			var duration = AnimationDuration.SNAP / 2U;
 
 			var rect = window.get_frame_rect ();
 			tile_preview.set_position (rect.x, rect.y);
@@ -1010,7 +1010,7 @@ namespace Gala
 
 		public override void minimize (WindowActor actor)
 		{
-			const int duration = MINIMIZE_DURATION;
+			const int duration = AnimationDuration.MINIMIZE;
 
 			if (!enable_animations
 				|| duration == 0
@@ -1075,7 +1075,7 @@ namespace Gala
 
 		void maximize (WindowActor actor, int ex, int ey, int ew, int eh)
 		{
-			const int duration = SNAP_DURATION;
+			const int duration = AnimationDuration.SNAP;
 
 			if (!enable_animations
 				|| duration == 0) {
@@ -1180,7 +1180,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					var duration = MINIMIZE_DURATION;
+					var duration = AnimationDuration.MINIMIZE;
 					if (duration == 0) {
 						unminimize_completed (actor);
 						return;
@@ -1232,7 +1232,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					var duration = MINIMIZE_DURATION;
+					var duration = AnimationDuration.MINIMIZE;
 					if (duration == 0) {
 						map_completed (actor);
 						return;
@@ -1270,7 +1270,7 @@ namespace Gala
 				case WindowType.MENU:
 				case WindowType.DROPDOWN_MENU:
 				case WindowType.POPUP_MENU:
-					var duration = MENU_DURATION;
+					var duration = AnimationDuration.MENU_MAP;
 					if (duration == 0) {
 						map_completed (actor);
 						return;
@@ -1356,7 +1356,7 @@ namespace Gala
 
 			switch (window.window_type) {
 				case WindowType.NORMAL:
-					const int duration = CLOSE_DURATION;
+					const int duration = AnimationDuration.CLOSE;
 					if (duration == 0) {
 						destroy_completed (actor);
 						return;
@@ -1407,7 +1407,7 @@ namespace Gala
 				case WindowType.MENU:
 				case WindowType.DROPDOWN_MENU:
 				case WindowType.POPUP_MENU:
-					var duration = MENU_DURATION;
+					var duration = AnimationDuration.MENU_MAP;
 					if (duration == 0) {
 						destroy_completed (actor);
 						return;
@@ -1436,7 +1436,7 @@ namespace Gala
 
 		void unmaximize (Meta.WindowActor actor, int ex, int ey, int ew, int eh)
 		{
-			const int duration = SNAP_DURATION;
+			const int duration = AnimationDuration.SNAP;
 			if (!enable_animations
 				|| duration == 0) {
 				return;
@@ -1556,7 +1556,7 @@ namespace Gala
 
 		public override void switch_workspace (int from, int to, MotionDirection direction)
 		{
-			const int animation_duration = WORKSPACE_SWITCH_DURATION;
+			const int animation_duration = AnimationDuration.WORKSPACE_SWITCH;
 
 			if (!enable_animations
 				|| animation_duration == 0


### PR DESCRIPTION
Fixes #512
Note that the GSettings are kept because Wingpanel is still using it but will be updated to use the values in the Constant.vala file