### PR TITLE
Lint the daemon directory via vala-lint

### DIFF
--- a/daemon/Main.vala
+++ b/daemon/Main.vala
@@ -16,122 +16,131 @@
 //
 
 namespace Gala {
-  [DBus (name = "org.gnome.SessionManager")]
-  public interface SessionManager : Object {
-    public abstract async ObjectPath register_client (string app_id, string client_start_id) throws DBusError, IOError;
-  }
+    [DBus (name = "org.gnome.SessionManager")]
+    public interface SessionManager : Object {
+        public abstract async ObjectPath register_client (
+            string app_id,
+            string client_start_id
+        ) throws DBusError, IOError;
+    }
 
-  [DBus (name = "org.gnome.SessionManager.ClientPrivate")]
-  public interface SessionClient : Object {
-    public abstract void end_session_response (bool is_ok, string reason) throws DBusError, IOError;
+    [DBus (name = "org.gnome.SessionManager.ClientPrivate")]
+    public interface SessionClient : Object {
+        public abstract void end_session_response (bool is_ok, string reason) throws DBusError, IOError;
 
-    public signal void stop () ;
-    public signal void query_end_session (uint flags);
-    public signal void end_session (uint flags);
-    public signal void cancel_end_session ();
-  }
+        public signal void stop () ;
+        public signal void query_end_session (uint flags);
+        public signal void end_session (uint flags);
+        public signal void cancel_end_session ();
+    }
 
-  public class Daemon {
-    SessionClient? sclient = null;
+    public class Daemon {
+        SessionClient? sclient = null;
 
-    public Daemon () {
-      register.begin ((o, res)=> {
-        bool success = register.end (res);
-        if (!success) {
-          message ("Failed to register with Session manager");
+        public Daemon () {
+            register.begin ((o, res)=> {
+                bool success = register.end (res);
+                if (!success) {
+                    message ("Failed to register with Session manager");
+                }
+            });
+
+            var menu_daemon = new MenuDaemon ();
+            menu_daemon.setup_dbus ();
         }
-      });
 
-      var menu_daemon = new MenuDaemon ();
-      menu_daemon.setup_dbus ();
+        public void run () {
+            Gtk.main ();
+        }
+
+        public static async SessionClient? register_with_session (string app_id) {
+            ObjectPath? path = null;
+            string? msg = null;
+            string? start_id = null;
+
+            SessionManager? session = null;
+            SessionClient? session_client = null;
+
+            start_id = Environment.get_variable ("DESKTOP_AUTOSTART_ID");
+            if (start_id != null) {
+                Environment.unset_variable ("DESKTOP_AUTOSTART_ID");
+            } else {
+                start_id = "";
+                warning (
+                    "DESKTOP_AUTOSTART_ID not set, session registration may be broken (not running via session?)"
+                );
+            }
+
+            try {
+                session = yield Bus.get_proxy (
+                    BusType.SESSION,
+                    "org.gnome.SessionManager",
+                    "/org/gnome/SessionManager"
+                );
+            } catch (Error e) {
+                warning ("Unable to connect to session manager: %s", e.message);
+                return null;
+            }
+
+            try {
+                path = yield session.register_client (app_id, start_id);
+            } catch (Error e) {
+                msg = e.message;
+                warning ("Error registering with session manager: %s", e.message);
+                return null;
+            }
+
+            try {
+                session_client = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", path);
+            } catch (Error e) {
+                warning ("Unable to get private sessions client proxy: %s", e.message);
+                return null;
+            }
+
+            return session_client;
+        }
+
+        async bool register () {
+            sclient = yield register_with_session ("org.pantheon.gala.daemon");
+
+            sclient.query_end_session.connect (() => end_session (false));
+            sclient.end_session.connect (() => end_session (false));
+            sclient.stop.connect (() => end_session (true));
+
+            return true;
+        }
+
+        void end_session (bool quit) {
+            if (quit) {
+                Gtk.main_quit ();
+                return;
+            }
+
+            try {
+                sclient.end_session_response (true, "");
+            } catch (Error e) {
+                warning ("Unable to respond to session manager: %s", e.message);
+            }
+        }
     }
 
-    public void run () {
-      Gtk.main ();
+    public static int main (string[] args) {
+        Gtk.init (ref args);
+
+        var ctx = new OptionContext ("Gala Daemon");
+        ctx.set_help_enabled (true);
+        ctx.add_group (Gtk.get_option_group (false));
+
+        try {
+            ctx.parse (ref args);
+        } catch (Error e) {
+            stderr.printf ("Error: %s\n", e.message);
+            return 0;
+        }
+
+        var daemon = new Daemon ();
+        daemon.run ();
+
+        return 0;
     }
-
-    public static async SessionClient? register_with_session (string app_id) {
-      ObjectPath? path = null;
-      string? msg = null;
-      string? start_id = null;
-
-      SessionManager? session = null;
-      SessionClient? session_client = null;
-
-      start_id = Environment.get_variable ("DESKTOP_AUTOSTART_ID");
-      if (start_id != null) {
-        Environment.unset_variable ("DESKTOP_AUTOSTART_ID");
-      } else {
-        start_id = "";
-        warning ("DESKTOP_AUTOSTART_ID not set, session registration may be broken (not running via session?)");
-      }
-
-      try {
-        session = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager");
-      } catch (Error e) {
-        warning ("Unable to connect to session manager: %s", e.message);
-        return null;
-      }
-
-      try {
-        path = yield session.register_client (app_id, start_id);
-      } catch (Error e) {
-        msg = e.message;
-        warning ("Error registering with session manager: %s", e.message);
-        return null;
-      }
-
-      try {
-        session_client = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", path);
-      } catch (Error e) {
-        warning ("Unable to get private sessions client proxy: %s", e.message);
-        return null;
-      }
-
-      return session_client;
-    }
-
-    async bool register () {
-      sclient = yield register_with_session ("org.pantheon.gala.daemon");
-
-      sclient.query_end_session.connect (() => end_session (false));
-      sclient.end_session.connect (() => end_session (false));
-      sclient.stop.connect (() => end_session (true));
-
-      return true;
-    }
-
-    void end_session (bool quit) {
-      if (quit) {
-        Gtk.main_quit ();
-        return;
-      }
-
-      try {
-        sclient.end_session_response (true, "");
-      } catch (Error e) {
-        warning ("Unable to respond to session manager: %s", e.message);
-      }
-    }
-  }
-
-  public static int main (string[] args) {
-    Gtk.init (ref args);
-
-    var ctx = new OptionContext ("Gala Daemon");
-    ctx.set_help_enabled (true);
-    ctx.add_group (Gtk.get_option_group (false));
-
-    try {
-      ctx.parse (ref args);
-    } catch (Error e) {
-      stderr.printf ("Error: %s\n", e.message);
-      return 0;
-    }
-
-    var daemon = new Daemon ();
-    daemon.run ();
-
-    return 0;
-  }
 }

--- a/daemon/Main.vala
+++ b/daemon/Main.vala
@@ -15,132 +15,123 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-namespace Gala
-{
-	[DBus (name = "org.gnome.SessionManager")]
-	public interface SessionManager : Object
-	{
-		public abstract async ObjectPath register_client (string app_id, string client_start_id) throws DBusError, IOError;
-	}
+namespace Gala {
+  [DBus (name = "org.gnome.SessionManager")]
+  public interface SessionManager : Object {
+    public abstract async ObjectPath register_client (string app_id, string client_start_id) throws DBusError, IOError;
+  }
 
-	[DBus (name = "org.gnome.SessionManager.ClientPrivate")]
-	public interface SessionClient : Object
-	{
-		public abstract void end_session_response (bool is_ok, string reason) throws DBusError, IOError;
+  [DBus (name = "org.gnome.SessionManager.ClientPrivate")]
+  public interface SessionClient : Object {
+    public abstract void end_session_response (bool is_ok, string reason) throws DBusError, IOError;
 
-		public signal void stop () ;
-		public signal void query_end_session (uint flags);
-		public signal void end_session (uint flags);
-		public signal void cancel_end_session ();
-	}
+    public signal void stop () ;
+    public signal void query_end_session (uint flags);
+    public signal void end_session (uint flags);
+    public signal void cancel_end_session ();
+  }
 
-	public class Daemon
-	{
-		SessionClient? sclient = null;
+  public class Daemon {
+    SessionClient? sclient = null;
 
-		public Daemon ()
-		{
-			register.begin ((o, res)=> {
-				bool success = register.end (res);
-				if (!success) {
-					message ("Failed to register with Session manager");
-				}
-			});
+    public Daemon () {
+      register.begin ((o, res)=> {
+        bool success = register.end (res);
+        if (!success) {
+          message ("Failed to register with Session manager");
+        }
+      });
 
-			var menu_daemon = new MenuDaemon ();
-			menu_daemon.setup_dbus ();
-		}
+      var menu_daemon = new MenuDaemon ();
+      menu_daemon.setup_dbus ();
+    }
 
-		public void run () {
-			Gtk.main ();
-		}
+    public void run () {
+      Gtk.main ();
+    }
 
-		public static async SessionClient? register_with_session (string app_id)
-		{
-			ObjectPath? path = null;
-			string? msg = null;
-			string? start_id = null;
+    public static async SessionClient? register_with_session (string app_id) {
+      ObjectPath? path = null;
+      string? msg = null;
+      string? start_id = null;
 
-			SessionManager? session = null;
-			SessionClient? session_client = null;
+      SessionManager? session = null;
+      SessionClient? session_client = null;
 
-			start_id = Environment.get_variable ("DESKTOP_AUTOSTART_ID");
-			if (start_id != null) {
-				Environment.unset_variable ("DESKTOP_AUTOSTART_ID");
-			} else {
-				start_id = "";
-				warning ("DESKTOP_AUTOSTART_ID not set, session registration may be broken (not running via session?)");
-			}
+      start_id = Environment.get_variable ("DESKTOP_AUTOSTART_ID");
+      if (start_id != null) {
+        Environment.unset_variable ("DESKTOP_AUTOSTART_ID");
+      } else {
+        start_id = "";
+        warning ("DESKTOP_AUTOSTART_ID not set, session registration may be broken (not running via session?)");
+      }
 
-			try {
-				session = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager");
-			} catch (Error e) {
-				warning ("Unable to connect to session manager: %s", e.message);
-				return null;
-			}
+      try {
+        session = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager");
+      } catch (Error e) {
+        warning ("Unable to connect to session manager: %s", e.message);
+        return null;
+      }
 
-			try {
-				path = yield session.register_client (app_id, start_id);
-			} catch (Error e) {
-				msg = e.message;
-				warning ("Error registering with session manager: %s", e.message);
-				return null;
-			}
+      try {
+        path = yield session.register_client (app_id, start_id);
+      } catch (Error e) {
+        msg = e.message;
+        warning ("Error registering with session manager: %s", e.message);
+        return null;
+      }
 
-			try {
-				session_client = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", path);
-			} catch (Error e) {
-				warning ("Unable to get private sessions client proxy: %s", e.message);
-				return null;
-			}
+      try {
+        session_client = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", path);
+      } catch (Error e) {
+        warning ("Unable to get private sessions client proxy: %s", e.message);
+        return null;
+      }
 
-			return session_client;
-		}
+      return session_client;
+    }
 
-		async bool register ()
-		{
-			sclient = yield register_with_session ("org.pantheon.gala.daemon");
+    async bool register () {
+      sclient = yield register_with_session ("org.pantheon.gala.daemon");
 
-			sclient.query_end_session.connect (() => end_session (false));
-			sclient.end_session.connect (() => end_session (false));
-			sclient.stop.connect (() => end_session (true));
+      sclient.query_end_session.connect (() => end_session (false));
+      sclient.end_session.connect (() => end_session (false));
+      sclient.stop.connect (() => end_session (true));
 
-			return true;
-		}
+      return true;
+    }
 
-		void end_session (bool quit)
-		{
-			if (quit) {
-				Gtk.main_quit ();
-				return;
-			}
+    void end_session (bool quit) {
+      if (quit) {
+        Gtk.main_quit ();
+        return;
+      }
 
-			try {
-				sclient.end_session_response (true, "");
-			} catch (Error e) {
-				warning ("Unable to respond to session manager: %s", e.message);
-			}
-		}
-	}
+      try {
+        sclient.end_session_response (true, "");
+      } catch (Error e) {
+        warning ("Unable to respond to session manager: %s", e.message);
+      }
+    }
+  }
 
-	public static int main (string[] args)
-	{
-		Gtk.init (ref args);
+  public static int main (string[] args) {
+    Gtk.init (ref args);
 
-		var ctx = new OptionContext ("Gala Daemon");
-		ctx.set_help_enabled (true);
-		ctx.add_group (Gtk.get_option_group (false));
+    var ctx = new OptionContext ("Gala Daemon");
+    ctx.set_help_enabled (true);
+    ctx.add_group (Gtk.get_option_group (false));
 
-		try {
-			ctx.parse (ref args);
-		} catch (Error e) {
-			stderr.printf ("Error: %s\n", e.message);
-			return 0;
-		}
+    try {
+      ctx.parse (ref args);
+    } catch (Error e) {
+      stderr.printf ("Error: %s\n", e.message);
+      return 0;
+    }
 
-		var daemon = new Daemon ();
-		daemon.run ();
+    var daemon = new Daemon ();
+    daemon.run ();
 
-		return 0;
-	}
+    return 0;
+  }
 }

--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -15,185 +15,174 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-namespace Gala
-{
-	const string DBUS_NAME = "org.pantheon.gala";
-	const string DBUS_OBJECT_PATH = "/org/pantheon/gala";
+namespace Gala {
+  const string DBUS_NAME = "org.pantheon.gala";
+  const string DBUS_OBJECT_PATH = "/org/pantheon/gala";
 
-	const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
-	const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
+  const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
+  const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
 
-	[DBus (name = "org.pantheon.gala")]
-	public interface WMDBus : GLib.Object
-	{
-		public abstract void perform_action (Gala.ActionType type) throws DBusError, IOError;
-	}
+  [DBus (name = "org.pantheon.gala")]
+  public interface WMDBus : GLib.Object {
+    public abstract void perform_action (Gala.ActionType type) throws DBusError, IOError;
+  }
 
-	[DBus (name = "org.pantheon.gala.daemon")]
-	public class MenuDaemon : Object
-	{
-		Gtk.Menu? window_menu = null;
-		Gtk.MenuItem minimize;
-		Gtk.MenuItem maximize;
-		Gtk.MenuItem move;
-		Gtk.MenuItem resize;
-		Gtk.CheckMenuItem always_on_top;
-		Gtk.CheckMenuItem on_visible_workspace;
-		Gtk.MenuItem move_left;
-		Gtk.MenuItem move_right;
-		Gtk.MenuItem close;
+  [DBus (name = "org.pantheon.gala.daemon")]
+  public class MenuDaemon : Object {
+    Gtk.Menu? window_menu = null;
+    Gtk.MenuItem minimize;
+    Gtk.MenuItem maximize;
+    Gtk.MenuItem move;
+    Gtk.MenuItem resize;
+    Gtk.CheckMenuItem always_on_top;
+    Gtk.CheckMenuItem on_visible_workspace;
+    Gtk.MenuItem move_left;
+    Gtk.MenuItem move_right;
+    Gtk.MenuItem close;
 
-		WMDBus? wm_proxy = null;
-		
-		ulong always_on_top_sid = 0U;
-		ulong on_visible_workspace_sid = 0U;
+    WMDBus? wm_proxy = null;
 
-		[DBus (visible = false)]
-		public void setup_dbus ()
-		{
-			var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT | BusNameOwnerFlags.REPLACE;
-			Bus.own_name (BusType.SESSION, DAEMON_DBUS_NAME, flags, on_bus_acquired, () => {}, null);
+    ulong always_on_top_sid = 0U;
+    ulong on_visible_workspace_sid = 0U;
 
-			Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE, gala_appeared, lost_gala);
-		}
+    [DBus (visible = false)]
+    public void setup_dbus () {
+      var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT | BusNameOwnerFlags.REPLACE;
+      Bus.own_name (BusType.SESSION, DAEMON_DBUS_NAME, flags, on_bus_acquired, () => {}, null);
 
-		void on_gala_get (GLib.Object? o, GLib.AsyncResult? res)
-		{
-			try {
-				wm_proxy = Bus.get_proxy.end (res);
-			} catch (Error e) {
-				warning ("Failed to get Gala proxy: %s", e.message);
-			}
-		}
+      Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE, gala_appeared, lost_gala);
+    }
 
-		void lost_gala ()
-		{
-			wm_proxy = null;
-		}
+    void on_gala_get (GLib.Object? o, GLib.AsyncResult? res) {
+      try {
+        wm_proxy = Bus.get_proxy.end (res);
+      } catch (Error e) {
+        warning ("Failed to get Gala proxy: %s", e.message);
+      }
+    }
 
-		void gala_appeared ()
-		{
-			if (wm_proxy == null) {
-				Bus.get_proxy.begin<WMDBus> (BusType.SESSION, DBUS_NAME, DBUS_OBJECT_PATH, 0, null, on_gala_get);
-			}
-		}
+    void lost_gala () {
+      wm_proxy = null;
+    }
 
-		void on_bus_acquired (DBusConnection conn)
-		{
-			try {
-				conn.register_object (DAEMON_DBUS_OBJECT_PATH, this);
-			} catch (Error e) {
-				stderr.printf ("Error registering MenuDaemon: %s\n", e.message);
-			}
-		}
+    void gala_appeared () {
+      if (wm_proxy == null) {
+        Bus.get_proxy.begin<WMDBus> (BusType.SESSION, DBUS_NAME, DBUS_OBJECT_PATH, 0, null, on_gala_get);
+      }
+    }
 
-		void perform_action (Gala.ActionType type)
-		{
-			if (wm_proxy != null) {
-				try {
-					wm_proxy.perform_action (type);
-				} catch (Error e) {
-					warning ("Failed to perform Gala action over DBus: %s", e.message);
-				}
-			}
-		}
+    void on_bus_acquired (DBusConnection conn) {
+      try {
+        conn.register_object (DAEMON_DBUS_OBJECT_PATH, this);
+      } catch (Error e) {
+        stderr.printf ("Error registering MenuDaemon: %s\n", e.message);
+      }
+    }
 
-		void init_window_menu ()
-		{
-			window_menu = new Gtk.Menu ();
+    void perform_action (Gala.ActionType type) {
+      if (wm_proxy != null) {
+        try {
+          wm_proxy.perform_action (type);
+        } catch (Error e) {
+          warning ("Failed to perform Gala action over DBus: %s", e.message);
+        }
+      }
+    }
 
-			minimize = new Gtk.MenuItem.with_label (_("Minimize"));
-			minimize.activate.connect (() => {
-				perform_action (Gala.ActionType.MINIMIZE_CURRENT);
-			});
-			window_menu.append (minimize);
+    void init_window_menu () {
+      window_menu = new Gtk.Menu ();
 
-			maximize = new Gtk.MenuItem.with_label ("");
-			maximize.activate.connect (() => {
-				perform_action (Gala.ActionType.MAXIMIZE_CURRENT);
-			});
-			window_menu.append (maximize);
+      minimize = new Gtk.MenuItem.with_label (_("Minimize"));
+      minimize.activate.connect (() => {
+        perform_action (Gala.ActionType.MINIMIZE_CURRENT);
+      });
+      window_menu.append (minimize);
 
-			move = new Gtk.MenuItem.with_label (_("Move"));
-			move.activate.connect (() => {
-				perform_action (Gala.ActionType.START_MOVE_CURRENT);
-			});
-			window_menu.append (move);
+      maximize = new Gtk.MenuItem.with_label ("");
+      maximize.activate.connect (() => {
+        perform_action (Gala.ActionType.MAXIMIZE_CURRENT);
+      });
+      window_menu.append (maximize);
 
-			resize = new Gtk.MenuItem.with_label (_("Resize"));
-			resize.activate.connect (() => {
-				perform_action (Gala.ActionType.START_RESIZE_CURRENT);
-			});
-			window_menu.append (resize);
+      move = new Gtk.MenuItem.with_label (_("Move"));
+      move.activate.connect (() => {
+        perform_action (Gala.ActionType.START_MOVE_CURRENT);
+      });
+      window_menu.append (move);
 
-			always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
-			always_on_top_sid = always_on_top.activate.connect (() => {
-				perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_TOP_CURRENT);
-			});
-			window_menu.append (always_on_top);
+      resize = new Gtk.MenuItem.with_label (_("Resize"));
+      resize.activate.connect (() => {
+        perform_action (Gala.ActionType.START_RESIZE_CURRENT);
+      });
+      window_menu.append (resize);
 
-			on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
-			on_visible_workspace_sid = on_visible_workspace.activate.connect (() => {
-				perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT);
-			});
-			window_menu.append (on_visible_workspace);
+      always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
+      always_on_top_sid = always_on_top.activate.connect (() => {
+        perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_TOP_CURRENT);
+      });
+      window_menu.append (always_on_top);
 
-			move_left = new Gtk.MenuItem.with_label (_("Move to Workspace Left"));
-			move_left.activate.connect (() => {
-				perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_LEFT);
-			});
-			window_menu.append (move_left);
+      on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
+      on_visible_workspace_sid = on_visible_workspace.activate.connect (() => {
+        perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT);
+      });
+      window_menu.append (on_visible_workspace);
 
-			move_right = new Gtk.MenuItem.with_label (_("Move to Workspace Right"));
-			move_right.activate.connect (() => {
-				perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_RIGHT);
-			});
-			window_menu.append (move_right);
+      move_left = new Gtk.MenuItem.with_label (_("Move to Workspace Left"));
+      move_left.activate.connect (() => {
+        perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_LEFT);
+      });
+      window_menu.append (move_left);
 
-			close = new Gtk.MenuItem.with_label (_("Close"));
-			close.activate.connect (() => {
-				perform_action (Gala.ActionType.CLOSE_CURRENT);
-			});
-			window_menu.append (close);
+      move_right = new Gtk.MenuItem.with_label (_("Move to Workspace Right"));
+      move_right.activate.connect (() => {
+        perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_RIGHT);
+      });
+      window_menu.append (move_right);
 
