### PR TITLE
Support g-s-d UngrabAccelerators API

### DIFF
--- a/src/DBusAccelerator.vala
+++ b/src/DBusAccelerator.vala
@@ -127,6 +127,15 @@ namespace Gala {
             return ret;
         }
 
+#if HAS_MUTTER334
+        public bool ungrab_accelerators (uint[] actions) throws DBusError, IOError {
+            foreach (uint action in actions) {
+                ungrab_accelerator (action);
+            }
+            return true;
+        }
+#endif
+
         [DBus (name = "ShowOSD")]
         public void show_osd (GLib.HashTable<string, Variant> parameters) throws DBusError, IOError {
             int32 monitor_index = -1;

--- a/src/DBusAccelerator.vala
+++ b/src/DBusAccelerator.vala
@@ -132,6 +132,7 @@ namespace Gala {
             foreach (uint action in actions) {
                 ungrab_accelerator (action);
             }
+
             return true;
         }
 #endif


### PR DESCRIPTION
This was added in g-s-d 3.33.0 [0].

Without this I was seeing:
```
gsd-media-keys[1927]: Failed to ungrab accelerators: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: No such method “UngrabAccelerators”
```

in the journal from g-s-d.

[0]: https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/blob/GNOME_SETTINGS_DAEMON_3_33_0/NEWS#L8