### PR TITLE
Cancel alt-tab view when pressing esc

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -378,6 +378,16 @@ namespace Gala {
             animate_dock_width ();
         }
 
+        public override bool key_press_event (Clutter.KeyEvent event) {
+            if (event.keyval == Clutter.Key.Escape) {
+                current_window = null;
+                close (event.time);
+                return true;
+            }
+
+            return false;
+        }
+
         public override bool key_release_event (Clutter.KeyEvent event) {
             if ((get_current_modifiers () & modifier_mask) == 0)
                 close (event.time);


### PR DESCRIPTION
Fixes #354

Quits the Alt-tab view and switches back to original app when pressing esc