### PR TITLE
Install gala daemon desktop to autostart, not apps

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,6 +4,11 @@ install_data(
     rename: 'org.pantheon.desktop.gala.gschema.xml'
 )
 
+install_data(
+    'gala-daemon.desktop',
+    install_dir: join_paths(get_option('sysconfdir'), 'xdg', 'autostart')
+)
+
 i18n.merge_file(
     input: 'gala.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
@@ -29,7 +34,7 @@ i18n.merge_file(
 	install: true,
 	install_dir: join_paths(data_dir, 'applications')
 )
-install_data(['gala.desktop', 'gala-daemon.desktop', 'gala-wayland.desktop'], install_dir: join_paths(data_dir, 'applications'))
+install_data(['gala.desktop', 'gala-wayland.desktop'], install_dir: join_paths(data_dir, 'applications'))
 install_data(files('20_elementary.pantheon.wm.gschema.override'), install_dir: join_paths(data_dir, 'glib-2.0', 'schemas'))
 
 icons_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')


### PR DESCRIPTION
Fixes the "Gala background services" desktop showing up in Plank