### PR TITLE
Faster workspace switch animation when using keyboard shortcuts

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -248,7 +248,7 @@ namespace Gala {
                 workspace_clone.restore_easing_state ();
             }
 
-            workspaces.set_easing_duration (animate ? AnimationDuration.WORKSPACE_SWITCH : 0);
+            workspaces.set_easing_duration (animate ? AnimationDuration.WORKSPACE_SWITCH_MIN : 0);
             workspaces.x = -active_x;
 
             reposition_icon_groups (animate);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1913,7 +1913,7 @@ namespace Gala {
 
                 int duration = gesture_animation_director.running
                     ? calculated_duration
-                    : AnimationDuration.WORKSPACE_SWITCH;
+                    : AnimationDuration.WORKSPACE_SWITCH_MIN;
                 animating_switch_workspace = true;
 
                 out_group.set_easing_mode (animation_mode);


### PR DESCRIPTION
Restore the default workspace switch animation time.

The animation was incremented to 400 ms and it should be 300 ms if we want to be consistent with stable.