### PR TITLE
Prevent double BackgroundManager destroy

### DIFF
--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -46,7 +46,7 @@ namespace Gala
 			destroy.connect (on_destroy);
 		}
 
-		void destroy ()
+		void on_destroy ()
 		{
 			BackgroundCache.get_default ().release_background_source (BACKGROUND_SCHEMA);
 			background_source = null;

--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -46,6 +46,11 @@ namespace Gala
 
 		public override void destroy ()
 		{
+			// when already detroyed, abort
+			if (background_source == null) {
+				return;
+			}
+
 			BackgroundCache.get_default ().release_background_source (BACKGROUND_SCHEMA);
 			background_source = null;
 

--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -42,15 +42,12 @@ namespace Gala
 			background_source = BackgroundCache.get_default ().get_background_source (screen, BACKGROUND_SCHEMA);
 
 			background_actor = create_background_actor ();
+
+			destroy.connect (on_destroy);
 		}
 
-		public override void destroy ()
+		void destroy ()
 		{
-			// when already detroyed, abort
-			if (background_source == null) {
-				return;
-			}
-
 			BackgroundCache.get_default ().release_background_source (BACKGROUND_SCHEMA);
 			background_source = null;
 
@@ -63,8 +60,6 @@ namespace Gala
 				background_actor.destroy ();
 				background_actor = null;
 			}
-
-			base.destroy ();
 		}
 
 		void swap_background_actor ()

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1018,6 +1018,12 @@ namespace Gala
 
 			Rectangle icon = {};
 			if (actor.get_meta_window ().get_icon_geometry (out icon)) {
+				// Fix icon position and size according to ui scaling factor.
+				int ui_scale = InternalUtils.get_ui_scaling_factor ();
+				icon.x *= ui_scale;
+				icon.y *= ui_scale;
+				icon.width *= ui_scale;
+				icon.height *= ui_scale;
 
 				float scale_x  = (float)icon.width  / actor.width;
 				float scale_y  = (float)icon.height / actor.height;


### PR DESCRIPTION
Fixes: #561
Fixes: #13

So this feels a bit hacky, but I don't know of a better way to prevent this automatic second destroy call. See #561 for more information.