### PR TITLE
SelectionArea: Align the rectangle to pixel grid

### DIFF
--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -168,6 +168,8 @@ namespace Gala
                 return true;
             }
 
+            ctx.translate (0.5, 0.5);
+
             int x, y, w, h;
             get_selection_rectangle (out x, out y, out w, out h);
 


### PR DESCRIPTION
Cairo by default draws lines like this:

![Screenshot from 2019-11-04 21-23-22](https://user-images.githubusercontent.com/1510457/68137784-76942480-ff1f-11e9-9762-3661f9f3e272.png)

Translate by 0.5, 0.5 to avoid that.