### PR TITLE
InternalUtils: Prevent X11 specific calls on wayland

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -93,6 +93,10 @@ namespace Gala {
          **/
 #if HAS_MUTTER330
         public static void set_input_area (Display display, InputArea area) {
+            if (Meta.Util.is_wayland_compositor ()) {
+                return;
+            }
+
             X.Xrectangle[] rects = {};
             int width, height;
             display.get_size (out width, out height);


### PR DESCRIPTION
This method causes a segfault when trying to use Gala as a wayland compositor.

I'm reasonably sure it's not needed under Wayland, and in the case that it is needed, it looks like it would just break the hot corners until we write an alternative.