### PR TITLE
Cancel multitasking drag and drop when removing workspace

### DIFF
--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -143,6 +143,11 @@ namespace Gala {
             var prev_workspace = manager.get_workspace_by_index (from);
             if (Utils.get_n_windows (prev_workspace) < 1
                 && from != manager.get_n_workspaces () - 1) {
+
+                // If we're about to remove a workspace, cancel any DnD going on in the multitasking view
+                // or else things might get broke
+                DragDropAction.cancel_all_by_id ("multitaskingview-window");
+
                 remove_workspace (prev_workspace);
             }
         }


### PR DESCRIPTION
I was able to produce crashes in gala by doing the following:

* Open multitasking view 
* Create an empty workspace by dragging a window into a new one and then out again
* Begin dragging empty workspace container
* Switch workspace in a manner that would cause the empty workspace to be automatically cleaned up with `<Super><Left>` and `<Super><Right>` while still holding the drag
* Let go of the drag

The simplest solution to this seems to be to cancel any ongoing drags when a workspace is about to be removed, since why are you doing this magic multi hand trick anyway.