### PR TITLE
Introduce a Tiling Mode

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -105,6 +105,18 @@
 			<summary>Automatically move fullscreened windows to a new workspace</summary>
 			<description></description>
 		</key>
+    <key type="b" name="experimental-tiling-mode">
+      <!-- TODO: set to false before merging -->
+			<default>true</default> 
+			<summary>Toggle experimental tiling mode.</summary>
+			<description></description>
+		</key>
+    <!-- TODO: remove before merging -->
+    <key type="b" name="experimental-tiling-mode-shrink">
+			<default>false</default> 
+			<summary>Whether or not the window shrunk when entering tiling mode.</summary>
+			<description></description>
+		</key>
   </schema>
 
   <schema path="/org/pantheon/desktop/gala/keybindings/" id="org.pantheon.desktop.gala.keybindings">
@@ -145,6 +157,12 @@
     <key type="as" name="expose-all-windows">
       <default><![CDATA[['<Super>a']]]></default>
       <summary>Shortcut to open the window overview for all windows</summary>
+      <description></description>
+    </key>
+    <key type="as" name="tiling-mode">
+      <!-- <default><![CDATA[['<Control><Super>Left', '<Control><Super>Down', '<Control><Super>Up', '<Control><Super>Right']]]></default> -->
+      <default><![CDATA[['<Super>Return']]]></default>
+      <summary>Show pie menu.</summary>
       <description></description>
     </key>
     <key type="as" name="cycle-workspaces-next">

