### PR TITLE
Mutter 3.36 support

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -302,7 +302,7 @@ namespace Gala {
                 try {
 #if HAS_MUTTER336
                     var image = new Clutter.Image ();
-                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                     image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                     texture.set_content (image);
 #else
@@ -367,7 +367,7 @@ namespace Gala {
                 try {
 #if HAS_MUTTER336
                     var image = new Clutter.Image ();
-                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                     image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                     texture.set_content (image);
 #else

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -289,16 +289,27 @@ namespace Gala {
          * @return The close button actor
          */
         public static Clutter.Actor create_close_button () {
+#if HAS_MUTTER336
+            var texture = new Clutter.Actor ();
+#else
             var texture = new Clutter.Texture ();
+#endif
             var pixbuf = get_close_button_pixbuf ();
 
             texture.reactive = true;
 
             if (pixbuf != null) {
                 try {
+#if HAS_MUTTER336
+                    var image = new Clutter.Image ();
+                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
+                    texture.set_content (image);
+#else
                     texture.set_from_rgb_data (pixbuf.get_pixels (), pixbuf.get_has_alpha (),
                     pixbuf.get_width (), pixbuf.get_height (),
                     pixbuf.get_rowstride (), (pixbuf.get_has_alpha () ? 4 : 3), 0);
+#endif
                 } catch (Error e) {}
             } else {
                 // we'll just make this red so there's at least something as an
@@ -343,16 +354,27 @@ namespace Gala {
          * @return The resize button actor
          */
         public static Clutter.Actor create_resize_button () {
+#if HAS_MUTTER336
+            var texture = new Clutter.Actor ();
+#else
             var texture = new Clutter.Texture ();
+#endif
             var pixbuf = get_resize_button_pixbuf ();
 
             texture.reactive = true;
 
             if (pixbuf != null) {
                 try {
+#if HAS_MUTTER336
+                    var image = new Clutter.Image ();
+                    Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
+                    texture.set_content (image);
+#else
                     texture.set_from_rgb_data (pixbuf.get_pixels (), pixbuf.get_has_alpha (),
-                        pixbuf.get_width (), pixbuf.get_height (),
-                        pixbuf.get_rowstride (), (pixbuf.get_has_alpha () ? 4 : 3), 0);
+                    pixbuf.get_width (), pixbuf.get_height (),
+                    pixbuf.get_rowstride (), (pixbuf.get_has_alpha () ? 4 : 3), 0);
+#endif
                 } catch (Error e) {}
             } else {
                 // we'll just make this red so there's at least something as an

--- a/lib/WindowIcon.vala
+++ b/lib/WindowIcon.vala
@@ -21,7 +21,11 @@ namespace Gala {
      * This is recommended way to grab an icon for a window as this method will make
      * sure the icon is updated if it becomes available at a later point.
      */
+#if HAS_MUTTER336
+    public class WindowIcon : Clutter.Actor {
+#else
     public class WindowIcon : Clutter.Texture {
+#endif
         static Bamf.Matcher matcher;
 
         static construct {
@@ -110,9 +114,16 @@ namespace Gala {
             var pixbuf = Gala.Utils.get_icon_for_xid (xid, icon_size, scale, !initial);
 
             try {
+#if HAS_MUTTER336
+                var image = new Clutter.Image ();
+                Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
+                set_content (image);
+#else
                 set_from_rgb_data (pixbuf.get_pixels (), pixbuf.get_has_alpha (),
                 pixbuf.get_width (), pixbuf.get_height (),
                 pixbuf.get_rowstride (), (pixbuf.get_has_alpha () ? 4 : 3), 0);
+#endif
             } catch (Error e) {}
         }
 

--- a/lib/WindowIcon.vala
+++ b/lib/WindowIcon.vala
@@ -116,7 +116,7 @@ namespace Gala {
             try {
 #if HAS_MUTTER336
                 var image = new Clutter.Image ();
-                Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                 image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                 set_content (image);
 #else

--- a/plugins/notify/Notification.vala
+++ b/plugins/notify/Notification.vala
@@ -238,7 +238,7 @@ namespace Gala.Plugins.Notify {
                 try {
 #if HAS_MUTTER336
                     var image = new Clutter.Image ();
-                    Cogl.PixelFormat pixel_format = (icon.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    Cogl.PixelFormat pixel_format = (icon.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                     image.set_data (icon.get_pixels (), pixel_format, icon.width, icon.height, icon.rowstride);
                     icon_texture.set_content (image);
 #else

--- a/plugins/notify/Notification.vala
+++ b/plugins/notify/Notification.vala
@@ -39,7 +39,11 @@ namespace Gala.Plugins.Notify {
         public bool being_destroyed { get; private set; default = false; }
 
         protected bool icon_only { get; protected set; default = false; }
+#if HAS_MUTTER336
+        protected Clutter.Actor icon_texture { get; private set; }
+#else
         protected Clutter.Texture icon_texture { get; private set; }
+#endif
         protected Actor icon_container { get; private set; }
 
         /**
@@ -55,7 +59,11 @@ namespace Gala.Plugins.Notify {
 
         // temporary things needed for the slide transition
         protected float animation_slide_height { get; private set; }
+#if HAS_MUTTER336
+        Clutter.Actor old_texture;
+#else
         Clutter.Texture old_texture;
+#endif
         float _animation_slide_y_offset = 0.0f;
         public float animation_slide_y_offset {
             get {
@@ -88,7 +96,11 @@ namespace Gala.Plugins.Notify {
             reactive = true;
             set_pivot_point (0.5f, 0.5f);
 
+#if HAS_MUTTER336
+            icon_texture = new Clutter.Actor ();
+#else
             icon_texture = new Clutter.Texture ();
+#endif
             icon_texture.set_pivot_point (0.5f, 0.5f);
 
             icon_container = new Actor ();
@@ -224,9 +236,16 @@ namespace Gala.Plugins.Notify {
         void set_values () {
             if (icon != null) {
                 try {
+#if HAS_MUTTER336
+                    var image = new Clutter.Image ();
+                    Cogl.PixelFormat pixel_format = (icon.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    image.set_data (icon.get_pixels (), pixel_format, icon.width, icon.height, icon.rowstride);
+                    icon_texture.set_content (image);
+#else
                     icon_texture.set_from_rgb_data (icon.get_pixels (), icon.get_has_alpha (),
                         icon.get_width (), icon.get_height (),
                         icon.get_rowstride (), (icon.get_has_alpha () ? 4 : 3), 0);
+#endif
                 } catch (Error e) {}
             }
 
@@ -324,15 +343,26 @@ namespace Gala.Plugins.Notify {
             var scale = style_context.get_scale ();
             var scaled_padding = PADDING * scale;
             var scaled_icon_size = ICON_SIZE * scale;
+#if HAS_MUTTER336
+            old_texture = new Clutter.Actor ();
+#else
             old_texture = new Clutter.Texture ();
+#endif
             icon_container.add_child (old_texture);
             icon_container.set_clip (0, -scaled_padding, scaled_icon_size, scaled_icon_size + scaled_padding * 2);
 
             if (icon != null) {
                 try {
+#if HAS_MUTTER336
+                    var image = new Clutter.Image ();
+                    Cogl.PixelFormat pixel_format = (icon.get_has_alpha () ? Cogl.PixelFormat.ARGB_8888 : Cogl.PixelFormat.RGB_888);
+                    image.set_data (icon.get_pixels (), pixel_format, icon.width, icon.height, icon.rowstride);
+                    old_texture.set_content (image);
+#else
                     old_texture.set_from_rgb_data (icon.get_pixels (), icon.get_has_alpha (),
                         icon.get_width (), icon.get_height (),
                         icon.get_rowstride (), (icon.get_has_alpha () ? 4 : 3), 0);
+#endif
                 } catch (Error e) {}
             }
 

--- a/plugins/pip/Main.vala
+++ b/plugins/pip/Main.vala
@@ -88,7 +88,11 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin {
                 int point_x = x - (int)active.x;
                 int point_y = y - (int)active.y;
 
+#if HAS_MUTTER336
+                var rect = Graphene.Rect.alloc ();
+#else
                 var rect = Clutter.Rect.alloc ();
+#endif
                 rect.init (point_x, point_y, width, height);
 
                 var popup_window = new PopupWindow (wm, active);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -204,7 +204,11 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
         return true;
     }
 
+#if HAS_MUTTER336
+    public void set_container_clip (Graphene.Rect? container_clip) {
+#else
     public void set_container_clip (Clutter.Rect? container_clip) {
+#endif
         container.clip_rect = container_clip;
         dynamic_container = true;
         update_container_scale ();

--- a/plugins/pip/ShadowEffect.vala
+++ b/plugins/pip/ShadowEffect.vala
@@ -43,7 +43,12 @@ namespace Gala.Plugins.PIP {
         public float scale_factor { get; set; default = 1; }
         public uint8 shadow_opacity { get; set; default = 255; }
 
+#if HAS_MUTTER336
+        Cogl.Pipeline pipeline;
+#else
         Cogl.Material material;
+#endif
+
         string? current_key = null;
 
         public ShadowEffect (int shadow_size, int shadow_spread) {
@@ -51,7 +56,12 @@ namespace Gala.Plugins.PIP {
         }
 
         construct {
+#if HAS_MUTTER336
+            pipeline = new Cogl.Pipeline (Clutter.get_default_backend ().get_cogl_context ());
+#else
             material = new Cogl.Material ();
+#endif
+
         }
 
         ~ShadowEffect () {
@@ -59,7 +69,11 @@ namespace Gala.Plugins.PIP {
                 decrement_shadow_users (current_key);
         }
 
+#if HAS_MUTTER336
+        Cogl.Texture? get_shadow (Cogl.Context context, int width, int height, int shadow_size, int shadow_spread) {
+#else
         Cogl.Texture? get_shadow (int width, int height, int shadow_size, int shadow_spread) {
+#endif
             var old_key = current_key;
 
             current_key = "%ix%i:%i:%i".printf (width, height, shadow_size, shadow_spread);
@@ -90,8 +104,13 @@ namespace Gala.Plugins.PIP {
             cr.set_source_surface (buffer.surface, 0, 0);
             cr.paint ();
 
+#if HAS_MUTTER336
+            var texture = new Cogl.Texture2D.from_data (context, width, height, Cogl.PixelFormat.BGRA_8888_PRE,
+                surface.get_stride (), surface.get_data ());
+#else
             var texture = new Cogl.Texture.from_data (width, height, 0, Cogl.PixelFormat.BGRA_8888_PRE,
                 Cogl.PixelFormat.ANY, surface.get_stride (), surface.get_data ());
+#endif
 
             shadow_cache.@set (current_key, new Shadow (texture));
 
@@ -108,6 +127,27 @@ namespace Gala.Plugins.PIP {
                 shadow_cache.unset (key);
         }
 
+#if HAS_MUTTER336
+        public override void paint (Clutter.PaintContext context, EffectPaintFlags flags) {
+            var bounding_box = get_bounding_box ();
+
+            var shadow = get_shadow (context.get_framebuffer ().get_context (), (int) (bounding_box.x2 - bounding_box.x1),
+            (int) (bounding_box.y2 - bounding_box.y1), shadow_size, shadow_spread);
+
+            if (shadow != null)
+                pipeline.set_layer_texture (0, shadow);
+
+            var opacity = actor.get_paint_opacity () * shadow_opacity / 255;
+            var alpha = Cogl.Color.from_4ub (255, 255, 255, opacity);
+            alpha.premultiply ();
+
+            pipeline.set_color (alpha);
+
+            context.get_framebuffer ().draw_rectangle (pipeline, bounding_box.x1, bounding_box.y1, bounding_box.x2, bounding_box.y2);
+
+            actor.continue_paint (context);
+        }
+#else
         public override void paint (EffectPaintFlags flags) {
             var bounding_box = get_bounding_box ();
             var shadow = get_shadow ((int) (bounding_box.x2 - bounding_box.x1), (int) (bounding_box.y2 - bounding_box.y1),
@@ -127,6 +167,7 @@ namespace Gala.Plugins.PIP {
 
             actor.continue_paint ();
         }
+#endif
 
         public virtual ActorBox get_bounding_box () {
             var size = shadow_size * scale_factor;

--- a/plugins/zoom/Main.vala
+++ b/plugins/zoom/Main.vala
@@ -97,11 +97,21 @@ namespace Gala.Plugins.Zoom {
 
                 mouse_poll_timer = Timeout.add (MOUSE_POLL_TIME, () => {
                     client_pointer.get_position (null, out mx, out my);
+#if HAS_MUTTER336
+                    var new_pivot = new Graphene.Point ();
+#else
                     var new_pivot = Clutter.Point.alloc ();
-                    new_pivot.init (mx / wins.width, my / wins.height);
-                    if (wins.pivot_point.equals (new_pivot))
-                        return true;
+#endif
 
+                    new_pivot.init (mx / wins.width, my / wins.height);
+#if HAS_MUTTER336
+                    if (wins.pivot_point.equal (new_pivot)) {
+#else
+                    if (wins.pivot_point.equals (new_pivot)) {
+#endif
+
+                        return true;
+}
                     wins.save_easing_state ();
                     wins.set_easing_mode (Clutter.AnimationMode.LINEAR);
                     wins.set_easing_duration (MOUSE_POLL_TIME);

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -78,8 +78,13 @@ namespace Gala {
 
         class DummyOffscreenEffect : Clutter.OffscreenEffect {
             public signal void done_painting ();
+#if HAS_MUTTER336
+            public override void post_paint (Clutter.PaintContext context) {
+                base.post_paint (context);
+#else
             public override void post_paint () {
                 base.post_paint ();
+#endif
                 done_painting ();
             }
         }

--- a/src/ShadowEffect.vala
+++ b/src/ShadowEffect.vala
@@ -165,7 +165,7 @@ namespace Gala {
             var width = (int) (bounding_box.x2 - bounding_box.x1);
             var height = (int) (bounding_box.y2 - bounding_box.y1);
 
-            var shadow = get_shadow (context.get_framebuffer ().get_context (), width, height, shadow_size, shadow_spread);
+            var shadow = get_shadow (width, height, shadow_size, shadow_spread);
             if (shadow != null)
                 material.set_layer (0, shadow);
 

--- a/src/ShadowEffect.vala
+++ b/src/ShadowEffect.vala
@@ -53,7 +53,11 @@ namespace Gala {
         public uint8 shadow_opacity { get; set; default = 255; }
         public string? css_class { get; set; default = null; }
 
+#if HAS_MUTTER336
+        Cogl.Pipeline pipeline;
+#else
         Cogl.Material material;
+#endif
         string? current_key = null;
 
         public ShadowEffect (int shadow_size, int shadow_spread) {
@@ -61,7 +65,12 @@ namespace Gala {
         }
 
         construct {
+#if HAS_MUTTER336
+            pipeline = new Cogl.Pipeline (Clutter.get_default_backend ().get_cogl_context ());
+#else
             material = new Cogl.Material ();
+#endif
+
         }
 
         ~ShadowEffect () {
@@ -69,7 +78,11 @@ namespace Gala {
                 decrement_shadow_users (current_key);
         }
 
+#if HAS_MUTTER336
+        Cogl.Texture? get_shadow (Cogl.Context context, int width, int height, int shadow_size, int shadow_spread) {
+#else
         Cogl.Texture? get_shadow (int width, int height, int shadow_size, int shadow_spread) {
+#endif
             var old_key = current_key;
             current_key = "%ix%i:%i:%i".printf (width, height, shadow_size, shadow_spread);
             if (old_key == current_key)
@@ -104,9 +117,13 @@ namespace Gala {
 
             cr.paint ();
 
+#if HAS_MUTTER336
+            var texture = new Cogl.Texture2D.from_data (context, width, height, Cogl.PixelFormat.BGRA_8888_PRE,
+                surface.get_stride (), surface.get_data ());
+#else
             var texture = new Cogl.Texture.from_data (width, height, 0, Cogl.PixelFormat.BGRA_8888_PRE,
                 Cogl.PixelFormat.ANY, surface.get_stride (), surface.get_data ());
-
+#endif
             shadow_cache.@set (current_key, new Shadow (texture));
 
             return texture;
@@ -122,12 +139,33 @@ namespace Gala {
                 shadow_cache.unset (key);
         }
 
+#if HAS_MUTTER336
+        public override void paint (Clutter.PaintContext context, EffectPaintFlags flags) {
+            var bounding_box = get_bounding_box ();
+            var width = (int) (bounding_box.x2 - bounding_box.x1);
+            var height = (int) (bounding_box.y2 - bounding_box.y1);
+
+            var shadow = get_shadow (context.get_framebuffer ().get_context (), width, height, shadow_size, shadow_spread);
+            if (shadow != null)
+                pipeline.set_layer_texture (0, shadow);
+
+            var opacity = actor.get_paint_opacity () * shadow_opacity / 255;
+            var alpha = Cogl.Color.from_4ub (255, 255, 255, opacity);
+            alpha.premultiply ();
+
+            pipeline.set_color (alpha);
+
+            context.get_framebuffer ().draw_rectangle (pipeline, bounding_box.x1, bounding_box.y1, bounding_box.x2, bounding_box.y2);
+
+            actor.continue_paint (context);
+        }
+#else
         public override void paint (EffectPaintFlags flags) {
             var bounding_box = get_bounding_box ();
             var width = (int) (bounding_box.x2 - bounding_box.x1);
             var height = (int) (bounding_box.y2 - bounding_box.y1);
 
-            var shadow = get_shadow (width, height, shadow_size, shadow_spread);
+            var shadow = get_shadow (context.get_framebuffer ().get_context (), width, height, shadow_size, shadow_spread);
             if (shadow != null)
                 material.set_layer (0, shadow);
 
@@ -142,6 +180,7 @@ namespace Gala {
 
             actor.continue_paint ();
         }
+#endif
 
         public virtual ActorBox get_bounding_box () {
             var size = shadow_size * scale_factor;

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -227,8 +227,8 @@ namespace Gala {
 
 #if HAS_MUTTER336
             Cogl.VertexP2T2C4 vertices[4];
-            vertices[0] = { x, y, 0, 0, 0, 0, 0, 0 };
-            vertices[1] = { x, y + height, 0, 1, 255, 255, 255, backdrop_opacity };
+            vertices[0] = { x, y + height, 0, 1, 255, 255, 255, backdrop_opacity };
+            vertices[1] = { x, y, 0, 0, 0, 0, 0, 0 };
             vertices[2] = { x + width, y + height, 1, 1, 255, 255, 255, backdrop_opacity };
             vertices[3] = { x + width, y, 1, 0, 0, 0, 0, 0 };
 

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -204,9 +204,18 @@ namespace Gala {
         /**
          * Override the paint handler to draw our backdrop if necessary
          */
+#if HAS_MUTTER336
+        public override void paint (Clutter.PaintContext context) {
+#else
         public override void paint () {
+#endif
             if (backdrop_opacity < 1 || drag_action.dragging) {
+#if HAS_MUTTER336
+                base.paint (context);
+#else
                 base.paint ();
+#endif
+
                 return;
             }
 
@@ -216,6 +225,17 @@ namespace Gala {
             var y = -10;
             var height = WorkspaceClone.BOTTOM_OFFSET * scale;
 
+#if HAS_MUTTER336
+            Cogl.VertexP2T2C4 vertices[4];
+            vertices[0] = { x, y, 0, 0, 0, 0, 0, 0 };
+            vertices[1] = { x, y + height, 0, 1, 255, 255, 255, backdrop_opacity };
+            vertices[2] = { x + width, y + height, 1, 1, 255, 255, 255, backdrop_opacity };
+            vertices[3] = { x + width, y, 1, 0, 0, 0, 0, 0 };
+
+            var primitive = new Cogl.Primitive.p2t2c4 (context.get_framebuffer ().get_context (), Cogl.VerticesMode.TRIANGLE_STRIP, vertices);
+            var pipeline = new Cogl.Pipeline (context.get_framebuffer ().get_context ());
+            primitive.draw (context.get_framebuffer (), pipeline);
+#else
             var color_top = Cogl.Color.from_4ub (0, 0, 0, 0);
             var color_bottom = Cogl.Color.from_4ub (255, 255, 255, backdrop_opacity);
             color_bottom.premultiply ();
@@ -231,8 +251,12 @@ namespace Gala {
             // color by setting a different material with no properties.
             Cogl.set_source (dummy_material);
             Cogl.polygon (vertices, true);
-
-            base.paint ();
+#endif
+#if HAS_MUTTER336
+                base.paint (context);
+#else
+                base.paint ();
+#endif
         }
 
         /**

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -23,6 +23,9 @@ namespace Gala {
      * Utility class which adds a border and a shadow to a Background
      */
     class FramedBackground : BackgroundManager {
+#if HAS_MUTTER336
+        private Cogl.Pipeline pipeline;
+#endif
 
 #if HAS_MUTTER330
         public FramedBackground (Display display) {
@@ -35,6 +38,9 @@ namespace Gala {
 #endif
 
         construct {
+#if HAS_MUTTER336
+            pipeline = new Cogl.Pipeline (Clutter.get_default_backend ().get_cogl_context ());
+#endif
 #if HAS_MUTTER330
             var primary = display.get_primary_monitor ();
             var monitor_geom = display.get_monitor_geometry (primary);
@@ -48,6 +54,21 @@ namespace Gala {
             add_effect (effect);
         }
 
+#if HAS_MUTTER336
+        public override void paint (Clutter.PaintContext context) {
+            base.paint (context);
+
+            pipeline.set_color4ub (0, 0, 0, 100);
+            var path = new Cogl.Path ();
+            path.rectangle (0, 0, width, height);
+            context.get_framebuffer ().stroke_path (pipeline, path);
+
+            path = new Cogl.Path ();
+            pipeline.set_color4ub (255, 255, 255, 25);
+            path.rectangle (0, 0, width, height);
+            context.get_framebuffer ().stroke_path (pipeline, path);
+        }
+#else
         public override void paint () {
             base.paint ();
 
@@ -60,6 +81,7 @@ namespace Gala {
             path.rectangle (0.5f, 0.5f, width - 1, height - 1);
             path.stroke ();
         }
+#endif
     }
 
     /**

--- a/vapi/Clutter-6.metadata
+++ b/vapi/Clutter-6.metadata
@@ -78,6 +78,8 @@ LayoutManager
 Actor
 	.animate skip=false
 	.animate_with_timeline skip=false
+Backend
+	.get_cogl_context skip=false
 Box
 	.pack skip=false
 	.pack_after skip=false
@@ -134,12 +136,10 @@ color_get_static nullable
 Event
 	.get_position.position out
 
-Texture2D
-	.new_from_data skip=false
-	.new_from_data.data array=true
-
 // Remove for clutter-2.0
 /////////////////////////
+
+StageView.layout skip
 
 Stage
  	.event name="emit_event"

--- a/vapi/Cogl-6-custom.vala
+++ b/vapi/Cogl-6-custom.vala
@@ -14,14 +14,15 @@ namespace Cogl {
 		public Color.from_hsl (float hue, float saturation, float luminance);
 	}
 
-	[Compact]
-	[CCode (cname = "CoglHandle", cheader_filename = "cogl/cogl.h", type_id = "cogl_handle_get_gtype ()", ref_function = "cogl_shader_ref", unref_function = "cogl_shader_unref")]
-	public class Shader : Cogl.Handle {
-	}
-
+	[CCode (cheader_filename = "cogl/cogl.h", type_id = "cogl_framebuffer_get_gtype ()")]
 	public interface Framebuffer {
 		[CCode (cheader_filename = "cogl-path/cogl-path.h")]
 		public void stroke_path (Cogl.Pipeline pipeline, Cogl.Path path);
+	}
+
+	[Compact]
+	[CCode (cname = "CoglHandle", cheader_filename = "cogl/cogl.h", type_id = "cogl_handle_get_gtype ()", ref_function = "cogl_shader_ref", unref_function = "cogl_shader_unref")]
+	public class Shader : Cogl.Handle {
 	}
 
 	[CCode (cheader_filename = "cogl/cogl.h", type_id = "cogl_primitive_get_gtype ()")]
@@ -72,7 +73,7 @@ namespace Cogl {
 	}
 
 	[Compact]
-	[CCode (cheader_filename = "cogl/cogl.h", type_id = "cogl_handle_get_gtype ()", ref_function = "cogl_handle_ref", unref_function = "cogl_handle_unref")]
+	[CCode (cheader_filename = "cogl/cogl.h", type_id = "cogl_handle_get_gtype ()", ref_function = "cogl_object_ref", unref_function = "cogl_object_unref")]
 	public class Handle {
 		[CCode (cheader_filename = "cogl/cogl.h", cname="cogl_is_material")]
 		[Version (deprecated = true, deprecated_since = "1.16")]

--- a/vapi/Cogl-6.metadata
+++ b/vapi/Cogl-6.metadata
@@ -24,6 +24,10 @@ Texture
   .set_data.data type="uint8[]"
   .set_region.data type="uint8[]"
 
+Texture2D
+  .new_from_data skip=false
+  .new_from_data.data array=true
+
 Matrix
   .transform_points.points_in type="uint8[]"
   .transform_points.stride_out out

--- a/vapi/mutter-clutter.vapi
+++ b/vapi/mutter-clutter.vapi
@@ -5689,6 +5689,10 @@ namespace Clutter {
 	public abstract class Backend : GLib.Object {
 		[CCode (has_construct_function = false)]
 		protected Backend ();
+#if HAS_MUTTER336
+		[Version (since = "1.8")]
+		public unowned Cogl.Context get_cogl_context ();
+#endif
 #if !HAS_MUTTER336
 		public void bell_notify ();
 		[Version (deprecated = true, deprecated_since = "1.4", since = "0.4")]

--- a/vapi/mutter-cogl-6.vapi
+++ b/vapi/mutter-cogl-6.vapi
@@ -41,7 +41,7 @@ namespace Cogl {
 	[Version (since = "1.14")]
 	public class FrameClosure {
 	}
-	[CCode (cheader_filename = "cogl/cogl.h", ref_function = "cogl_handle_ref", type_id = "cogl_handle_get_gtype ()", unref_function = "cogl_handle_unref")]
+	[CCode (cheader_filename = "cogl/cogl.h", ref_function = "cogl_object_ref", type_id = "cogl_handle_get_gtype ()", unref_function = "cogl_object_unref")]
 	[Compact]
 	public class Handle {
 		[CCode (cheader_filename = "cogl/cogl.h", cname = "cogl_is_material")]
@@ -364,6 +364,9 @@ namespace Cogl {
 		[CCode (has_construct_function = false)]
 		[Version (since = "2.0")]
 		public Texture2D.from_bitmap (Cogl.Bitmap bitmap);
+		[CCode (has_construct_function = false)]
+		[Version (since = "2.0")]
+		public Texture2D.from_data (Cogl.Context ctx, int width, int height, Cogl.PixelFormat format, int rowstride, [CCode (array_length = false, type = "const uint8_t*")] uint8[] data) throws GLib.Error;
 	}
 	[CCode (cheader_filename = "cogl/cogl.h", lower_case_csuffix = "texture_2d_sliced", type_id = "cogl_texture_2d_sliced_get_gtype ()")]
 	public class Texture2DSliced : Cogl.Object, Cogl.Texture {


### PR DESCRIPTION
These changes allow gala to compile and run against mutter 3.36. I haven't merged the `mutter-clutter` vapi changes into the main file as I couldn't figure out a way to do this efficiently.