### PR TITLE
Don't move to next workspace when maximizing a window on secondary monitor

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1620,7 +1620,7 @@ namespace Gala {
             }
 
             // Do nothing if window is not on primary monitor
-            if (!window.is_on_primary_monitor()) {
+            if (!window.is_on_primary_monitor ()) {
                 return;
             }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1619,6 +1619,11 @@ namespace Gala {
                 return;
             }
 
+            // Do nothing if window is not on primary monitor
+            if (!window.is_on_primary_monitor()) {
+                return;
+            }
+
             var old_ws_index = win_ws.index ();
             var new_ws_index = old_ws_index + 1;
             InternalUtils.insert_workspace_with_window (new_ws_index, window);


### PR DESCRIPTION
If you are on a multi-monitor setup, maximizing a window on a secondary monitor causes the workspaces on the primary monitor to  move to the next one, even though the maximized window is not moving. I'm just adding a check on `move_window_to_next_ws ()` to ensure that the window is on the primary monitor before doing any other checks