### PR TITLE
Notify plugin control server

### DIFF
--- a/plugins/notify/Main.vala
+++ b/plugins/notify/Main.vala
@@ -78,7 +78,7 @@ namespace Gala.Plugins.Notify
 				(con, name) => {
 					warning ("Could not aquire bus %s", name);
 					destroy ();
-			});
+				});
 		}
 
 		void update_position ()

--- a/plugins/notify/PluginServer.vala
+++ b/plugins/notify/PluginServer.vala
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright (c) 2019 Gala Developers (http://github.com/elementary/gala)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+using Meta;
+
+namespace Gala.Plugins.Notify
+{
+    [DBus (name = "org.pantheon.gala.plugins.notify")]
+	public class PluginServer : Object
+	{
+        [DBus (visible = false)]
+        public int offset { get; private set; default = 0; }
+
+        public void set_stack_y_offset (int offset) throws Error
+        {
+            this.offset = offset;
+        }
+    }
+}

--- a/plugins/notify/meson.build
+++ b/plugins/notify/meson.build
@@ -5,6 +5,7 @@ gala_notify_sources = [
 	'Notification.vala',
 	'NotificationStack.vala',
 	'NotifyServer.vala',
+	'PluginServer.vala',
 	'NotifySettings.vala',
 ]
 


### PR DESCRIPTION
This adds a plugin control DBus server which exposes one method to set the y offset of the notification stack. If the wingpanel expands, it can call this method to make notifications update their position so that they don't overlap. This is needed by https://github.com/elementary/wingpanel/pull/212 to work correctly.