### PR TITLE
Use Gdk.Seat instead of Gdk.DeviceManager to get the pointer position

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -67,7 +67,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     }
 
     static void get_current_cursor_position (out int x, out int y) {
-        Gdk.Display.get_default ().get_device_manager ().get_client_pointer ().get_position (null, out x, out y);
+        Gdk.Display.get_default ().get_default_seat ().get_pointer ().get_position (null, out x, out y);
     }
 
     public PopupWindow (Gala.WindowManager wm, Meta.WindowActor window_actor) {

--- a/plugins/zoom/Main.vala
+++ b/plugins/zoom/Main.vala
@@ -91,7 +91,7 @@ namespace Gala.Plugins.Zoom {
             // to show requested zoomed area
             if (mouse_poll_timer == 0) {
                 float mx, my;
-                var client_pointer = Gdk.Display.get_default ().get_device_manager ().get_client_pointer ();
+                var client_pointer = Gdk.Display.get_default ().get_default_seat ().get_pointer ();
                 client_pointer.get_position (null, out mx, out my);
                 wins.set_pivot_point (mx / wins.width, my / wins.height);
 

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -119,7 +119,7 @@ namespace Gala {
             screen.monitors_changed.disconnect (monitors_changed);
 #endif
 
-            foreach (var background in backgrounds) {
+            foreach (var background in backgrounds.values) {
                 background.changed.disconnect (background_changed);
                 background.destroy ();
             }

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -778,7 +778,7 @@ namespace Gala {
         Gdk.ModifierType get_current_modifiers () {
             Gdk.ModifierType modifiers;
             double[] axes = {};
-            Gdk.Display.get_default ().get_device_manager ().get_client_pointer ()
+            Gdk.Display.get_default ().get_default_seat ().get_pointer ()
                 .get_state (Gdk.get_default_root_window (), axes, out modifiers);
 
             return modifiers;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -834,7 +834,7 @@ namespace Gala {
         }
 
         public void get_current_cursor_position (out int x, out int y) {
-            Gdk.Display.get_default ().get_device_manager ().get_client_pointer ().get_position (null,
+            Gdk.Display.get_default ().get_default_seat ().get_pointer ().get_position (null,
                 out x, out y);
         }
 


### PR DESCRIPTION
Fixes some deprecation warnings. (See https://valadoc.org/gdk-3.0/Gdk.Display.get_device_manager.html)


 <strike> Also containes #869, which is necessary to compile. Therefore should be merged after #869. </strike> 