### PR TITLE
Gschema: Move screensaver keys to io.elementary.desktop

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -16,7 +16,7 @@
 		<value nick='natural' value='1'/>
 	</enum>
 
-	<schema path="/io/elementary/desktop/screensaver/" id="io.elementary.desktop.screensaver/">
+	<schema path="/io/elementary/desktop/screensaver/" id="io.elementary.desktop.screensaver">
 		<key type="b" name="lock-on-screen-off">
 		    <default>true</default>
 		    <summary>Automatically lock the screen when the display turns off due to inactivity</summary>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -15,7 +15,20 @@
 		<value nick='grid' value='0'/>
 		<value nick='natural' value='1'/>
 	</enum>
-	
+
+	<schema path="/io/elementary/desktop/screensaver/" id="io.elementary.desktop.screensaver/">
+		<key type="b" name="lock-on-screen-off">
+		    <default>true</default>
+		    <summary>Automatically lock the screen when the display turns off due to inactivity</summary>
+		    <description></description>
+		</key>
+	    <key type="b" name="lock-on-suspend">
+		    <default>true</default>
+		    <summary>Automatically lock the screen when the computer suspends</summary>
+		    <description></description>
+		</key>
+	</schema>
+
 	<schema path="/org/pantheon/desktop/gala/behavior/" id="org.pantheon.desktop.gala.behavior">
 		<key enum="GalaActionType" name="hotcorner-topleft">
 			<default>'none'</default>
@@ -91,16 +104,6 @@
 			<default>false</default>
 			<summary>Automatically move maximized windows to a new workspace</summary>
 			<description></description>
-		</key>
-		<key type="b" name="lock-on-screen-off">
-		    <default>true</default>
-		    <summary>Automatically lock the screen when the display turns off due to inactivity</summary>
-		    <description></description>
-		</key>
-	    <key type="b" name="lock-on-suspend">
-		    <default>true</default>
-		    <summary>Automatically lock the screen when the computer suspends</summary>
-		    <description></description>
 		</key>
 	</schema>
 	

--- a/src/Widgets/ScreenShield.vala
+++ b/src/Widgets/ScreenShield.vala
@@ -111,7 +111,7 @@ namespace Gala {
 
         construct {
             lockdown_settings = new GLib.Settings ("org.gnome.desktop.lockdown");
-            gala_settings = new GLib.Settings (Config.SCHEMA + ".behavior");
+            gala_settings = new GLib.Settings ("io.elementary.desktop.screensaver");
 
             visible = false;
             reactive = true;


### PR DESCRIPTION
Since these are new keys, it would be nice to have them RDNN'd correctly so we don't have to migrate them later