### PR TITLE
Fix for #764

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2114,8 +2114,6 @@ namespace Gala {
                     } else {
                         clutter_actor_reparent (actor, parents.nth_data (i));
                     }
-
-                    continue;
                 }
 
                 kill_window_effects (window);


### PR DESCRIPTION
Fixes #764 

`continue` was meant for `null` or destroyed window.
I believe this is handled in lines above.