-			window_menu.show_all ();
-		}
+      close = new Gtk.MenuItem.with_label (_("Close"));
+      close.activate.connect (() => {
+        perform_action (Gala.ActionType.CLOSE_CURRENT);
+      });
+      window_menu.append (close);
 
-		public void show_window_menu (Gala.WindowFlags flags, int x, int y) throws DBusError, IOError
-		{
-			if (window_menu == null) {
-				init_window_menu ();
-			}
+      window_menu.show_all ();
+    }
 
-			minimize.visible = Gala.WindowFlags.CAN_MINIMIZE in flags;
-			maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
-			maximize.label = Gala.WindowFlags.IS_MAXIMIZED in flags ? _("Unmaximize") : _("Maximize");
-			move.visible = Gala.WindowFlags.ALLOWS_MOVE in flags;
-			resize.visible = Gala.WindowFlags.ALLOWS_RESIZE in flags;
-			
-			// Setting active causes signal fires on activate so
-			// we temporarily block those signals from emissions
-			SignalHandler.block (always_on_top, always_on_top_sid);
-			SignalHandler.block (on_visible_workspace, on_visible_workspace_sid);
+    public void show_window_menu (Gala.WindowFlags flags, int x, int y) throws DBusError, IOError {
+      if (window_menu == null) {
+        init_window_menu ();
+      }
 
-			always_on_top.active = Gala.WindowFlags.ALWAYS_ON_TOP in flags;
-			on_visible_workspace.active = Gala.WindowFlags.ON_ALL_WORKSPACES in flags;
-			
-			SignalHandler.unblock (always_on_top, always_on_top_sid);
-			SignalHandler.unblock (on_visible_workspace, on_visible_workspace_sid);
+      minimize.visible = Gala.WindowFlags.CAN_MINIMIZE in flags;
+      maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
+      maximize.label = Gala.WindowFlags.IS_MAXIMIZED in flags ? _("Unmaximize") : _("Maximize");
+      move.visible = Gala.WindowFlags.ALLOWS_MOVE in flags;
+      resize.visible = Gala.WindowFlags.ALLOWS_RESIZE in flags;
 
-			move_right.visible = !on_visible_workspace.active;
-			move_left.visible = !on_visible_workspace.active;
-			close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
+      // Setting active causes signal fires on activate so
+      // we temporarily block those signals from emissions
+      SignalHandler.block (always_on_top, always_on_top_sid);
+      SignalHandler.block (on_visible_workspace, on_visible_workspace_sid);
 
-			window_menu.popup (null, null, (m, ref px, ref py, out push_in) => {
-				var scale = m.scale_factor;
-				px = x / scale;
-				// Move the menu 1 pixel outside of the pointer or else it closes instantly
-				// on the mouse up event
-				py = (y / scale) + 1;
-				push_in = true;
-			}, 3, Gdk.CURRENT_TIME);
-		}
-	}
+      always_on_top.active = Gala.WindowFlags.ALWAYS_ON_TOP in flags;
+      on_visible_workspace.active = Gala.WindowFlags.ON_ALL_WORKSPACES in flags;
+
+      SignalHandler.unblock (always_on_top, always_on_top_sid);
+      SignalHandler.unblock (on_visible_workspace, on_visible_workspace_sid);
+
+      move_right.visible = !on_visible_workspace.active;
+      move_left.visible = !on_visible_workspace.active;
+      close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
+
+      window_menu.popup (null, null, (m, ref px, ref py, out push_in) => {
+        var scale = m.scale_factor;
+        px = x / scale;
+        // Move the menu 1 pixel outside of the pointer or else it closes instantly
+        // on the mouse up event
+        py = (y / scale) + 1;
+        push_in = true;
+      }, 3, Gdk.CURRENT_TIME);
+    }
+  }
 }

