### PR TITLE
Fix #1018: Align multi-touch animations to physical pixels

### DIFF
--- a/src/GestureAnimationDirector.vala
+++ b/src/GestureAnimationDirector.vala
@@ -96,8 +96,15 @@ public class Gala.GestureAnimationDirector : Object {
         handlers.clear ();
     }
 
-    public static float animation_value (float initial_value, float target_value, int percentage) {
-        return (((target_value - initial_value) * percentage) / 100) + initial_value;
+    public static float animation_value (float initial_value, float target_value, int percentage, bool rounded = false) {
+        float value = (((target_value - initial_value) * percentage) / 100) + initial_value;
+
+        if (rounded) {
+            var scale_factor = InternalUtils.get_ui_scaling_factor ();
+            value = (float) Math.round (value * scale_factor) / scale_factor;
+        }
+
+        return value;
     }
 
     public void update_animation (HashTable<string,Variant> hints) {

--- a/src/GestureAnimationDirector.vala
+++ b/src/GestureAnimationDirector.vala
@@ -96,6 +96,18 @@ public class Gala.GestureAnimationDirector : Object {
         handlers.clear ();
     }
 
+    /**
+     * Utility method to calculate the current animation value based on the percentage of the
+     * gesture performed.
+     * Animations are always linear, as they are 1:1 to the user's movement.
+     * @param initial_value Animation start value.
+     * @param target_value Animation end value.
+     * @param percentage Current animation percentage.
+     * @param rounded If the returned value should be rounded to match physical pixels.
+     * Default to false because some animations, like for example scaling an actor, use intermediate
+     * values not divisible by physical pixels.
+     * @returns The linear animation value at the specified percentage.
+     */
     public static float animation_value (float initial_value, float target_value, int percentage, bool rounded = false) {
         float value = (((target_value - initial_value) * percentage) / 100) + initial_value;
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -499,7 +499,7 @@ namespace Gala {
             var dest = (direction == Meta.MotionDirection.LEFT ? 32.0f : -32.0f);
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {
-                var x = GestureAnimationDirector.animation_value (0.0f, dest, percentage);
+                var x = GestureAnimationDirector.animation_value (0.0f, dest, percentage, true);
                 ui_group.x = x;
             };
 
@@ -1890,8 +1890,8 @@ namespace Gala {
             var animation_mode = Clutter.AnimationMode.EASE_OUT_CUBIC;
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {
-                var x_out = GestureAnimationDirector.animation_value (0.1f, x2, percentage);
-                var x_in = GestureAnimationDirector.animation_value (-x2, 0.1f, percentage);
+                var x_out = GestureAnimationDirector.animation_value (0.1f, x2, percentage, true);
+                var x_in = GestureAnimationDirector.animation_value (-x2, 0.1f, percentage, true);
 
                 out_group.x = x_out;
                 in_group.x = x_in;


### PR DESCRIPTION
Allow to align the switch workspace animation to physical pixels.

With the current master it is not easy to notice the difference, it is easier to test with https://github.com/elementary/gala/pull/1017

With LoDPI displays, the values returned by `GestureAnimationDirector.animation_value` are integers (0, 1, 2, 3...)
With HiDPI displays, let's say that the scale factor is 2, values will be 0, 0.5, 1, 1.5...

If I understood how scaling works in Gala those should be the right values on HiDPI. However, I don't have a HiDPI display to test this, so I'd appreciate your help testing it for me :smile: 

Fix https://github.com/elementary/gala/issues/1018