### PR TITLE
Fix white box presence when dragging around a window clone

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -532,6 +532,8 @@ namespace Gala
 			prev_parent.remove_child (this);
 			stage.add_child (this);
 
+			active_shape.hide ();
+
 			var scale = window_icon.width / clone.width;
 
 			clone.get_transformed_position (out abs_x, out abs_y);
@@ -620,6 +622,8 @@ namespace Gala
 		{
 			Meta.Workspace workspace = null;
 			var primary = window.get_screen ().get_primary_monitor ();
+
+			active_shape.show ();
 
 			if (destination is IconGroup) {
 				workspace = ((IconGroup) destination).workspace;


### PR DESCRIPTION
Fixes #505.

Hide the active shape when the drag action is starting and hide it when ending.