--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -16,173 +16,173 @@
 //
 
 namespace Gala {
-  const string DBUS_NAME = "org.pantheon.gala";
-  const string DBUS_OBJECT_PATH = "/org/pantheon/gala";
+    const string DBUS_NAME = "org.pantheon.gala";
+    const string DBUS_OBJECT_PATH = "/org/pantheon/gala";
 
-  const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
-  const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
+    const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
+    const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
 
-  [DBus (name = "org.pantheon.gala")]
-  public interface WMDBus : GLib.Object {
-    public abstract void perform_action (Gala.ActionType type) throws DBusError, IOError;
-  }
-
-  [DBus (name = "org.pantheon.gala.daemon")]
-  public class MenuDaemon : Object {
-    Gtk.Menu? window_menu = null;
-    Gtk.MenuItem minimize;
-    Gtk.MenuItem maximize;
-    Gtk.MenuItem move;
-    Gtk.MenuItem resize;
-    Gtk.CheckMenuItem always_on_top;
-    Gtk.CheckMenuItem on_visible_workspace;
-    Gtk.MenuItem move_left;
-    Gtk.MenuItem move_right;
-    Gtk.MenuItem close;
-
-    WMDBus? wm_proxy = null;
-
-    ulong always_on_top_sid = 0U;
-    ulong on_visible_workspace_sid = 0U;
-
-    [DBus (visible = false)]
-    public void setup_dbus () {
-      var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT | BusNameOwnerFlags.REPLACE;
-      Bus.own_name (BusType.SESSION, DAEMON_DBUS_NAME, flags, on_bus_acquired, () => {}, null);
-
-      Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE, gala_appeared, lost_gala);
+    [DBus (name = "org.pantheon.gala")]
+    public interface WMDBus : GLib.Object {
+        public abstract void perform_action (Gala.ActionType type) throws DBusError, IOError;
     }
 
-    void on_gala_get (GLib.Object? o, GLib.AsyncResult? res) {
-      try {
-        wm_proxy = Bus.get_proxy.end (res);
-      } catch (Error e) {
-        warning ("Failed to get Gala proxy: %s", e.message);
-      }
-    }
+    [DBus (name = "org.pantheon.gala.daemon")]
+    public class MenuDaemon : Object {
+        Gtk.Menu? window_menu = null;
+        Gtk.MenuItem minimize;
+        Gtk.MenuItem maximize;
+        Gtk.MenuItem move;
+        Gtk.MenuItem resize;
+        Gtk.CheckMenuItem always_on_top;
+        Gtk.CheckMenuItem on_visible_workspace;
+        Gtk.MenuItem move_left;
+        Gtk.MenuItem move_right;
+        Gtk.MenuItem close;
 
-    void lost_gala () {
-      wm_proxy = null;
-    }
+        WMDBus? wm_proxy = null;
 
-    void gala_appeared () {
-      if (wm_proxy == null) {
-        Bus.get_proxy.begin<WMDBus> (BusType.SESSION, DBUS_NAME, DBUS_OBJECT_PATH, 0, null, on_gala_get);
-      }
-    }
+        ulong always_on_top_sid = 0U;
+        ulong on_visible_workspace_sid = 0U;
 
-    void on_bus_acquired (DBusConnection conn) {
-      try {
-        conn.register_object (DAEMON_DBUS_OBJECT_PATH, this);
-      } catch (Error e) {
-        stderr.printf ("Error registering MenuDaemon: %s\n", e.message);
-      }
-    }
+        [DBus (visible = false)]
+        public void setup_dbus () {
+            var flags = BusNameOwnerFlags.ALLOW_REPLACEMENT | BusNameOwnerFlags.REPLACE;
+            Bus.own_name (BusType.SESSION, DAEMON_DBUS_NAME, flags, on_bus_acquired, () => {}, null);
 
-    void perform_action (Gala.ActionType type) {
-      if (wm_proxy != null) {
-        try {
-          wm_proxy.perform_action (type);
-        } catch (Error e) {
-          warning ("Failed to perform Gala action over DBus: %s", e.message);
+            Bus.watch_name (BusType.SESSION, DBUS_NAME, BusNameWatcherFlags.NONE, gala_appeared, lost_gala);
         }
-      }
+
+        void on_gala_get (GLib.Object? o, GLib.AsyncResult? res) {
+            try {
+                wm_proxy = Bus.get_proxy.end (res);
+            } catch (Error e) {
+                warning ("Failed to get Gala proxy: %s", e.message);
+            }
+        }
+
+        void lost_gala () {
+            wm_proxy = null;
+        }
+
+        void gala_appeared () {
+            if (wm_proxy == null) {
+                Bus.get_proxy.begin<WMDBus> (BusType.SESSION, DBUS_NAME, DBUS_OBJECT_PATH, 0, null, on_gala_get);
+            }
+        }
+
+        void on_bus_acquired (DBusConnection conn) {
+            try {
+                conn.register_object (DAEMON_DBUS_OBJECT_PATH, this);
+            } catch (Error e) {
+                stderr.printf ("Error registering MenuDaemon: %s\n", e.message);
+            }
+        }
+
+        void perform_action (Gala.ActionType type) {
+            if (wm_proxy != null) {
+                try {
+                    wm_proxy.perform_action (type);
+                } catch (Error e) {
+                    warning ("Failed to perform Gala action over DBus: %s", e.message);
+                }
+            }
+        }
+
+        void init_window_menu () {
+            window_menu = new Gtk.Menu ();
+
+            minimize = new Gtk.MenuItem.with_label (_("Minimize"));
+            minimize.activate.connect (() => {
+                perform_action (Gala.ActionType.MINIMIZE_CURRENT);
+            });
+            window_menu.append (minimize);
+
+            maximize = new Gtk.MenuItem.with_label ("");
+            maximize.activate.connect (() => {
+                perform_action (Gala.ActionType.MAXIMIZE_CURRENT);
+            });
+            window_menu.append (maximize);
+
+            move = new Gtk.MenuItem.with_label (_("Move"));
+            move.activate.connect (() => {
+                perform_action (Gala.ActionType.START_MOVE_CURRENT);
+            });
+            window_menu.append (move);
+
+            resize = new Gtk.MenuItem.with_label (_("Resize"));
+            resize.activate.connect (() => {
+                perform_action (Gala.ActionType.START_RESIZE_CURRENT);
+            });
+            window_menu.append (resize);
+
+            always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
+            always_on_top_sid = always_on_top.activate.connect (() => {
+                perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_TOP_CURRENT);
+            });
+            window_menu.append (always_on_top);
+
+            on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
+            on_visible_workspace_sid = on_visible_workspace.activate.connect (() => {
+                perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT);
+            });
+            window_menu.append (on_visible_workspace);
+
+            move_left = new Gtk.MenuItem.with_label (_("Move to Workspace Left"));
+            move_left.activate.connect (() => {
+                perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_LEFT);
+            });
+            window_menu.append (move_left);
+
+            move_right = new Gtk.MenuItem.with_label (_("Move to Workspace Right"));
+            move_right.activate.connect (() => {
+                perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_RIGHT);
+            });
+            window_menu.append (move_right);
+
+            close = new Gtk.MenuItem.with_label (_("Close"));
+            close.activate.connect (() => {
+                perform_action (Gala.ActionType.CLOSE_CURRENT);
+            });
+            window_menu.append (close);
+
+            window_menu.show_all ();
+        }
+
+        public void show_window_menu (Gala.WindowFlags flags, int x, int y) throws DBusError, IOError {
+            if (window_menu == null) {
+                init_window_menu ();
+            }
+
+            minimize.visible = Gala.WindowFlags.CAN_MINIMIZE in flags;
+            maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
+            maximize.label = Gala.WindowFlags.IS_MAXIMIZED in flags ? _("Unmaximize") : _("Maximize");
+            move.visible = Gala.WindowFlags.ALLOWS_MOVE in flags;
+            resize.visible = Gala.WindowFlags.ALLOWS_RESIZE in flags;
+
+            // Setting active causes signal fires on activate so
+            // we temporarily block those signals from emissions
+            SignalHandler.block (always_on_top, always_on_top_sid);
+            SignalHandler.block (on_visible_workspace, on_visible_workspace_sid);
+
+            always_on_top.active = Gala.WindowFlags.ALWAYS_ON_TOP in flags;
+            on_visible_workspace.active = Gala.WindowFlags.ON_ALL_WORKSPACES in flags;
+
+            SignalHandler.unblock (always_on_top, always_on_top_sid);
+            SignalHandler.unblock (on_visible_workspace, on_visible_workspace_sid);
+
+            move_right.visible = !on_visible_workspace.active;
+            move_left.visible = !on_visible_workspace.active;
+            close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
+
+            window_menu.popup (null, null, (m, ref px, ref py, out push_in) => {
+                var scale = m.scale_factor;
+                px = x / scale;
+                // Move the menu 1 pixel outside of the pointer or else it closes instantly
+                // on the mouse up event
+                py = (y / scale) + 1;
+                push_in = true;
+            }, 3, Gdk.CURRENT_TIME);
+        }
     }
