### PR TITLE
Fix app notification schema not being found

### DIFF
--- a/plugins/notify/NotifyServer.vala
+++ b/plugins/notify/NotifyServer.vala
@@ -206,7 +206,7 @@ namespace Gala.Plugins.Notify
 
 					GLib.Settings? app_settings = app_settings_cache.get (app_id);
 					if (app_settings == null) {
-						var schema = SettingsSchemaSource.get_default ().lookup ("org.pantheon.desktop.gala.notifications.application", false);
+						var schema = SettingsSchemaSource.get_default ().lookup ("org.pantheon.desktop.gala.notifications.application", true);
 						if (schema != null) {
 							app_settings = new GLib.Settings.full (schema, null, "/org/pantheon/desktop/gala/notifications/applications/%s/".printf (app_id));
 							app_settings_cache.set (app_id, app_settings);


### PR DESCRIPTION
Fixes https://github.com/elementary/switchboard-plug-notifications/issues/41.

As seen in https://github.com/elementary/switchboard-plug-notifications/blob/master/src/Backend/App.vala#L32 we need `true` for the recursive parameter, otherwise the schema won't be found and no settings will be applied.