### PR TITLE
ScreenShield: Set locked hint on logind

### DIFF
--- a/src/Widgets/ScreenShield.vala
+++ b/src/Widgets/ScreenShield.vala
@@ -416,6 +416,12 @@ namespace Gala {
                 active_changed ();
             }
 
+            try {
+                login_session.set_locked_hint (active);
+            } catch (Error e) {
+                warning ("Unable to set locked hint on login session: %s", e.message);
+            }
+
             sync_inhibitor ();
         }
     }


### PR DESCRIPTION
This is something I missed from the screensaver branch and is present in the GNOME implementation of their screen locker.

logind has a DBus property on the system bus that indicates whether the session is locked or not. This is queried by other components.

So, let's ensure we keep that property up to date.