### PR TITLE
MaskCorners: Remove radius setting

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -260,6 +260,12 @@
 			<default>true</default>
 			<summary>Enable rounded corner mask</summary>
 		</key>
+		<key type="i" name="corner-radius">
+			<default>4</default>
+			<range min="1" max="32"/>
+			<summary>Corner radius</summary>
+			<description>DEPRECATED: This setting is no longer used</description>
+		</key>
 		<key type="b" name="disable-on-fullscreen">
 			<default>true</default>
 			<summary>Disable corner mask on fullscreen</summary>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -260,11 +260,6 @@
 			<default>true</default>
 			<summary>Enable rounded corner mask</summary>
 		</key>
-		<key type="i" name="corner-radius">
-			<default>4</default>
-			<range min="1" max="32"/>
-			<summary>Corner radius</summary>
-		</key>
 		<key type="b" name="disable-on-fullscreen">
 			<default>true</default>
 			<summary>Disable corner mask on fullscreen</summary>

--- a/plugins/maskcorners/Main.vala
+++ b/plugins/maskcorners/Main.vala
@@ -29,7 +29,7 @@ namespace Gala.Plugins.MaskCorners {
         Settings settings;
 
         List<Actor>[] cornermasks;
-        int corner_radius = 4;
+        private int corner_radius = 6;
 
         public override void initialize (Gala.WindowManager wm) {
             this.wm = wm;
@@ -61,7 +61,7 @@ namespace Gala.Plugins.MaskCorners {
             int n_monitors = screen.get_n_monitors ();
 #endif
             cornermasks = new List<Actor>[n_monitors];
-            corner_radius = settings.corner_radius * scale;
+            corner_radius = corner_radius * scale;
 
             if (settings.only_on_primary) {
 #if HAS_MUTTER330

--- a/plugins/maskcorners/Settings.vala
+++ b/plugins/maskcorners/Settings.vala
@@ -27,7 +27,6 @@ namespace Gala.Plugins.MaskCorners {
         }
 
         public bool enable { get; set; default = true; }
-        public int corner_radius { get; set; default = 4; }
         public bool disable_on_fullscreen { get; set; default = true; }
         public bool only_on_primary { get; set; default = false; }
 


### PR DESCRIPTION
And bump to 6px to match Greenfield

There's no real reason this should be configurable