### PR TITLE
Fix: Animations for two tiled windows

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -962,14 +962,30 @@ namespace Gala
 
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
+			debug("size_change");
 			unowned Meta.Window window = actor.get_meta_window ();
+			switch (which_change) {
+				case Meta.SizeChange.MAXIMIZE:
+					debug("maximize");
+					break;
+				case Meta.SizeChange.UNMAXIMIZE:
+					debug("minimize");
+					break;
+				case Meta.SizeChange.FULLSCREEN:
+				case Meta.SizeChange.UNFULLSCREEN:
+					debug("fullscreen/unfullscreen");
+					handle_fullscreen_window (actor.get_meta_window (), which_change);
+					break;
+			}
 
 			if (which_change == Meta.SizeChange.UNFULLSCREEN || which_change == Meta.SizeChange.FULLSCREEN) {
 				handle_fullscreen_window (window, which_change);
-			} else if (window.get_tile_match () == null) { // don't animate windows with tiled match
+			} else (window.get_tile_match () == null) { 
 				ulong size_signal_id = 0U;
 				ulong position_signal_id = 0U;
-				size_signal_id = window.size_changed.connect (() => window_change_complete (actor, which_change, size_signal_id, position_signal_id));
+				//  if (window.get_tile_match () == null) { // don't animate resizing of two tiled windows
+					size_signal_id = window.size_changed.connect (() => window_change_complete (actor, which_change, size_signal_id, position_signal_id));
+				//  }
 				position_signal_id = window.position_changed.connect (() => window_change_complete (actor, which_change, size_signal_id, position_signal_id));
 				return; // must wait for size/position-changed-signal to get updated rect_frame
 			}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -982,7 +982,9 @@ namespace Gala
 		void window_change_complete (Meta.WindowActor actor, Meta.SizeChange which_change, ulong size_signal_id, ulong position_signal_id) {
 			unowned Meta.Window window = actor.get_meta_window ();
 
+			if (size_signal_id != 0U) { // only disconnect if signal was connected
 			window.disconnect (size_signal_id);
+			}
 			window.disconnect (position_signal_id);
 
 			var new_rect = window.get_frame_rect ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -983,11 +983,11 @@ namespace Gala
 		// size_changed gets called after frame_rect has updated
 		public override void size_changed (Meta.WindowActor actor) 
 		{
-			Meta.SizeChange? which_change_local = which_change;
 			if (which_change == null) {
 				return;
 			} 
 
+			Meta.SizeChange? which_change_local = which_change;
 			which_change = null;
 
 			unowned Meta.Window window = actor.get_meta_window ();
@@ -999,6 +999,7 @@ namespace Gala
 					if (window.get_tile_match () != null && !window.maximized_horizontally) {
 						var old_end = old_rect_size_change.x + old_rect_size_change.width;
 						var new_end = new_rect.x + new_rect.width;
+
 						// a tiled window is just resized (and not moved) if its start_x or its end_x stays the same
 						if (old_rect_size_change.x == new_rect.x || old_end == new_end) { 
 							break;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -971,12 +971,15 @@ namespace Gala
 			}
 		}
 
+		// must wait for size_changed to get updated frame_rect
+		// as which_change is not passed to size_changed, save it as instance variable
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change_local, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
 			which_change = which_change_local;
 		}
 
-		public override void size_changed (Meta.WindowActor actor)
+		// size_changed gets called after frame_rect has updated
+		public override void size_changed (Meta.WindowActor actor) 
 		{
 			Meta.SizeChange? which_change_local = which_change;
 			if (which_change == null) {
@@ -990,7 +993,7 @@ namespace Gala
 
 			switch (which_change_local) {
 				case Meta.SizeChange.MAXIMIZE:
-					if (window.get_tile_match () == null) {
+					if (window.get_tile_match () == null) { // don't animate resizing of two tiled windows
 						maximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
 					}
 					break;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -962,21 +962,7 @@ namespace Gala
 
 		public override void size_change (Meta.WindowActor actor, Meta.SizeChange which_change, Meta.Rectangle old_frame_rect, Meta.Rectangle old_buffer_rect)
 		{
-			debug("size_change");
 			unowned Meta.Window window = actor.get_meta_window ();
-			switch (which_change) {
-				case Meta.SizeChange.MAXIMIZE:
-					debug("maximize");
-					break;
-				case Meta.SizeChange.UNMAXIMIZE:
-					debug("minimize");
-					break;
-				case Meta.SizeChange.FULLSCREEN:
-				case Meta.SizeChange.UNFULLSCREEN:
-					debug("fullscreen/unfullscreen");
-					handle_fullscreen_window (actor.get_meta_window (), which_change);
-					break;
-			}
 
 			if (which_change == Meta.SizeChange.UNFULLSCREEN || which_change == Meta.SizeChange.FULLSCREEN) {
 				handle_fullscreen_window (window, which_change);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -980,12 +980,12 @@ namespace Gala
 
 			if (which_change == Meta.SizeChange.UNFULLSCREEN || which_change == Meta.SizeChange.FULLSCREEN) {
 				handle_fullscreen_window (window, which_change);
-			} else (window.get_tile_match () == null) { 
+			} else { 
 				ulong size_signal_id = 0U;
 				ulong position_signal_id = 0U;
-				//  if (window.get_tile_match () == null) { // don't animate resizing of two tiled windows
+				if (window.get_tile_match () == null) { // don't animate resizing of two tiled windows
 					size_signal_id = window.size_changed.connect (() => window_change_complete (actor, which_change, size_signal_id, position_signal_id));
-				//  }
+				}
 				position_signal_id = window.position_changed.connect (() => window_change_complete (actor, which_change, size_signal_id, position_signal_id));
 				return; // must wait for size/position-changed-signal to get updated rect_frame
 			}


### PR DESCRIPTION
Fixes: #582

There was no animation when moving a tiled window on top of another tiled window or when maximizing one of two tiled windows ...

**Before** (slowed down animations)
![ani_bug](https://user-images.githubusercontent.com/24651767/61177240-360b4680-a5d0-11e9-8197-e3c82293268c.gif)

**After** (slowed down animations)
![ani_fixed](https://user-images.githubusercontent.com/24651767/61177242-386da080-a5d0-11e9-8705-1f6956d11331.gif)