### PR TITLE
fix Gala.Utils.create_close_button and Gala.Utils.create_refresh_butt…

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -305,6 +305,7 @@ namespace Gala {
                     Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                     image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                     texture.set_content (image);
+                    texture.set_size (pixbuf.width, pixbuf.height);
 #else
                     texture.set_from_rgb_data (pixbuf.get_pixels (), pixbuf.get_has_alpha (),
                     pixbuf.get_width (), pixbuf.get_height (),
@@ -370,6 +371,7 @@ namespace Gala {
                     Cogl.PixelFormat pixel_format = (pixbuf.get_has_alpha () ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888);
                     image.set_data (pixbuf.get_pixels (), pixel_format, pixbuf.width, pixbuf.height, pixbuf.rowstride);
                     texture.set_content (image);
+                    texture.set_size (pixbuf.width, pixbuf.height);
 #else
                     texture.set_from_rgb_data (pixbuf.get_pixels (), pixbuf.get_has_alpha (),
                     pixbuf.get_width (), pixbuf.get_height (),


### PR DESCRIPTION
I'm using pantheon on fedora 32 and ubuntu 20.04 (manually compiled in both),
and I'm facing the same issue with PIP (awesome feature BTW), close and resize handles are both invisible, and pip windows cannot be closed.

This issue seems to disappear with the following changes in lib/Utils.vala.

It's like the texture does not take the current size of the pixmap.

Is anyone else affected by this problem?

Mutter version: 3.36.1
Clutter version: 1.26.4