### PR TITLE
Updated build to package the binary as a library, so can reuse compon…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ po/Rules-quot
 po/stamp-po
 src/gala
 build
+.vscode/

--- a/meson.build
+++ b/meson.build
@@ -183,6 +183,8 @@ subdir('plugins/notify')
 subdir('plugins/pip')
 subdir('plugins/template')
 subdir('plugins/zoom')
+subdir('plugins/app-windows')
+
 if get_option('documentation')
 	subdir('docs')
 endif

--- a/plugins/app-windows/AppWindowOverview.vala
+++ b/plugins/app-windows/AppWindowOverview.vala
@@ -1,0 +1,377 @@
+//  
+//  Copyright (C) 2012 Tom Beckmann, Rico Tzschichholz
+// 
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+// 
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+// 
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// 
+
+using Meta;
+using Clutter;
+
+namespace Gala {
+
+    public class AppWindowOverview : Actor, ActivatableComponent {
+        const int BORDER = 10;
+        const int TOP_GAP = 30;
+        const int BOTTOM_GAP = 100;
+
+        public WindowManager wm { get; construct; }
+
+#if HAS_MUTTER330
+        Meta.Display display;
+#else
+        Meta.Screen screen;
+#endif
+
+        ModalProxy modal_proxy;
+        bool ready;
+
+        // the workspaces which we expose right now
+        List<Workspace> workspaces;
+
+        public AppWindowOverview (WindowManager wm) {
+            Object (wm : wm);
+        }
+
+        construct {
+#if HAS_MUTTER330
+            display = wm.get_display ();
+
+            display.get_workspace_manager ().workspace_switched.connect (close);
+            display.restacked.connect (restack_windows);
+#else
+            screen = wm.get_screen ();
+
+            screen.workspace_switched.connect (close);
+            screen.restacked.connect (restack_windows);
+#endif
+
+            visible = false;
+            ready = true;
+            reactive = true;
+        }
+
+        ~AppWindowOverview () {
+#if HAS_MUTTER330
+            display.restacked.disconnect (restack_windows);
+#else
+            screen.restacked.disconnect (restack_windows);
+#endif
+        }
+
+        public override bool key_press_event (Clutter.KeyEvent event) {
+            if (event.keyval == Clutter.Key.Escape) {
+                close ();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public override void key_focus_out () {
+            if (!contains (get_stage ().key_focus))
+                close ();
+        }
+
+        public override bool button_press_event (Clutter.ButtonEvent event) {
+            if (event.button == 1)
+                close ();
+
+            return true;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public bool is_opened () {
+            return visible;
+        }
+
+        /**
+         * {@inheritDoc}
+         * You may specify 'all-windows' in hints to expose all windows
+         */
+        public void open (HashTable<string,Variant>? hints = null) {
+            if (!ready)
+                return;
+
+            if (visible) {
+                close ();
+                return;
+            }
+
+            var all_windows = hints != null && "all-windows" in hints;
+
+            var used_windows = new SList<Window> ();
+
+            workspaces = new List<Workspace> ();
+
+#if HAS_MUTTER330
+            unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
+            if (all_windows) {
+                for (int i = 0; i < manager.get_n_workspaces (); i++) {
+                    workspaces.append (manager.get_workspace_by_index (i));
+                }
+            } else {
+                workspaces.append (manager.get_active_workspace ());
+            }
+#else
+            if (all_windows) {
+                foreach (var workspace in screen.get_workspaces ())
+                    workspaces.append (workspace);
+            } else {
+                workspaces.append (screen.get_active_workspace ());
+            }
+#endif
+
+            Gee.HashMap<string, Gee.List<Window>> class_to_window = new Gee.HashMap<string, Gee.List<Window>>();
+            string focused_window_class = null;
+
+            foreach (var workspace in workspaces) {
+                foreach (var window in workspace.list_windows ()) {;
+                    if (window.window_type != WindowType.NORMAL &&
+                        window.window_type != WindowType.DOCK &&
+                        window.window_type != WindowType.DIALOG ||
+                        window.is_attached_dialog ()) {
+                        var actor = window.get_compositor_private () as WindowActor;
+                        if (actor != null)
+                            actor.hide ();
+                        continue;
+                    }
+                    if (window.window_type == WindowType.DOCK)
+                        continue;
+
+                    // skip windows that are on all workspace except we're currently
+                    // processing the workspace it actually belongs to
+                    if (window.is_on_all_workspaces () && window.get_workspace () != workspace)
+                        continue;
+
+                    if (window.appears_focused) {
+                        focused_window_class = window.wm_class;
+                    }
+
+                    if (class_to_window.get(window.wm_class) == null) {
+                        class_to_window.set(window.wm_class, new Gee.ArrayList<Window>());
+                    }
+
+                    class_to_window.get(window.wm_class).add(window);
+                }
+            }
+
+            if (focused_window_class != null) {
+                foreach (Window window in class_to_window.get(focused_window_class)) {
+                    used_windows.append(window);
+                }
+            }
+
+            var n_windows = used_windows.length ();
+            if (n_windows == 0)
+                return;
+
+            ready = false;
+
+            foreach (var workspace in workspaces) {
+                workspace.window_added.connect (add_window);
+                workspace.window_removed.connect (remove_window);
+            }
+
+#if HAS_MUTTER330
+            display.window_left_monitor.connect (window_left_monitor);
+
+            // sort windows by stacking order
+            var windows = display.sort_windows_by_stacking (used_windows);
+#else
+            screen.window_left_monitor.connect (window_left_monitor);
+
+            // sort windows by stacking order
+            var windows = screen.get_display ().sort_windows_by_stacking (used_windows);
+#endif
+
+            grab_key_focus ();
+
+            modal_proxy = wm.push_modal ();
+            modal_proxy.keybinding_filter = keybinding_filter;
+
+            visible = true;
+
+#if HAS_MUTTER330
+            for (var i = 0; i < display.get_n_monitors (); i++) {
+                var geometry = display.get_monitor_geometry (i);
+#else
+            for (var i = 0; i < screen.get_n_monitors (); i++) {
+                var geometry = screen.get_monitor_geometry (i);
+#endif
+
+                var container = new WindowCloneContainer (true);
+                container.padding_top = TOP_GAP;
+                container.padding_left = container.padding_right = BORDER;
+                container.padding_bottom = BOTTOM_GAP;
+                container.set_position (geometry.x, geometry.y);
+                container.set_size (geometry.width, geometry.height);
+                container.window_selected.connect (thumb_selected);
+
+                add_child (container);
+            }
+
+            foreach (var window in windows) {
+                unowned WindowActor actor = window.get_compositor_private () as WindowActor;
+                if (actor != null)
+                    actor.hide ();
+
+                unowned WindowCloneContainer container = get_child_at_index (window.get_monitor ()) as WindowCloneContainer;
+                if (container == null)
+                    continue;
+
+                container.add_window (window);
+            }
+
+            foreach (var child in get_children ())
+                ((WindowCloneContainer) child).open ();
+
+            ready = true;
+        }
+
+        bool keybinding_filter (KeyBinding binding) {
+            var name = binding.get_name ();
+            return (name != "expose-windows" && name != "expose-all-windows");
+        }
+
+#if HAS_MUTTER330
+        void restack_windows (Display display) {
+            foreach (var child in get_children ())
+                ((WindowCloneContainer) child).restack_windows (display);
+        }
+#else
+        void restack_windows (Screen screen) {
+            foreach (var child in get_children ())
+                ((WindowCloneContainer) child).restack_windows (screen);
+        }
+#endif
+
+        void window_left_monitor (int num, Window window) {
+            unowned WindowCloneContainer container = get_child_at_index (num) as WindowCloneContainer;
+            if (container == null)
+                return;
+
+            // make sure the window belongs to one of our workspaces
+            foreach (var workspace in workspaces)
+                if (window.located_on_workspace (workspace)) {
+                    container.remove_window (window);
+                    break;
+                }
+        }
+
+        void add_window (Window window) {
+            if (!visible
+                || (window.window_type != WindowType.NORMAL && window.window_type != WindowType.DIALOG))
+                return;
+
+            unowned WindowCloneContainer container = get_child_at_index (window.get_monitor ()) as WindowCloneContainer;
+            if (container == null)
+                return;
+
+            // make sure the window belongs to one of our workspaces
+            foreach (var workspace in workspaces)
+                if (window.located_on_workspace (workspace)) {
+                    container.add_window (window);
+                    break;
+                }
+        }
+
+        void remove_window (Window window) {
+            unowned WindowCloneContainer container = get_child_at_index (window.get_monitor ()) as WindowCloneContainer;
+            if (container == null)
+                return;
+
+            container.remove_window (window);
+        }
+
+#if HAS_MUTTER330
+        void thumb_selected (Window window) {
+            if (window.get_workspace () == display.get_workspace_manager ().get_active_workspace ()) {
+                window.activate (display.get_current_time ());
+                close ();
+            } else {
+                close ();
+                //wait for the animation to finish before switching
+                Timeout.add (400, () => {
+                    window.get_workspace ().activate_with_focus (window, display.get_current_time ());
+                    return false;
+                });
+            }
+        }
+#else
+        void thumb_selected (Window window) {
+            if (window.get_workspace () == screen.get_active_workspace ()) {
+                window.activate (screen.get_display ().get_current_time ());
+                close ();
+            } else {
+                close ();
+                //wait for the animation to finish before switching
+                Timeout.add (400, () => {
+                    window.get_workspace ().activate_with_focus (window, screen.get_display ().get_current_time ());
+                    return false;
+                });
+            }
+        }
+#endif
+
+        /**
+         * {@inheritDoc}
+         */
+        public void close () {
+            if (!visible || !ready)
+                return;
+
+            foreach (var workspace in workspaces) {
+                workspace.window_added.disconnect (add_window);
+                workspace.window_removed.disconnect (remove_window);
+            }
+#if HAS_MUTTER330
+            display.window_left_monitor.disconnect (window_left_monitor);
+#else
+            screen.window_left_monitor.disconnect (window_left_monitor);
+#endif
+
+            ready = false;
+
+            wm.pop_modal (modal_proxy);
+
+            foreach (var child in get_children ()) {
+                ((WindowCloneContainer) child).close ();
+            }
+
+            Clutter.Threads.Timeout.add (300, () => {
+                cleanup ();
+
+                return false;
+            });
+        }
+
+        void cleanup () {
+            ready = true;
+            visible = false;
+
+#if HAS_MUTTER330
+            foreach (var window in display.get_workspace_manager ().get_active_workspace ().list_windows ())
+#else
+            foreach (var window in screen.get_active_workspace ().list_windows ())
+#endif
+                if (window.showing_on_its_workspace ())
+                    ((Actor) window.get_compositor_private ()).show ();
+
+            destroy_all_children ();
+        }
+    }
+}

--- a/plugins/app-windows/Main.vala
+++ b/plugins/app-windows/Main.vala
@@ -1,0 +1,64 @@
+using Clutter;
+
+namespace Gala.Plugins.AppWindowOverview {
+    public class Main : Gala.Plugin {
+        Gala.AppWindowOverview appWindowOverview;
+        Gala.WindowManager wm;
+
+        ~Main() {
+            appWindowOverview = null;
+            wm = null;
+        }
+
+        public override void initialize (Gala.WindowManager wm) {
+            this.wm = wm;
+#if HAS_MUTTER330
+            var display = wm.get_display ();
+#else
+            var display = wm.get_screen ().get_display ();
+#endif
+            Meta.KeyBinding.set_custom_handler("set-spew-mark", handle_switch_windows);
+#if HAS_MUTTER330
+            unowned Meta.Display display = wm.get_display ();
+#else
+            var screen = wm.get_screen ();
+#endif
+            appWindowOverview = new Gala.AppWindowOverview (wm);
+            wm.ui_group.add_child (appWindowOverview);
+        }
+
+        public override void destroy () {
+            if (wm == null) {
+                return;
+            }
+
+#if HAS_MUTTER330
+            var display = wm.get_display ();
+#else
+            var display = wm.get_screen ().get_display ();
+#endif
+
+            display.remove_keybinding ("app-window-overview");
+        }
+
+        void handle_switch_windows (Meta.Display display, Meta.Screen screen,
+            Meta.Window? window,
+            Clutter.KeyEvent? event, Meta.KeyBinding binding) {
+            if (appWindowOverview.is_opened ()) {
+                appWindowOverview.close ();
+            } else {
+                appWindowOverview.open ();
+            }
+        }
+    }
+}
+
+public Gala.PluginInfo register_plugin () {
+    return Gala.PluginInfo () {
+        name = "App windows",
+        author = "Jack Darlington",
+        plugin_type = typeof (Gala.Plugins.AppWindowOverview.Main),
+        provides = Gala.PluginFunction.ADDITION,
+        load_priority = Gala.LoadPriority.IMMEDIATE
+    };
+}

--- a/plugins/app-windows/meson.build
+++ b/plugins/app-windows/meson.build
@@ -1,0 +1,14 @@
+gala_app_windows_sources = [
+	'Main.vala',
+	'AppWindowOverview.vala'
+]
+
+gala_app_windows_lib = shared_library(
+	'gala-app-windows',
+	gala_app_windows_sources,
+	dependencies: [gala_bin_lib_dep, gala_dep, gala_base_dep],
+	include_directories: config_inc_dir,
+	install: true,
+	install_dir: plugins_dir,
+	install_rpath: mutter_typelib_dir,
+)

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -120,8 +120,8 @@ namespace Gala {
 #endif
 
             foreach (var background in backgrounds) {
-                background.changed.disconnect (background_changed);
-                background.destroy ();
+                background.value.changed.disconnect (background_changed);
+                background.value.destroy ();
             }
         }
 

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -119,9 +119,9 @@ namespace Gala {
             screen.monitors_changed.disconnect (monitors_changed);
 #endif
 
-            foreach (var background in backgrounds) {
-                background.value.changed.disconnect (background_changed);
-                background.value.destroy ();
+            foreach (var background in backgrounds.values) {
+                background.changed.disconnect (background_changed);
+                background.destroy ();
             }
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -47,3 +47,15 @@ gala_bin = executable(
 	install_rpath: mutter_typelib_dir,
 	install: true,
 )
+
+gala_bin_lib = shared_library(
+	'gala-bin-lib',
+	gala_bin_sources,
+	dependencies: [gala_dep, gala_base_dep],
+	include_directories: [config_inc_dir],
+	install: true,
+	install_dir: [true, join_paths(get_option('includedir'), 'gala'), true],
+	install_rpath: mutter_typelib_dir
+)
+
+gala_bin_lib_dep = declare_dependency(link_with: [gala_bin_lib], include_directories: include_directories('.'))


### PR DESCRIPTION
Changes to have OSX functionality of showing windows that match current application as well as existing that shows all windows open.

I created as a plugin for now, so didn't need to recompile and install gala on my machine. But ultimately, would be best if I subclassed WindowOverview, and then just override the 1 bit I need to cut down on code changes.

Let me know if there is anything I can do.

I have tested, and works as expected for me

Cheers

Jack