### PR TITLE
Rename 'Minimize' to 'Hide'

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -32,14 +32,14 @@ namespace Gala {
         // Window Menu
         private Granite.AccelLabel always_on_top_accellabel;
         private Granite.AccelLabel close_accellabel;
-        private Granite.AccelLabel minimize_accellabel;
+        private Granite.AccelLabel hide_accellabel;
         private Granite.AccelLabel move_accellabel;
         private Granite.AccelLabel move_left_accellabel;
         private Granite.AccelLabel move_right_accellabel;
         private Granite.AccelLabel on_visible_workspace_accellabel;
         private Granite.AccelLabel resize_accellabel;
         Gtk.Menu? window_menu = null;
-        Gtk.MenuItem minimize;
+        Gtk.MenuItem hide;
         Gtk.MenuItem maximize;
         Gtk.MenuItem move;
         Gtk.MenuItem resize;
@@ -108,12 +108,12 @@ namespace Gala {
         }
 
         private void init_window_menu () {
-            minimize_accellabel = new Granite.AccelLabel (_("Minimize"));
+            hide_accellabel = new Granite.AccelLabel (_("Hide"));
 
-            minimize = new Gtk.MenuItem ();
-            minimize.add (minimize_accellabel);
-            minimize.activate.connect (() => {
-                perform_action (Gala.ActionType.MINIMIZE_CURRENT);
+            hide = new Gtk.MenuItem ();
+            hide.add (hide_accellabel);
+            hide.activate.connect (() => {
+                perform_action (Gala.ActionType.HIDE_CURRENT);
             });
 
             maximize = new Gtk.MenuItem ();
@@ -178,7 +178,7 @@ namespace Gala {
             });
 
             window_menu = new Gtk.Menu ();
-            window_menu.append (minimize);
+            window_menu.append (hide);
             window_menu.append (maximize);
             window_menu.append (move);
             window_menu.append (resize);
@@ -195,9 +195,9 @@ namespace Gala {
                 init_window_menu ();
             }
 
-            minimize.visible = Gala.WindowFlags.CAN_MINIMIZE in flags;
-            if (minimize.visible) {
-                minimize_accellabel.accel_string = keybind_settings.get_strv ("minimize")[0];
+            hide.visible = Gala.WindowFlags.CAN_HIDE in flags;
+            if (hide.visible) {
+                hide_accellabel.accel_string = keybind_settings.get_strv ("minimize")[0];
             }
 
             maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;

--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -22,8 +22,8 @@ namespace Gala {
         OPEN = 350,
         // Duration of the close animation
         CLOSE = 195,
-        // Duration of the minimize animation
-        MINIMIZE = 200,
+        // Duration of the hide animation
+        HIDE = 200,
         // Duration of the menu mapping animation
         MENU_MAP = 150,
         // Duration of the snap animation as used by maximize/unmaximize

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -20,7 +20,7 @@ namespace Gala {
         NONE = 0,
         SHOW_WORKSPACE_VIEW,
         MAXIMIZE_CURRENT,
-        MINIMIZE_CURRENT,
+        HIDE_CURRENT,
         OPEN_LAUNCHER,
         CUSTOM_COMMAND,
         WINDOW_OVERVIEW,
@@ -38,7 +38,7 @@ namespace Gala {
     [Flags]
     public enum WindowFlags {
         NONE = 0,
-        CAN_MINIMIZE,
+        CAN_HIDE,
         CAN_MAXIMIZE,
         IS_MAXIMIZED,
         ALLOWS_MOVE,

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -886,7 +886,7 @@ namespace Gala {
                     else
                         current.maximize (Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
                     break;
-                case ActionType.MINIMIZE_CURRENT:
+                case ActionType.HIDE_CURRENT:
                     if (current != null && current.window_type == Meta.WindowType.NORMAL)
                         current.minimize ();
                     break;
@@ -1016,7 +1016,7 @@ namespace Gala {
 
                     WindowFlags flags = WindowFlags.NONE;
                     if (window.can_minimize ())
-                        flags |= WindowFlags.CAN_MINIMIZE;
+                        flags |= WindowFlags.CAN_HIDE;
 
                     if (window.can_maximize ())
                         flags |= WindowFlags.CAN_MAXIMIZE;
@@ -1222,7 +1222,7 @@ namespace Gala {
         }
 
         public override void minimize (Meta.WindowActor actor) {
-            const int duration = AnimationDuration.MINIMIZE;
+            const int duration = AnimationDuration.HIDE;
 
             if (!enable_animations
                 || duration == 0
@@ -1403,7 +1403,7 @@ namespace Gala {
 
             switch (window.window_type) {
                 case Meta.WindowType.NORMAL:
-                    var duration = AnimationDuration.MINIMIZE;
+                    var duration = AnimationDuration.HIDE;
                     if (duration == 0) {
                         unminimize_completed (actor);
                         return;
@@ -1457,7 +1457,7 @@ namespace Gala {
 
             switch (window.window_type) {
                 case Meta.WindowType.NORMAL:
-                    var duration = AnimationDuration.MINIMIZE;
+                    var duration = AnimationDuration.HIDE;
                     if (duration == 0) {
                         map_completed (actor);
                         return;


### PR DESCRIPTION
Rationale:

* There is no "minimized" version of a window anywhere on the screen, so the name as I understand it doesn't make sense
* The new name also matches the existing meta+H shortcut (and hopefully makes it easier to memorize)

![Bildschirmfoto 2020-10-21 um 13 07 05](https://user-images.githubusercontent.com/70772/98021881-2804b900-1e05-11eb-8edc-6e555aab2e7c.png)

Instead of only changing the localizable string, I've also renamed all occurences of the word "minimized" that weren't inherited from base classes. Are there any third-party projects that might be affected by this? Should I bump an so version number or similar to indicate a breaking change; or should I revert some of the renames?

I've kept the internal name of the "minimize" shortcut to avoid breaking existing setups.