### PR TITLE
Remove org.freedesktop.ScreenSaver interface

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -64,19 +64,11 @@ namespace Gala {
             unowned WindowManagerGala? gala_wm = wm as WindowManagerGala;
             if (gala_wm != null) {
                 var screensaver_manager = gala_wm.screensaver;
-                Bus.own_name (BusType.SESSION, "org.freedesktop.ScreenSaver", BusNameOwnerFlags.REPLACE,
-                    (connection) => {
-                        try {
-                            connection.register_object ("/org/freedesktop/ScreenSaver", screensaver_manager);
-                        } catch (Error e) { warning (e.message); }
-                    },
-                    () => {},
-                    () => critical ("Could not acquire freedesktop ScreenSaver bus") );
 
                 Bus.own_name (BusType.SESSION, "org.gnome.ScreenSaver", BusNameOwnerFlags.REPLACE,
                     (connection) => {
                         try {
-                            connection.register_object ("/org/gnome/ScreenSaver", screensaver_manager.gnome_manager);
+                            connection.register_object ("/org/gnome/ScreenSaver", screensaver_manager);
                         } catch (Error e) { warning (e.message); }
                     },
                     () => {},

--- a/src/ScreenSaverManager.vala
+++ b/src/ScreenSaverManager.vala
@@ -16,12 +16,9 @@
 //
 
 namespace Gala {
-    [DBus (name="org.freedesktop.ScreenSaver")]
+    [DBus (name="org.gnome.ScreenSaver")]
     public class ScreenSaverManager : Object {
         public signal void active_changed (bool new_value);
-
-        [DBus (visible = false)]
-        public GNOMEScreenSaverManager gnome_manager { get; construct; }
 
         [DBus (visible = false)]
         public ScreenShield screen_shield { get; construct; }
@@ -31,10 +28,8 @@ namespace Gala {
         }
 
         construct {
-            gnome_manager = new GNOMEScreenSaverManager (this);
             screen_shield.active_changed.connect (() => {
                 active_changed (screen_shield.active);
-                gnome_manager.active_changed (screen_shield.active);
             });
         }
 
@@ -61,42 +56,6 @@ namespace Gala {
             } else {
                 return 0;
             }
-        }
-    }
-
-    [DBus (name="org.gnome.ScreenSaver")]
-    public class GNOMEScreenSaverManager : GLib.Object {
-        [DBus (visible = false)]
-        public weak ScreenSaverManager manager { get; construct; }
-
-        public signal void active_changed (bool new_value);
-
-        public signal void wake_up_screen ();
-
-        public GNOMEScreenSaverManager (ScreenSaverManager manager) {
-            Object (manager: manager);
-        }
-
-        construct {
-            manager.screen_shield.wake_up_screen.connect (() => {
-                wake_up_screen ();
-            });
-        }
-
-        public new void @lock () throws GLib.Error {
-            manager.@lock ();
-        }
-
-        public new bool get_active () throws GLib.Error {
-            return manager.get_active ();
-        }
-
-        public new void set_active (bool active) throws GLib.Error {
-            manager.set_active (active);
-        }
-
-        public new uint get_active_time () throws GLib.Error {
-            return manager.get_active_time ();
         }
     }
 }


### PR DESCRIPTION
Gala was exporting two DBus interfaces for the screensaver with identical implementations (the GNOME one and freedesktop one). If we use the g-s-d ScreensaverProxy plugin as proposed in https://github.com/elementary/session-settings/pull/36 , then this implements the freedesktop interface for us and makes the inhibitor work properly too.

That way we no longer need this duplicated interface in Gala.