### PR TITLE
ScreenshotManager: Null-check the window in screenshot_window()

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -115,6 +115,11 @@ namespace Gala
 #else
 			var window = wm.get_screen ().get_display ().get_focus_window ();
 #endif
+
+			if (window == null) {
+				throw new DBusError.FAILED ("Cannot find active window");
+			}
+
 			var window_actor = (Meta.WindowActor) window.get_compositor_private ();
 			unowned Meta.ShapedTexture window_texture = (Meta.ShapedTexture) window_actor.get_texture ();
 


### PR DESCRIPTION
Throw an error instead of crashing if there's no window to screenshot.

Fixes https://github.com/elementary/gala/issues/626