### PR TITLE
KeyboardManager: listen to sources gsettings key

### DIFF
--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -70,7 +70,7 @@ namespace Gala {
 
         [CCode (instance_pos = -1)]
         void set_keyboard_layout (GLib.Settings settings, string key) {
-            if (!(key == "current" || key == "source" || key == "xkb-options"))
+            if (!(key == "current" || key == "sources" || key == "xkb-options"))
                 return;
 
             string layout = "us", variant = "", options = "";


### PR DESCRIPTION
Looks like this was a typo, there isn't a key called `source` and `sources` is referred to throughout the rest of this file.