### PR TITLE
Drag the window down to open workspace view

### DIFF
--- a/src/DragDropAction.vala
+++ b/src/DragDropAction.vala
@@ -124,6 +124,16 @@ namespace Gala
 				release_actor (actor);
 		}
 
+		public void start_drag_action (int x, int y)
+		{
+			actor.get_stage ().captured_event.connect (follow_move);
+			clicked = true;
+			last_x = x;
+			last_y = y;
+			
+			start_motion (x, y);
+		}
+
 		public override void set_actor (Actor? new_actor)
 		{
 			if (actor != null) {
@@ -194,24 +204,7 @@ namespace Gala
 
 						var drag_threshold = Clutter.Settings.get_default ().dnd_drag_threshold;
 						if (Math.fabsf (last_x - x) > drag_threshold || Math.fabsf (last_y - y) > drag_threshold) {
-							handle = drag_begin (x, y);
-							if (handle == null) {
-								actor.get_stage ().captured_event.disconnect (follow_move);
-								critical ("No handle has been returned by the started signal, aborting drag.");
-								return false;
-							}
-
-							handle.reactive = false;
-
-							clicked = false;
-							dragging = true;
-
-							var source_list = sources.@get (drag_id);
-							if (source_list != null) {
-								foreach (var actor in source_list) {
-									actor.reactive = false;
-								}
-							}
+							start_motion (x, y);
 						}
 						return true;
 					case EventType.BUTTON_RELEASE:
@@ -295,6 +288,27 @@ namespace Gala
 			}
 
 			return false;
+		}
+
+		void start_motion (float x, float y)
+		{
+			handle = drag_begin (x, y);
+			if (handle == null) {
+				actor.get_stage ().captured_event.disconnect (follow_move);
+				critical ("No handle has been returned by the started signal, aborting drag.");
+			}
+
+			handle.reactive = false;
+
+			clicked = false;
+			dragging = true;
+
+			var source_list = sources.@get (drag_id);
+			if (source_list != null) {
+				foreach (var actor in source_list) {
+					actor.reactive = false;
+				}
+			}
 		}
 
 		/**

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -118,6 +118,32 @@ namespace Gala
 			});
 		}
 
+        public void start_drag_window (Window window, int x, int y)
+        {
+            bool found = false;
+            foreach (unowned Clutter.Actor child in workspaces.get_children ()) {
+                unowned WorkspaceClone workspace_clone = (WorkspaceClone)child;
+                if (workspace_clone.workspace != window.get_workspace ()) {
+                    continue;
+                }
+
+                foreach (unowned Clutter.Actor window_child in workspace_clone.window_container.get_children ()) {
+                    unowned WindowClone window_clone = (WindowClone)window_child;
+                    if (window_clone.window != window) {
+                        continue;
+                    }
+
+                    window_clone.start_drag (x, y);
+                    found = true;
+                    break;
+                }
+
+                if (found) {
+                    break;
+                }
+            }
+        }
+
 		/**
 		 * Places the primary container for the WorkspaceClones and the
 		 * MonitorClones at the right positions

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -375,7 +375,7 @@ namespace Gala
 
 			ActorBox alloc = {};
 			alloc.set_origin ((input_rect.x - outer_rect.x) * scale_factor,
-							  (input_rect.y - outer_rect.y) * scale_factor);
+			                  (input_rect.y - outer_rect.y) * scale_factor);
 			alloc.set_size (actor.width * scale_factor, actor.height * scale_factor);
 
 			clone.allocate (alloc, flags);

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -75,6 +75,8 @@ namespace Gala
 
 		public bool dragging { get; private set; default = false; }
 
+		bool animate_clone_transformation = true;
+
 		bool _active = false;
 		/**
 		 * When active fades a white border around the window in. Used for the visually
@@ -373,7 +375,7 @@ namespace Gala
 
 			ActorBox alloc = {};
 			alloc.set_origin ((input_rect.x - outer_rect.x) * scale_factor,
-			                  (input_rect.y - outer_rect.y) * scale_factor);
+							  (input_rect.y - outer_rect.y) * scale_factor);
 			alloc.set_size (actor.width * scale_factor, actor.height * scale_factor);
 
 			clone.allocate (alloc, flags);
@@ -430,6 +432,13 @@ namespace Gala
 
 				window_icon.restore_easing_state ();
 			}
+		}
+
+		public void start_drag (int x, int y)
+		{
+			animate_clone_transformation = false;
+			drag_action.start_drag_action (x, y);
+			animate_clone_transformation = true;
 		}
 
 		void toggle_shadow (bool show)
@@ -537,13 +546,20 @@ namespace Gala
 			var scale = window_icon.width / clone.width;
 
 			clone.get_transformed_position (out abs_x, out abs_y);
-			clone.save_easing_state ();
-			clone.set_easing_duration (200);
-			clone.set_easing_mode (AnimationMode.EASE_IN_CUBIC);
+			
+			if (animate_clone_transformation) {
+				clone.save_easing_state ();
+				clone.set_easing_duration (200);
+				clone.set_easing_mode (AnimationMode.EASE_IN_CUBIC);
+			}
+
 			clone.set_scale (scale, scale);
 			clone.opacity = 0;
 			clone.set_pivot_point ((click_x - abs_x) / clone.width, (click_y - abs_y) / clone.height);
-			clone.restore_easing_state ();
+			
+			if (animate_clone_transformation) {
+				clone.restore_easing_state ();
+			}
 
 			request_reposition ();
 
@@ -553,12 +569,18 @@ namespace Gala
 			set_easing_duration (0);
 			set_position (abs_x + prev_parent_x, abs_y + prev_parent_y);
 
-			window_icon.save_easing_state ();
-			window_icon.set_easing_duration (200);
-			window_icon.set_easing_mode (AnimationMode.EASE_IN_OUT_CUBIC);
+			if (animate_clone_transformation) {
+				window_icon.save_easing_state ();
+				window_icon.set_easing_duration (200);
+				window_icon.set_easing_mode (AnimationMode.EASE_IN_OUT_CUBIC);
+			}
+
 			window_icon.set_position (click_x - (abs_x + prev_parent_x) - window_icon.width / 2,
 				click_y - (abs_y + prev_parent_y) - window_icon.height / 2);
-			window_icon.restore_easing_state ();
+			
+			if (animate_clone_transformation) {
+				window_icon.restore_easing_state ();
+			}
 
 			close_button.opacity = 0;
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -70,6 +70,8 @@ namespace Gala
 		Window? moving; //place for the window that is being moved over
 
 		Daemon? daemon_proxy = null;
+		
+		WindowMovementTracker window_movement_tracker;
 
 		Gee.LinkedList<ModalProxy> modal_stack = new Gee.LinkedList<ModalProxy> ();
 
@@ -139,6 +141,10 @@ namespace Gala
 			MediaFeedback.init ();
 			WindowListener.init (screen);
 			KeyboardManager.init (display);
+			
+			window_movement_tracker = new WindowMovementTracker (display);
+			window_movement_tracker.watch ();
+			window_movement_tracker.open.connect (on_wmt_open);
 
 			// Due to a bug which enables access to the stage when using multiple monitors
 			// in the screensaver, we have to listen for changes and make sure the input area
@@ -1516,6 +1522,20 @@ namespace Gala
 					unmaximizing.remove (actor);
 				});
 			}
+		}
+
+		void on_wmt_open (Window window, int x, int y)
+		{
+			unowned Meta.Display display = get_screen ().get_display ();
+			display.end_grab_op (display.get_current_time ());
+
+			workspace_view.open (null);
+
+			Idle.add (() => {
+				((MultitaskingView)workspace_view).start_drag_window (window, x, y);
+				window_movement_tracker.restore_window_state ();
+				return false;
+			});
 		}
 
 		// Cancel attached animation of an actor and reset it

--- a/src/WindowMovementTracker.vala
+++ b/src/WindowMovementTracker.vala
@@ -1,0 +1,110 @@
+//
+//  Copyright (C) 2019 Adam Bieńkowski
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using Meta;
+
+namespace Gala
+{
+	public class WindowMovementTracker : Object {
+		public weak Meta.Display display { get; construct; }
+		public signal void open (Meta.Window window, int x, int y);
+		private Meta.Window? current_window;
+		private const float TRIGGER_RATIO = 0.98f;
+
+		private float start_x;
+		private float start_y;
+		private Meta.MaximizeFlags maximize_flags;
+
+		public WindowMovementTracker (Meta.Display display)
+		{
+			Object (display: display);
+		}
+
+		public void watch ()
+		{
+			display.grab_op_begin.connect (on_grab_op_begin);
+			display.grab_op_end.connect (on_grab_op_end);
+		}
+
+		public void unwatch () 
+		{
+			display.grab_op_begin.disconnect (on_grab_op_begin);
+			display.grab_op_end.disconnect (on_grab_op_end); 
+			
+			if (current_window != null) {
+				current_window.position_changed.disconnect (on_position_changed);
+			}
+		}
+
+		public void restore_window_state ()
+		{
+			var actor = (Meta.WindowActor)current_window.get_compositor_private ();
+			current_window.move_frame (false, (int)start_x, (int)start_y);
+			if (maximize_flags != 0) {
+				unowned AnimationSettings settings = AnimationSettings.get_default ();
+				int previous = settings.snap_duration;
+				settings.snap_duration = 0;
+				current_window.maximize (maximize_flags);
+				settings.snap_duration = previous;
+
+				/**
+				 * kill_window_effects does not reset the translation
+				 * and that's the only thing we want to do
+				 */  
+				actor.set_translation (0.0f, 0.0f, 0.0f);
+			}
+		}
+
+		private void on_grab_op_begin (Meta.Screen screen, Meta.Window? window, Meta.GrabOp op)
+		{
+			if (window == null) {
+				return;
+			}
+
+			current_window = window;
+
+			var actor = (Meta.WindowActor)window.get_compositor_private ();
+			start_x = actor.x;
+			start_y = actor.y;
+			maximize_flags = window.get_maximized ();
+
+			current_window.position_changed.connect (on_position_changed);
+		}
+
+		private void on_grab_op_end (Meta.Screen screen, Meta.Window? window, Meta.GrabOp op) 
+		{
+			current_window.position_changed.disconnect (on_position_changed);
+		}
+
+		private void on_position_changed (Meta.Window window)
+		{
+			unowned Meta.Screen screen = window.get_screen ();
+			unowned Meta.CursorTracker ct = Meta.CursorTracker.get_for_screen (screen);
+			int x, y;
+			Clutter.ModifierType type;
+			ct.get_pointer (out x, out y, out type);
+
+			int height;
+			screen.get_size (null, out height);
+
+			if (y > (float)height * TRIGGER_RATIO) {
+				window.position_changed.disconnect (on_position_changed);
+				open (window, x, y);
+			}
+		}
+	}
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ gala_bin_sources = files(
 	'WindowListener.vala',
 	'WindowManager.vala',
 	'WorkspaceManager.vala',
+    'WindowMovementTracker.vala',
 	'Background/Animation.vala',
 	'Background/Background.vala',
 	'Background/BackgroundCache.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,7 +17,7 @@ gala_bin_sources = files(
 	'WindowListener.vala',
 	'WindowManager.vala',
 	'WorkspaceManager.vala',
-    'WindowMovementTracker.vala',
+	'WindowMovementTracker.vala',
 	'Background/Animation.vala',
 	'Background/Background.vala',
 	'Background/BackgroundCache.vala',


### PR DESCRIPTION
Fixes #569.

Enables dragging the window down to the bottom screen edge to open workspace view and immediately move the window elsewhere.

Currently based on screen percentage (more than 98% of the height), we may rethink if this should happen.