### PR TITLE
AppCache: Rebuild in a thread

### DIFF
--- a/lib/AppCache.vala
+++ b/lib/AppCache.vala
@@ -65,8 +65,8 @@ public class Gala.AppCache : GLib.Object {
                 var app_infos = GLib.AppInfo.get_all ();
 
                 foreach (unowned GLib.AppInfo app in app_infos) {
-                    var id = app.get_id ();
-                    var startup_wm_class = ((GLib.DesktopAppInfo)app).get_startup_wm_class ();
+                    unowned string id = app.get_id ();
+                    unowned string? startup_wm_class = ((GLib.DesktopAppInfo)app).get_startup_wm_class ();
 
                     id_to_app[id] = (GLib.DesktopAppInfo)app;
 


### PR DESCRIPTION
This class is initialized in a static constructor so its in the critical path of Gala starting up. There isn't an async version of `GLib.AppInfo.get_all` and it's an I/O heavy operation that enumerates the desktop files on the system, so we should move this out of the main compositor thread.