### PR TITLE
Calculate notification width dynamically

### DIFF
--- a/src/NotificationStack.vala
+++ b/src/NotificationStack.vala
@@ -28,7 +28,6 @@ public class Gala.NotificationStack : Object {
 
     private const int WIDTH = 300;
 
-    private int stack_x;
     private int stack_y;
     private int stack_width;
 
@@ -84,7 +83,12 @@ public class Gala.NotificationStack : Object {
          */
         update_positions (animate, notification.height);
 
-        move_window (notification, stack_x, stack_y + TOP_OFFSET + ADDITIONAL_MARGIN * scale);
+        var primary = display.get_primary_monitor ();
+        var area = display.get_workspace_manager ().get_active_workspace ().get_work_area_for_monitor (primary);
+
+        int notification_x_pos = area.width - window.get_frame_rect ().width;
+
+        move_window (notification, notification_x_pos, stack_y + TOP_OFFSET + ADDITIONAL_MARGIN * scale);
         notifications.insert (0, notification);
     }
 
@@ -95,7 +99,6 @@ public class Gala.NotificationStack : Object {
         var scale = Utils.get_ui_scaling_factor ();
         stack_width = (WIDTH + MARGIN) * scale;
 
-        stack_x = area.x + area.width - stack_width;
         stack_y = area.y;
     }
 
@@ -147,7 +150,7 @@ public class Gala.NotificationStack : Object {
     /**
      * This function takes care of properly updating both the actor
      * position and the actual window position.
-     * 
+     *
      * To enable animations for a window we first need to move it's frame
      * in the compositor and then calculate & apply the coordinates for the window
      * actor.

--- a/src/NotificationStack.vala
+++ b/src/NotificationStack.vala
@@ -86,7 +86,7 @@ public class Gala.NotificationStack : Object {
         var primary = display.get_primary_monitor ();
         var area = display.get_workspace_manager ().get_active_workspace ().get_work_area_for_monitor (primary);
 
-        int notification_x_pos = area.width - window.get_frame_rect ().width;
+        int notification_x_pos = area.x + area.width - window.get_frame_rect ().width;
 
         move_window (notification, notification_x_pos, stack_y + TOP_OFFSET + ADDITIONAL_MARGIN * scale);
         notifications.insert (0, notification);


### PR DESCRIPTION
Fixes #821 

Instead of using a constant value for the notification width, lets calculate it based on the resolution of the monitor and the width of the notification.