--- a/src/Widgets/TilingMode.vala
+++ b/src/Widgets/TilingMode.vala
@@ -1,0 +1,356 @@
+/*
+* Copyright 2020 Felix Andreas
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+*/
+
+public class Gala.TilingMode : Clutter.Actor, ActivatableComponent {
+    const int DEFAULT_GAP = 12;
+    const int ICON_SIZE = 64;
+
+    public WindowManager wm { get; construct; }
+    public bool is_preview_active = false;
+    private Meta.Display display;
+    private ModalProxy? modal_proxy;
+    private Meta.Window? current_window = null;
+    private Meta.Rectangle tile_rect;
+    private Clutter.Actor window_icon;
+    private int scale;
+    private bool _is_opened = false;
+    private int _grid[2];
+    private int grid_x {
+        get { 
+            var wa = current_window.get_work_area_for_monitor (current_monitor);
+            return int.min (scale * wa.width / 600, _grid[0]);
+        }
+    }
+    private int grid_y {
+        get { 
+            var wa = current_window.get_work_area_for_monitor (current_monitor);
+            return int.min (scale * wa.height / 400, _grid[1]);
+        }
+    }
+    private int current_monitor;
+    private int pos_x;
+    private int pos_y;
+    private int col;
+    private int row;
+    private int max_col { get { return 2 * (grid_x - 1); } }
+    private int max_row { get { return 2 * (grid_y - 1); } }
+    private int gap = DEFAULT_GAP;
+    private int direction = 0; /* x - 0, y - 1 */
+    //  TODO: remove before merging
+    private GLib.Settings behavior_settings;
+
+    public TilingMode (WindowManager wm) {
+        Object (wm : wm);
+    }
+
+    construct {
+        visible = false;
+        reactive = true;
+        display = wm.get_display ();
+        scale = InternalUtils.get_ui_scaling_factor ();
+        int screen_width, screen_height;
+        display.get_size (out screen_width, out screen_height);
+        width = screen_width;
+        height = screen_height;
+        _grid = {2, 2};
+        //  TODO: remove before merging
+        behavior_settings = new GLib.Settings (Config.SCHEMA + ".behavior");
+    }
+
+    public void open (HashTable<string,Variant>? hints = null) {
+        direction = 0;
+        current_window = display.get_focus_window ();
+        if (hints != null && ("mouse" in hints)) {
+            current_monitor = display.get_current_monitor ();
+            int pointer_x, pointer_y;
+            display.get_cursor_tracker ().get_pointer (out pointer_x, out pointer_y, null);
+            pos_x = pointer_x;
+            pos_y = pointer_y;
+        } else {
+            current_monitor = current_window.get_monitor ();
+            Meta.Rectangle rect = current_window.get_frame_rect ();
+            pos_x = rect.x + rect.width / 2;
+            pos_y = rect.y + rect.height / 2;
+        }
+
+        set_col_row_from_x_y (pos_x, pos_y);
+        calculate_tile_rect ();
+        init_preview ((float) pos_x, (float) pos_y);
+
+        visible = true;
+        _is_opened = true;
+        grab_key_focus ();
+        modal_proxy = wm.push_modal ();
+    }
+
+    public void close () {
+        if (current_window != null) {
+            end_preview ();
+            current_window = null;
+        }
+
+        visible = false;
+        _is_opened = false;
+        if (modal_proxy != null) {
+            wm.pop_modal (modal_proxy);
+        }
+    }
+
+    public bool is_opened () {
+        return _is_opened;
+    }
+
+    public override bool key_press_event (Clutter.KeyEvent event) {
+        switch (event.keyval) {
+            case Clutter.Key.Return:
+            case Clutter.Key.KP_Enter:
+            case Clutter.Key.space:
+                tile ();
+                close ();
+                break;
+            case Clutter.Key.Escape:
+                close ();
+                break;
+            case Clutter.Key.Left:
+            case Clutter.Key.a:
+            case Clutter.Key.h:
+                set_col_row_from_direction (Meta.MotionDirection.LEFT);
+                update_preview_keyboard ();
+                break;
+            case Clutter.Key.Right:
+            case Clutter.Key.d:
+            case Clutter.Key.l:
+                set_col_row_from_direction (Meta.MotionDirection.RIGHT);
+                update_preview_keyboard ();
+                break;
+            case Clutter.Key.Up:
+            case Clutter.Key.w:
+            case Clutter.Key.k:
+                set_col_row_from_direction (Meta.MotionDirection.UP);
+                update_preview_keyboard ();
+                break;
+            case Clutter.Key.Down:
+            case Clutter.Key.s:
+            case Clutter.Key.j:
+                set_col_row_from_direction (Meta.MotionDirection.DOWN);
+                update_preview_keyboard ();
+                break;
+            case Clutter.Key.G:
+            case Clutter.Key.g:
+                gap = gap == 0 ? DEFAULT_GAP : 0;
+                calculate_tile_rect ();
+                update_preview ();
+                break;
+            case Clutter.Key.@1:
+            case Clutter.Key.@2:
+            case Clutter.Key.@3:
+            case Clutter.Key.@4:
+                var old_max_row = max_row;
+                var old_max_col = max_col;
+                _grid[direction] = (int)(event.keyval - Clutter.Key.@1 + 1);
+                col = (col + (max_col - old_max_col) / 2).clamp (0, max_col);
+                row = (row + (max_row - old_max_row) / 2).clamp (0, max_row);
+                update_preview_keyboard ();
+                direction = 1 - direction;
+                break;
+            default:
+                return false;
+        }
+
+        return true;
+    }
+
+    public override bool button_press_event (Clutter.ButtonEvent event) {
+        if (event.button == 1) {
+            tile ();
+            close ();
+            return true;
+        } 
+        return false;
+    }
+
+    public override bool button_release_event (Clutter.ButtonEvent event) {
+        if (event.button == 1) {
+            tile ();
+            close ();
+            return true;
+        } 
+        return false;
+    }
+
+    public override bool motion_event (Clutter.MotionEvent event) {
+        update_preview_mouse ((int)event.x, (int)event.y);
+        return true;
+    }
+
+    private void tile () {
+        if (current_window.maximized_horizontally || current_window.maximized_vertically) {
+            current_window.unmaximize (Meta.MaximizeFlags.BOTH);
+        }
+
+        current_window.move_resize_frame (true, tile_rect.x, tile_rect.y, tile_rect.width, tile_rect.height);
+    }
+
+    private void update_preview_mouse (int x, int y) {
+        pos_x = x;
+        pos_y = y;
+        current_monitor = display.get_current_monitor ();
+        set_col_row_from_x_y (pos_x, pos_y);
+        calculate_tile_rect ();
+        update_preview ();
+    }
+
+    private void update_preview_keyboard () {
+        calculate_tile_rect ();
+        pos_x = tile_rect.x + tile_rect.width / 2;
+        pos_y = tile_rect.y + tile_rect.height / 2;
+        update_preview ();
+    }
+
+    private void update_preview () {
+        window_icon.set_position ((float)(pos_x - ICON_SIZE / 2), (float)(pos_y - ICON_SIZE / 2));
+        wm.show_tile_preview (current_window, tile_rect, current_monitor);
+    }
+
+    private void init_preview (float x, float y) {
+        is_preview_active = true;
+        if (behavior_settings.get_boolean ("experimental-tiling-mode-shrink")) {
+            float abs_x, abs_y;
+            var actor = (Meta.WindowActor)current_window.get_compositor_private ();
+            actor.get_transformed_position (out abs_x, out abs_y);
+            actor.set_pivot_point ((x - abs_x) / actor.width, (y - abs_y) / actor.height);
+            actor.save_easing_state ();
+            actor.set_easing_mode (Clutter.AnimationMode.EASE_IN_EXPO);
+            actor.set_easing_duration (AnimationDuration.SNAP);
+            actor.set_scale (0.0f, 0.0f);
+            actor.opacity = 0U;
+            actor.restore_easing_state ();
+        }
+
+        window_icon = new WindowIcon (current_window, ICON_SIZE, scale);
+        window_icon.opacity = 255;
+        window_icon.set_pivot_point (0.5f, 0.5f);
+        add_child (window_icon);
+        update_preview ();
+    }
+
+    private void end_preview () {
+        is_preview_active = false;
+        if (behavior_settings.get_boolean ("experimental-tiling-mode-shrink")) {
+            var actor = (Meta.WindowActor)current_window.get_compositor_private ();
+            actor.set_pivot_point (0.5f, 1.0f);
+            actor.set_scale (0.01f, 0.1f);
+            actor.opacity = 0U;
+            actor.save_easing_state ();
+            actor.set_easing_mode (Clutter.AnimationMode.EASE_OUT_EXPO);
+            actor.set_easing_duration (AnimationDuration.SNAP);
+            actor.set_scale (1.0f, 1.0f);
+            actor.opacity = 255U;
+            actor.restore_easing_state ();
+        }
+
+        window_icon.opacity = 0;
+        remove_child (window_icon);
+
+        wm.hide_tile_preview ();
+    }
+
+    private void calculate_tile_rect () {
+        Meta.Rectangle wa = current_window.get_work_area_for_monitor (current_monitor);
+        int gap = gap * scale;
+        int tile_width = (wa.width - (grid_x + 1) * gap) / grid_x;
+        int tile_height = (wa.height - (grid_y + 1) * gap) / grid_y;
+        tile_rect = {
+            wa.x + gap + (col >> 1) * (tile_width + gap),
+            wa.y + gap + (row >> 1) * (tile_height + gap),
+            tile_width + (col & 1) * (tile_width + gap),
+            tile_height + (row & 1) * (tile_height + gap),
+        };
+    }
+
+    private void set_col_row_from_x_y (int x, int y) {
+        Meta.Rectangle wa = current_window.get_work_area_for_monitor (current_monitor);
+        col = ((int)(((3 * grid_x - 1) * (x - wa.x) / wa.width) / 1.5)).clamp (0, max_col);
+        row = ((int)(((3 * grid_y - 1) * (y - wa.y) / wa.height) / 1.5)).clamp (0, max_row);
+    }
+
+    private void set_col_row_from_direction (Meta.MotionDirection? direction) {
+        switch (direction) {
+            case Meta.MotionDirection.LEFT:
+                if (col > 0) {
+                    col -= 1; 
+                } else {
+                    var neighbor = display.get_monitor_neighbor_index (current_monitor, Meta.DisplayDirection.LEFT);
+                    if (neighbor != -1) {
+                        var old_max_row = max_row;
+                        current_monitor = neighbor;
+                        col = max_col;
+                        row = (row + (max_row - old_max_row) / 2).clamp (0, max_row);
+                    }
+                }
+                break;
+            case Meta.MotionDirection.RIGHT:
+                if (col < max_col) {
+                    col += 1; 
+                } else {
+                    var neighbor = display.get_monitor_neighbor_index (current_monitor, Meta.DisplayDirection.RIGHT);
+                    if (neighbor != -1) {
+                        var old_max_row = max_row;
+                        current_monitor = neighbor;
+                        col = 0;
+                        row = (row + (max_row - old_max_row) / 2).clamp (0, max_row);
+                    }
+                }
+                break;
+            case Meta.MotionDirection.UP:
+                if (row > 0) {
+                    row -= 1; 
+                } else {
+                    var neighbor = display.get_monitor_neighbor_index (current_monitor, Meta.DisplayDirection.UP);
+                    if (neighbor != -1) {
+                        var old_max_col = max_col;
+                        current_monitor = neighbor;
+                        col = (col + (max_col - old_max_col) / 2).clamp (0, max_col);
+                        row = max_row;
+                    }
+                }
+                break;
+            case Meta.MotionDirection.DOWN:
+                if (row < max_row) {
+                    row += 1; 
+                } else {
+                    var neighbor = display.get_monitor_neighbor_index (current_monitor, Meta.DisplayDirection.DOWN);
+                    if (neighbor != -1) {
+                        var old_max_col = max_col;
+                        current_monitor = neighbor;
+                        col = (col + (max_col - old_max_col) / 2).clamp (0, max_col);
+                        row = 0;
+                    }
+                }
+                break;
+            default:
+                return;
+        }
+    }
+
+    //  private void show_grid () {
+    //      debug ("show_grid: Not implemented yet!");
+    //  }
+}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -77,6 +77,8 @@ namespace Gala {
         private Meta.Window? moving; //place for the window that is being moved over
 
         Daemon? daemon_proxy = null;
+        
+        TilingMode tiling_mode;
 
         NotificationStack notification_stack;
 
@@ -173,6 +175,26 @@ namespace Gala {
 #endif
             KeyboardManager.init (display);
 
+            tiling_mode = new TilingMode (this);
+            display.grab_op_begin.connect ((display, window, op) => {
+                if (behavior_settings.get_boolean ("experimental-tiling-mode")) {
+                    if (op == Meta.GrabOp.MOVING && window != null) {
+                        int x, y;
+                        Clutter.ModifierType type;
+                        display.get_cursor_tracker ().get_pointer (out x, out y, out type);
+            
+                        if ((type & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.BUTTON3_MASK)) != 0) {
+                            if (!tiling_mode.is_opened ()) {
+                                display.end_grab_op (display.get_current_time ());
+                                var hints = new HashTable<string,Variant> (str_hash, str_equal);
+                                hints.@set ("mouse", true);
+                                tiling_mode.open ();
+                            }
+                        }  
+                    }
+                }
+            });
+
 #if HAS_MUTTER330
             notification_stack = new NotificationStack (display);
 #else
@@ -253,6 +275,7 @@ namespace Gala {
             pointer_locator = new PointerLocator (this);
             ui_group.add_child (pointer_locator);
             ui_group.add_child (new DwellClickTimer (this));
+            ui_group.add_child (tiling_mode);
 #endif
             ui_group.add_child (screen_shield);
 
@@ -368,6 +391,11 @@ namespace Gala {
                     var hints = new HashTable<string,Variant> (str_hash, str_equal);
                     hints.@set ("all-windows", true);
                     window_overview.open (hints);
+                }
+            });
+            display.add_keybinding ("tiling-mode", keybinding_settings, 0, () => {
+                if (behavior_settings.get_boolean ("experimental-tiling-mode") && !tiling_mode.is_opened ()) {
+                    tiling_mode.open ();
                 }
             });
 
