### PR TITLE
Update the meson_version in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gala',
 	'c', 'vala',
 	version: '3.2.0',
-	meson_version: '>= 0.42.0',
+	meson_version: '>=0.51.0',
 	license: 'GPL3',
 )
 


### PR DESCRIPTION
it was changed to something with the required tools and systems used in the meson.build file here, this was needed because when running the installer I put it fully on to 0.52.? [? = the exact patch, I forgot what it was) in order for it to work without those pesky errors that made future things not fun to deal with.

Do know that the errors I got said it required "0.50.0" and I made it "0.51.0" because I felt like it would be easier to deal with if there were patches that fixed it that I do not know about. It worked fully on 0.52.0 as the system.

It is not a huge change, but [from recent experience] an important one. Also, other errors can be ignored [often just not having every libmutter version and other non-required packages]. However, the errors talking about the version seem not to work. Although I had the correct versions, it decided to not work outputting an error along the lines of "the version required is below the required version that these features need" and it did not work properly (reasons unknown).