### PR TITLE
Do not try to move a window to left if it is on the first workspace

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -575,8 +575,8 @@ namespace Gala
 			var next = active.get_neighbor (direction);
 
 			//dont allow empty workspaces to be created by moving, if we have dynamic workspaces
-			if ((Prefs.get_dynamic_workspaces () && 
-				Utils.get_n_windows (active) == 1 && next.index () == screen.n_workspaces - 1) || next.index () == 0) {
+			if ((Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () == screen.n_workspaces - 1)
+				|| (active.index () == 0 && next.index () == 0)) {
 				Utils.bell (screen);
 				return;
 			}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -576,7 +576,7 @@ namespace Gala
 
 			//dont allow empty workspaces to be created by moving, if we have dynamic workspaces
 			if ((Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () == screen.n_workspaces - 1)
-				|| (active.index () == 0 && next.index () == 0)) {
+				|| (active == next)) {
 				Utils.bell (screen);
 				return;
 			}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -575,7 +575,8 @@ namespace Gala
 			var next = active.get_neighbor (direction);
 
 			//dont allow empty workspaces to be created by moving, if we have dynamic workspaces
-			if (Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () ==  screen.n_workspaces - 1) {
+			if ((Prefs.get_dynamic_workspaces () && 
+				Utils.get_n_windows (active) == 1 && next.index () == screen.n_workspaces - 1) || next.index () == 0) {
 				Utils.bell (screen);
 				return;
 			}


### PR DESCRIPTION
Fixes #503.

Fixes a glitch where a window would be "moved" to the same workspace and then switching to the next workspace would have an animation glitch. This was caused by trying to move the window from first workspace to first workspace. It is worth noticing that this change also results in a bell when moving window from first workspace to previous. This is now consistent with the second behaviour when moving to the right.