-
-    void init_window_menu () {
-      window_menu = new Gtk.Menu ();
-
-      minimize = new Gtk.MenuItem.with_label (_("Minimize"));
-      minimize.activate.connect (() => {
-        perform_action (Gala.ActionType.MINIMIZE_CURRENT);
-      });
-      window_menu.append (minimize);
-
-      maximize = new Gtk.MenuItem.with_label ("");
-      maximize.activate.connect (() => {
-        perform_action (Gala.ActionType.MAXIMIZE_CURRENT);
-      });
-      window_menu.append (maximize);
-
-      move = new Gtk.MenuItem.with_label (_("Move"));
-      move.activate.connect (() => {
-        perform_action (Gala.ActionType.START_MOVE_CURRENT);
-      });
-      window_menu.append (move);
-
-      resize = new Gtk.MenuItem.with_label (_("Resize"));
-      resize.activate.connect (() => {
-        perform_action (Gala.ActionType.START_RESIZE_CURRENT);
-      });
-      window_menu.append (resize);
-
-      always_on_top = new Gtk.CheckMenuItem.with_label (_("Always on Top"));
-      always_on_top_sid = always_on_top.activate.connect (() => {
-        perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_TOP_CURRENT);
-      });
-      window_menu.append (always_on_top);
-
-      on_visible_workspace = new Gtk.CheckMenuItem.with_label (_("Always on Visible Workspace"));
-      on_visible_workspace_sid = on_visible_workspace.activate.connect (() => {
-        perform_action (Gala.ActionType.TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT);
-      });
-      window_menu.append (on_visible_workspace);
-
-      move_left = new Gtk.MenuItem.with_label (_("Move to Workspace Left"));
-      move_left.activate.connect (() => {
-        perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_LEFT);
-      });
-      window_menu.append (move_left);
-
-      move_right = new Gtk.MenuItem.with_label (_("Move to Workspace Right"));
-      move_right.activate.connect (() => {
-        perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_RIGHT);
-      });
-      window_menu.append (move_right);
-
-      close = new Gtk.MenuItem.with_label (_("Close"));
-      close.activate.connect (() => {
-        perform_action (Gala.ActionType.CLOSE_CURRENT);
-      });
-      window_menu.append (close);
-
-      window_menu.show_all ();
-    }
-
-    public void show_window_menu (Gala.WindowFlags flags, int x, int y) throws DBusError, IOError {
-      if (window_menu == null) {
-        init_window_menu ();
-      }
-
-      minimize.visible = Gala.WindowFlags.CAN_MINIMIZE in flags;
-      maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
-      maximize.label = Gala.WindowFlags.IS_MAXIMIZED in flags ? _("Unmaximize") : _("Maximize");
-      move.visible = Gala.WindowFlags.ALLOWS_MOVE in flags;
-      resize.visible = Gala.WindowFlags.ALLOWS_RESIZE in flags;
-
-      // Setting active causes signal fires on activate so
-      // we temporarily block those signals from emissions
-      SignalHandler.block (always_on_top, always_on_top_sid);
-      SignalHandler.block (on_visible_workspace, on_visible_workspace_sid);
-
-      always_on_top.active = Gala.WindowFlags.ALWAYS_ON_TOP in flags;
-      on_visible_workspace.active = Gala.WindowFlags.ON_ALL_WORKSPACES in flags;
-
-      SignalHandler.unblock (always_on_top, always_on_top_sid);
-      SignalHandler.unblock (on_visible_workspace, on_visible_workspace_sid);
-
-      move_right.visible = !on_visible_workspace.active;
-      move_left.visible = !on_visible_workspace.active;
-      close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
-
-      window_menu.popup (null, null, (m, ref px, ref py, out push_in) => {
-        var scale = m.scale_factor;
-        px = x / scale;
-        // Move the menu 1 pixel outside of the pointer or else it closes instantly
-        // on the mouse up event
-        py = (y / scale) + 1;
-        push_in = true;
-      }, 3, Gdk.CURRENT_TIME);
-    }
-  }
 }


### PR DESCRIPTION
Ran vala-lint on the daemon directory and fixed any errors/warnings that came up. One thing to note, vala-lint doesn't enforce 4 spaces yet, so I haven't updated these files with new spacing rules yet.

## Run vala-lint locally:

Assuming you have [vala-lint](https://github.com/elementary/vala-lint) installed locally:
```sh
io.elementary.vala-lint -d daemon
```

## Run vala-lint via a container:
Assuming you have docker installed locally:
```sh
docker run -v "$PWD":/var/opt/vala-lint elementary/docker:vala-lint io.elementary.vala-lint -d daemon
```