@@ -1058,25 +1086,40 @@ namespace Gala {
                 tile_preview.opacity = 0U;
 
                 window_group.add_child (tile_preview);
-            } else if (tile_preview.is_visible ()) {
-                float width, height, x, y;
-                tile_preview.get_position (out x, out y);
-                tile_preview.get_size (out width, out height);
-
-                if ((tile_rect.width == width && tile_rect.height == height && tile_rect.x == x && tile_rect.y == y)
-                    || tile_preview.get_transition ("size") != null) {
-                    return;
-                }
             }
 
-            unowned Meta.WindowActor window_actor = window.get_compositor_private () as Meta.WindowActor;
-            window_group.set_child_below_sibling (tile_preview, window_actor);
+            float width, height, x, y;
+            Clutter.AnimationMode animation_mode;
+            if (tile_preview.is_visible ()) {
+                animation_mode = Clutter.AnimationMode.EASE_IN_OUT_QUAD;
+                tile_preview.get_position (out x, out y);
+                tile_preview.get_size (out width, out height);
+                if (tile_rect.width == width && tile_rect.height == height && tile_rect.x == x && tile_rect.y == y) {
+                    return;
+                } else if (tile_preview.get_transition ("size") != null) {
+                    ulong handler_id = 0UL;
+                    handler_id = tile_preview.transitions_completed.connect(() => {
+                        tile_preview.disconnect (handler_id);
+                        show_tile_preview (window, tile_rect, tile_monitor_number);
+                    });
+                    return;
+                }
+            } else {
+                animation_mode = Clutter.AnimationMode.LINEAR;
+                var rect = window.get_frame_rect ();
+                width = rect.width;
+                height = rect.height;
+                x = rect.x;
+                y = rect.y;
+            }
+
+            //  unowned Meta.WindowActor window_actor = window.get_compositor_private () as Meta.WindowActor;
+            //  window_group.set_child_below_sibling (tile_preview, window_actor);
 
             var duration = AnimationDuration.SNAP / 2U;
 
