### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: ''
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -46,12 +46,12 @@ If applicable, add screenshots or screen recordings to help explain your problem
 
 ### Logs
 <!--
-If applicable, share logs.
+If applicable, please share logs.
 
-If you notice erroneous behavior share logs, how:
+Notice erroneous behavior? Get and share debug logs by following:
 https://elementary.io/docs/code/os-dev#debug-logs
 
-For example when an application crashes please share crash logs, how:
+The application crashes? Get and share crash logs by following:
 https://elementary.io/docs/code/os-dev#inspecting-crashes
 -->
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,72 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+By filing an Issue, you are expected to comply with the elementary code of conduct: https://elementary.io/code-of-conduct
+
+Please fill out this template with all the information you have. We can't do much without a detailed description of what you've encountered. Please do your best!
+
+Please note that this tracker is only for bugs and feature requests. Please try these locations if you have a question or comment:
+
+  https://elementaryos.stackexchange.com/
+  https://www.reddit.com/r/elementaryos/
+
+Please read and follow these tips:
+https://elementary.io/docs/code/reference#be-prepared-to-provide-more-information
+
+Lastly, be sure to preview your issue before saving. Thanks!
+-->
+
+## Prerequisites
+- [ ] I have searched open and closed issues for duplicates.
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+If applicable, add screenshots or screen recordings to help explain your problem.
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots or screen recordings
+If applicable, add screenshots or screen recordings to help explain your problem.
+
+### Logs
+<!--
+If applicable, share logs.
+
+If you notice erroneous behavior share logs, how:
+https://elementary.io/docs/code/os-dev#debug-logs
+
+For example when an application crashes please share crash logs, how:
+https://elementary.io/docs/code/os-dev#inspecting-crashes
+-->
+
+## Platform Information
+<!--
+Please share a screenshot of the System Settings > About screen.
+If you can't please share:
+ - OS: [e.g. elementary OS]
+ - OS Version [e.g. Juno]
+ - Hardware info
+
+Please check what applies:
+-->
+- [ ] I'm using the latest version from git that I've manually compiled
+- [ ] I'm using the latest released stable version
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,43 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+<!--
+By filing an Issue, you are expected to comply with the elementary code of conduct: https://elementary.io/code-of-conduct
+
+Please note that this tracker is only for bugs and feature requests. Please try these locations if you have a question or comment:
+
+  https://elementaryos.stackexchange.com/
+  https://www.reddit.com/r/elementaryos/
+
+Please read and follow these tips:
+https://elementary.io/docs/code/reference#proposing-design-changes
+
+Lastly, be sure to preview your issue before saving. Thanks!
+-->
+
+## Prerequisites
+- [ ] I have searched open and closed issues for duplicates.
+
+## Feature
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+If applicable, add screenshots or screen recordings to help explain your problem.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. If possible, visualize.
+
+**Existing work**
+Does this feature exist elsewhere? Please share as much info as possible about that approach.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: Priority: Wishlist
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: Priority: Wishlist
+labels: 'Priority: Wishlist, Needs Design'
 assignees: ''
 
 ---

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -17,6 +17,8 @@
 
 namespace Gala
 {
+	const string EXTENSION = ".png";
+
 	[DBus (name="org.gnome.Shell.Screenshot")]
 	public class ScreenshotManager : Object
 	{
@@ -167,15 +169,23 @@ namespace Gala
 
 		static async bool save_image (Cairo.ImageSurface image, string filename, out string used_filename)
 		{
-			if (!Path.is_absolute (filename)) {
-				var path = find_target_path ();
-				if (!filename.has_suffix (".png")) {
-					used_filename = Path.build_filename (path, filename.concat (".png"), null);
-				} else {
-					used_filename = Path.build_filename (path, filename, null);
+			used_filename = filename;
+
+			// We only alter non absolute filename because absolute
+			// filename is used for temp clipboard file and shouldn't be changed
+			if (!Path.is_absolute (used_filename)) {
+				if (!used_filename.has_suffix (EXTENSION)) {
+					used_filename = used_filename.concat (EXTENSION);
 				}
-			} else {
-				used_filename = filename;
+
+				var scale_factor = InternalUtils.get_ui_scaling_factor ();
+				if (scale_factor > 1) {
+					var scale_pos = -EXTENSION.length;
+					used_filename = used_filename.splice (scale_pos, scale_pos, "@%ix".printf (scale_factor));
+				}
+
+				var path = find_target_path ();
+				used_filename = Path.build_filename (path, used_filename, null);
 			}
 
 			try {


### PR DESCRIPTION
First example of https://github.com/elementary/os/issues/209

Goal is to improve the quality of issues, for example making sure people include all the relevant information from the get go. 

Inspired by:
- Github's default issue templates
- @kgrubb proposal
- [Signal's issue template](https://github.com/signalapp/Signal-Desktop/issues/new)

Tried to include as many existing resources as possible. 

I'm hoping to copy these templates to almost all repo's with minor customizations. 