### PR TITLE
(Re-)Make highlights in multitasking view transparent

### DIFF
--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -227,9 +227,9 @@ namespace Gala {
 
 #if HAS_MUTTER336
             Cogl.VertexP2T2C4 vertices[4];
-            vertices[0] = { x, y + height, 0, 1, 255, 255, 255, backdrop_opacity };
+            vertices[0] = { x, y + height, 0, 1, backdrop_opacity, backdrop_opacity, backdrop_opacity, backdrop_opacity };
             vertices[1] = { x, y, 0, 0, 0, 0, 0, 0 };
-            vertices[2] = { x + width, y + height, 1, 1, 255, 255, 255, backdrop_opacity };
+            vertices[2] = { x + width, y + height, 1, 1, backdrop_opacity, backdrop_opacity, backdrop_opacity, backdrop_opacity };
             vertices[3] = { x + width, y, 1, 0, 0, 0, 0, 0 };
 
             var primitive = new Cogl.Primitive.p2t2c4 (context.get_framebuffer ().get_context (), Cogl.VerticesMode.TRIANGLE_STRIP, vertices);

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -63,9 +63,10 @@ namespace Gala {
             path.rectangle (0, 0, width, height);
             context.get_framebuffer ().stroke_path (pipeline, path);
 
-            path = new Cogl.Path ();
-            pipeline.set_color4ub (255, 255, 255, 25);
-            path.rectangle (0, 0, width, height);
+            var color = Cogl.Color.from_4ub (255, 255, 255, 25);
+            color.premultiply ();
+            pipeline.set_color (color);
+            path.rectangle (0.5f, 0.5f, width - 1, height - 1);
             context.get_framebuffer ().stroke_path (pipeline, path);
         }
 #else


### PR DESCRIPTION
Since the mutter 3.36 the highlights in the multitasking view had no transparency. To my understanding the issue was, that the RGB values were not pre-multiplied.

**Master using mutter 3.36**
![image](https://user-images.githubusercontent.com/24651767/89115294-0c48ea00-d487-11ea-9744-440bd4b213a2.png)


**This branch using mutter 3.36**
![image](https://user-images.githubusercontent.com/24651767/89115276-d99ef180-d486-11ea-953b-95a9102c9c90.png)