-            var rect = window.get_frame_rect ();
-            tile_preview.set_position (rect.x, rect.y);
-            tile_preview.set_size (rect.width, rect.height);
+            tile_preview.set_position (x, y);
+            tile_preview.set_size (width, height);
             tile_preview.show ();
 
             if (enable_animations) {
@@ -1093,7 +1136,7 @@ namespace Gala {
         }
 
         public override void hide_tile_preview () {
-            if (tile_preview != null) {
+            if (tile_preview != null && !tiling_mode.is_preview_active) {
                 tile_preview.remove_all_transitions ();
                 tile_preview.opacity = 0U;
                 tile_preview.hide ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,7 @@ gala_bin_sources = files(
     'Widgets/SafeWindowClone.vala',
     'Widgets/ScreenShield.vala',
     'Widgets/SelectionArea.vala',
+    'Widgets/TilingMode.vala',
     'Widgets/WindowClone.vala',
     'Widgets/WindowCloneContainer.vala',
     'Widgets/WindowIconActor.vala',


### PR DESCRIPTION
#### Behavior

1. Similar to other tiling window managers a *Tiling-Mode*  can be activated by pressing <kbd>Super</kbd><kbd>Return</kbd>: This will show a tile preview for the current window, which can then be moved using <kbd>↑</kbd><kbd>←</kbd><kbd>↓</kbd><kbd>→</kbd>, <kbd>w</kbd><kbd>a</kbd><kbd>s</kbd><kbd>d</kbd>, <kbd>h</kbd><kbd>j</kbd><kbd>k</kbd><kbd>l</kbd> or the mouse. Pressing <kbd>Return</kbd> or <kbd>space</kbd> will confirm the current preview and will tile the window accordingly. (Windows can also be moved between multiple monitors)
2. In the future this mode could be complement with a *Window-Selection-Mode*: Here windows can be selected using the arrow keys (similar to the Multitasking view).
3. The grid can be changed by pressing the number keys when in *Tiling-Mode*. For example pressing <kbd>3</kbd><kbd>2</kbd> will set a 3 by 2 grid.
4. Inspired by the [latest blog post](https://blog.elementary.io/dark-style-progress/) I also added optional gaps, which can be toggled by pressing <kbd>g</kbd> when in tiling mode.
5. The <kbd>Drag</kbd><kbd>Ctrl</kbd> tile action of #595 is still available. But I consider to remove it as it just as convenient to press the <kbd>Super</kbd><kbd>Return</kbd> shortcut.