### PR TITLE
Do not animate check items in the right-click menu

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -22,6 +22,12 @@ namespace Gala
 
 	const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
 	const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
+	
+	const string CHECK_ITEM_STYLE = """
+		menuitem check {
+			transition: none;
+		}
+	""";
 
 	[DBus (name = "org.pantheon.gala")]
 	public interface WMDBus : GLib.Object
@@ -47,6 +53,13 @@ namespace Gala
 		
 		ulong always_on_top_sid = 0U;
 		ulong on_visible_workspace_sid = 0U;
+
+		static construct
+		{
+			var css_provider = new Gtk.CssProvider ();
+			css_provider.load_from_data (CHECK_ITEM_STYLE);
+			Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+		}
 
 		[DBus (visible = false)]
 		public void setup_dbus ()


### PR DESCRIPTION
Disables transition animations on check items in the right-click menu to prevent them from animating when right-clicking on the titlebar.