### PR TITLE
ScreenShield: Use async versions of Bus.get_proxy

### DIFF
--- a/src/Widgets/ScreenShield.vala
+++ b/src/Widgets/ScreenShield.vala
@@ -136,11 +136,15 @@ namespace Gala {
 
             expand_to_screen_size ();
 
+            init_dbus_interfaces.begin ();
+        }
+
+        private async void init_dbus_interfaces () {
             bool success = true;
 
             try {
-                login_manager = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
-                login_user_manager = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1/user/self");
+                login_manager = yield Bus.get_proxy (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1");
+                login_user_manager = yield Bus.get_proxy (BusType.SYSTEM, "org.freedesktop.login1", "/org/freedesktop/login1/user/self");
 
                 // Listen for sleep/resume events from logind
                 login_manager.prepare_for_sleep.connect (prepare_for_sleep);
@@ -162,7 +166,7 @@ namespace Gala {
             }
 
             try {
-                session_presence = Bus.get_proxy_sync (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager/Presence");
+                session_presence = yield Bus.get_proxy (BusType.SESSION, "org.gnome.SessionManager", "/org/gnome/SessionManager/Presence");
                 on_status_changed (session_presence.status);
                 session_presence.status_changed.connect ((status) => on_status_changed (status));
             } catch (Error e) {
@@ -174,7 +178,7 @@ namespace Gala {
             string? seat_path = GLib.Environment.get_variable ("XDG_SEAT_PATH");
             if (seat_path != null) {
                 try {
-                    display_manager = Bus.get_proxy_sync (BusType.SYSTEM, "org.freedesktop.DisplayManager", seat_path);
+                    display_manager = yield Bus.get_proxy (BusType.SYSTEM, "org.freedesktop.DisplayManager", seat_path);
                 } catch (Error e) {
                     success = false;
                     critical ("Unable to connect to display manager bus, screen locking disabled");


### PR DESCRIPTION
This class' constructor is on the critical path of Gala starting up, so we should use the async versions of these methods. There are already checks in place that the interfaces are ready before using them in all the other methods.