### PR TITLE
WindowManager: fixed nudge flicker and improved performance

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -592,13 +592,13 @@ namespace Gala {
 
             var dest = (direction == Meta.MotionDirection.LEFT ? 32.0f : -32.0f);
 
-            double[] keyframes = { 0.28, 0.58 };
-            GLib.Value[] x = { dest, dest };
+            double[] keyframes = { 0.5 };
+            GLib.Value[] x = { dest };
 
-            var nudge = new Clutter.KeyframeTransition ("x");
+            var nudge = new Clutter.KeyframeTransition ("translation-x");
             nudge.duration = 360;
             nudge.remove_on_complete = true;
-            nudge.progress_mode = Clutter.AnimationMode.LINEAR;
+            nudge.progress_mode = Clutter.AnimationMode.EASE_IN_QUAD;
             nudge.set_from_value (0.0f);
             nudge.set_to_value (0.0f);
             nudge.set_key_frames (keyframes);


### PR DESCRIPTION
When scrolling past the first/last workspace, Gala nudges the current workspace to indicate that there's no other workspace in the direction that you are scrolling. This nudge sometimes flickers Gala's background on top of the workspace's clone.

This changes fix this by simplifying the animation. I also replace animating `x` with animating `translation-x`, which improves performance by avoiding any relayout calculations made by Clutter. 