### PR TITLE
Make Enter key enter the workspace even without a selected window

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -363,7 +363,10 @@ namespace Gala
 					break;
 				case Clutter.Key.Return:
 				case Clutter.Key.KP_Enter:
-					get_active_workspace_clone ().window_container.activate_selected_window ();
+					if (!get_active_workspace_clone ().window_container.activate_selected_window ()) {
+						toggle ();
+					}
+
 					break;
 			}
 

--- a/src/Widgets/WindowCloneContainer.vala
+++ b/src/Widgets/WindowCloneContainer.vala
@@ -308,10 +308,14 @@ namespace Gala
 		/**
 		 * Emit the selected signal for the current_window.
 		 */
-		public void activate_selected_window ()
+		public bool activate_selected_window ()
 		{
-			if (current_window != null)
+			if (current_window != null) {
 				current_window.selected ();
+				return true;
+			}
+
+			return false;
 		}
 
 		/**


### PR DESCRIPTION
Fixes #519.

Previous code only made use of Enter when a window was selected in the current workspace preview. The change now checks if that was successful and if not, then just toggle out of the multitasking view.