### PR TITLE
Multitasking view 1:1 switch desktop animation with scroll events

### DIFF
--- a/lib/Constants.vala
+++ b/lib/Constants.vala
@@ -31,5 +31,7 @@ namespace Gala {
         // Duration of the workspace switch animation
         WORKSPACE_SWITCH_MIN = 300,
         WORKSPACE_SWITCH = 400,
+        // Duration of the nudge animation when trying to switch to at the end of the workspace list
+        NUDGE = 360,
     }
 }

--- a/src/GestureAnimationDirector.vala
+++ b/src/GestureAnimationDirector.vala
@@ -67,7 +67,7 @@ public class Gala.GestureAnimationDirector : Object {
         velocity = 0;
     }
 
-    public GestureAnimationDirector(int min_animation_duration, int max_animation_duration) {
+    public GestureAnimationDirector (int min_animation_duration, int max_animation_duration) {
         Object (min_animation_duration: min_animation_duration, max_animation_duration: max_animation_duration);
     }
 

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -17,13 +17,6 @@
  */
 
 namespace Gala {
-    public enum GestureType {
-        NOT_SUPPORTED = 0,
-        SWIPE = 1,
-        PINCH = 2,
-        SCROLL,
-    }
-
     public enum GestureDirection {
         UNKNOWN = 0,
 
@@ -38,16 +31,10 @@ namespace Gala {
         OUT = 6,
     }
 
-    public enum DeviceType {
-        UNKNOWN = 0,
-        TOUCHPAD = 1,
-        TOUCHSCREEN = 2,
-    }
-
     public class Gesture {
-        public GestureType type;
+        public Gdk.EventType type;
         public GestureDirection direction;
         public int fingers;
-        public DeviceType performed_on_device_type;
+        public Gdk.InputSource performed_on_device_type;
     }
 }

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 elementary, Inc (https://elementary.io)
+ *           2020 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Gala {
+    public enum GestureType {
+        NOT_SUPPORTED = 0,
+        SWIPE = 1,
+        PINCH = 2,
+        SCROLL,
+    }
+
+    public enum GestureDirection {
+        UNKNOWN = 0,
+
+        // GestureType.SWIPE and GestureType.SCROLL
+        UP = 1,
+        DOWN = 2,
+        LEFT = 3,
+        RIGHT = 4,
+
+        // GestureType.PINCH
+        IN = 5,
+        OUT = 6,
+    }
+
+    public enum DeviceType {
+        UNKNOWN = 0,
+        TOUCHPAD = 1,
+        TOUCHSCREEN = 2,
+    }
+
+    public class Gesture {
+        public GestureType type;
+        public GestureDirection direction;
+        public int fingers;
+        public DeviceType performed_on_device_type;
+    }
+}

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2020 elementary, Inc (https://elementary.io)
- *           2020 José Expósito <jose.exposito89@gmail.com>
+ * Copyright 2021 elementary, Inc (https://elementary.io)
+ *           2021 José Expósito <jose.exposito89@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -34,8 +34,8 @@ public class Gala.GestureSettings : Object {
         touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
     }
 
-    public bool is_natural_scroll_enabled (DeviceType device_type) {
-        return (device_type == DeviceType.TOUCHSCREEN)
+    public bool is_natural_scroll_enabled (Gdk.InputSource device_type) {
+        return (device_type == Gdk.InputSource.TOUCHSCREEN)
             ? true
             : touchpad_settings.get_boolean ("natural-scroll");
     }

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 elementary, Inc (https://elementary.io)
+ *           2021 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Utility class to access the gesture settings. Easily accessible through GestureTracker.settings.
+ */
+public class Gala.GestureSettings : Object {
+    private static GLib.Settings gala_settings;
+    private static GLib.Settings touchpad_settings;
+
+    public const string MULTITASKING_ENABLED = "multitasking-gesture-enabled";
+    public const string MULTITASKING_FINGERS = "multitasking-gesture-fingers";
+
+    public const string WORKSPACE_ENABLED = "workspaces-gesture-enabled";
+    public const string WORKSPACE_FINGERS = "workspaces-gesture-fingers";
+
+    static construct {
+        gala_settings = new GLib.Settings ("io.elementary.desktop.wm.gestures");
+        touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
+    }
+
+    public bool is_natural_scroll_enabled (DeviceType device_type) {
+        return (device_type == DeviceType.TOUCHSCREEN)
+            ? true
+            : touchpad_settings.get_boolean ("natural-scroll");
+    }
+
+    public bool is_gesture_enabled (string setting_id) {
+        return gala_settings.get_boolean (setting_id);
+    }
+
+    public int gesture_fingers (string setting_id) {
+        return gala_settings.get_int (setting_id);
+    }
+}

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2021 elementary, Inc (https://elementary.io)
+ *           2021 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ public class Gala.GestureTracker : Object {
+    /**
+     * Percentage of the animation to be completed to apply the action.
+     */
+    private const int SUCCESS_PERCENTAGE_THRESHOLD = 20;
+
+    /**
+     * When a gesture ends with a velocity greater than this constant, the action is not cancelled,
+     * even if the animation threshold has not been reached.
+     */
+    private const double SUCCESS_VELOCITY_THRESHOLD = 0.3;
+
+    /**
+     * When a gesture ends with less velocity that this constant, this velocity is used instead.
+     */
+    private const double ANIMATION_BASE_VELOCITY = 0.002;
+
+    /**
+     * Maximum velocity allowed on gesture update.
+     */
+    private const double MAX_VELOCITY = 0.5;
+
+    public Clutter.Actor actor { get; construct; }
+    public int min_animation_duration { get; construct; }
+    public int max_animation_duration { get; construct; }
+
+    public bool running { get; set; default = false; }
+    public bool canceling { get; set; default = false; }
+
+    public signal void on_animation_begin (double percentage);
+    public signal void on_animation_update (double percentage);
+    public signal void on_animation_end (double percentage, bool cancel_action, int calculated_duration);
+
+    public delegate void OnBegin (double percentage);
+    public delegate void OnUpdate (double percentage);
+    public delegate void OnEnd (double percentage, bool cancel_action, int calculated_duration);
+
+    private ScrollBackend scroll_backend;
+
+    private Gee.ArrayList<ulong> handlers;
+
+    private double previous_percentage;
+    private uint64 previous_time;
+    private double percentage_delta;
+    private double velocity;
+
+    construct {
+        handlers = new Gee.ArrayList<ulong> ();
+        previous_percentage = 0;
+        previous_time = 0;
+        percentage_delta = 0;
+        velocity = 0;
+    }
+
+    public GestureTracker (Clutter.Actor actor, int min_animation_duration, int max_animation_duration, Clutter.Orientation orientation) {
+        Object (actor: actor, min_animation_duration: min_animation_duration,
+            max_animation_duration: max_animation_duration);
+
+        // TODO Use the scroll backend only if required (pass a config or something)
+        scroll_backend = new ScrollBackend (actor, orientation);
+        scroll_backend.on_begin.connect (update_animation_begin);
+        scroll_backend.on_update.connect (update_animation_update);
+        scroll_backend.on_end.connect (update_animation_end);
+    }
+
+    public void connect_handlers (owned OnBegin? on_begin, owned OnUpdate? on_update, owned OnEnd? on_end) {
+        if (on_begin != null) {
+            ulong handler_id = on_animation_begin.connect ((percentage) => on_begin (percentage));
+            handlers.add (handler_id);
+        }
+
+        if (on_update != null) {
+            ulong handler_id = on_animation_update.connect ((percentage) => on_update (percentage));
+            handlers.add (handler_id);
+        }
+
+        if (on_end != null) {
+            ulong handler_id = on_animation_end.connect ((percentage, cancel_action, duration) => on_end (percentage, cancel_action, duration));
+            handlers.add (handler_id);
+        }
+    }
+
+    public void disconnect_all_handlers () {
+        foreach (var handler in handlers) {
+            disconnect (handler);
+        }
+
+        handlers.clear ();
+    }
+
+    /**
+     * Utility method to calculate the current animation value based on the percentage of the
+     * gesture performed.
+     * Animations are always linear, as they are 1:1 to the user's movement.
+     * @param initial_value Animation start value.
+     * @param target_value Animation end value.
+     * @param percentage Current animation percentage.
+     * @param rounded If the returned value should be rounded to match physical pixels.
+     * Default to false because some animations, like for example scaling an actor, use intermediate
+     * values not divisible by physical pixels.
+     * @returns The linear animation value at the specified percentage.
+     */
+    public static float animation_value (float initial_value, float target_value, double percentage, bool rounded = false) {
+        float value = (((target_value - initial_value) * (float) percentage) / 100) + initial_value;
+
+        if (rounded) {
+            var scale_factor = InternalUtils.get_ui_scaling_factor ();
+            value = (float) Math.round (value * scale_factor) / scale_factor;
+        }
+
+        return value;
+    }
+
+    public void update_animation (HashTable<string,Variant> hints) {
+        string event = hints.get ("event").get_string ();
+        double percentage = hints.get ("percentage").get_double ();
+        uint64 elapsed_time = hints.get ("elapsed_time").get_uint64 ();
+
+        switch (event) {
+            case "begin":
+                update_animation_begin (percentage, elapsed_time);
+                break;
+            case "update":
+                update_animation_update (percentage, elapsed_time);
+                break;
+            case "end":
+            default:
+                update_animation_end (percentage, elapsed_time);
+                break;
+        }
+    }
+
+    private void update_animation_begin (double percentage, uint64 elapsed_time) {
+        debug (@"################ BEGIN: $(percentage) $(elapsed_time)");
+
+        on_animation_begin (percentage);
+
+        previous_percentage = percentage;
+        previous_time = elapsed_time;
+    }
+
+    private void update_animation_update (double percentage, uint64 elapsed_time) {
+        debug (@"################ UPDATE: $(percentage) $(elapsed_time)");
+
+        if (elapsed_time != previous_time) {
+            double distance = percentage - previous_percentage;
+            double time = (double)(elapsed_time - previous_time);
+            velocity = (distance / time);
+
+            if (velocity > MAX_VELOCITY) {
+                velocity = MAX_VELOCITY;
+                var used_percentage = MAX_VELOCITY * time + previous_percentage;
+                percentage_delta += percentage - used_percentage;
+            }
+        }
+
+        on_animation_update (applied_percentage (percentage, percentage_delta));
+
+        previous_percentage = percentage;
+        previous_time = elapsed_time;
+    }
+
+    private void update_animation_end (double percentage, uint64 elapsed_time) {
+        debug (@"################ END: $(percentage) $(elapsed_time)");
+
+        double end_percentage = applied_percentage (percentage, percentage_delta);
+        bool cancel_action = (end_percentage < SUCCESS_PERCENTAGE_THRESHOLD)
+            && ((end_percentage <= previous_percentage) && (velocity < SUCCESS_VELOCITY_THRESHOLD));
+        int calculated_duration = calculate_end_animation_duration (end_percentage, cancel_action);
+
+        on_animation_end (end_percentage, cancel_action, calculated_duration);
+
+        previous_percentage = 0;
+        previous_time = 0;
+        percentage_delta = 0;
+        velocity = 0;
+    }
+
+    private static double applied_percentage (double percentage, double percentage_delta) {
+        return (percentage - percentage_delta).clamp (0, 100);
+    }
+
+    /**
+     * Calculates the end animation duration using the current gesture velocity.
+     */
+    private int calculate_end_animation_duration (double end_percentage, bool cancel_action) {
+        double animation_velocity = (velocity > ANIMATION_BASE_VELOCITY)
+            ? velocity
+            : ANIMATION_BASE_VELOCITY;
+
+        double pending_percentage = cancel_action ? end_percentage : 100 - end_percentage;
+
+        int duration = ((int)(pending_percentage / animation_velocity).abs ())
+            .clamp (min_animation_duration, max_animation_duration);
+        return duration;
+    }
+ }

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -16,6 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Allow to use multi-touch gestures from different sources (backends).
+ * Usage:
+ * - Create a new instance of the class
+ * - Use the enable_* methods to enable different backends
+ * - Connect the on_gesture_detected to your code
+ * - When on_gesture_detected is emitted, if you want to handle the gesture, call connect_handlers
+ *   to start receiving events
+ * - on_begin will be emitted once right after on_gesture_detected
+ * - on_update will be emitted 0 or more times
+ * - on_end will be emitted once when the gesture end
+ * - When on_end is emitted, the handler connected with connect_handlers will be automatically
+ *   disconnected and you will only receive on_gesture_detected signals
+ * - The enabled flag is usually disabled on_end and re-enabled once the end animation finish. In
+ *   this way, new gestures are not received while animating
+ */
 public class Gala.GestureTracker : Object {
     /**
      * Percentage of the animation to be completed to apply the action.
@@ -26,7 +42,7 @@ public class Gala.GestureTracker : Object {
      * When a gesture ends with a velocity greater than this constant, the action is not cancelled,
      * even if the animation threshold has not been reached.
      */
-    private const double SUCCESS_VELOCITY_THRESHOLD = 0.3;
+    private const double SUCCESS_VELOCITY_THRESHOLD = 0.003;
 
     /**
      * When a gesture ends with less velocity that this constant, this velocity is used instead.
@@ -36,23 +52,56 @@ public class Gala.GestureTracker : Object {
     /**
      * Maximum velocity allowed on gesture update.
      */
-    private const double MAX_VELOCITY = 0.5;
+    private const double MAX_VELOCITY = 0.01;
+
+    /**
+     * Multiplier used to match libhandy's animation duration.
+     */
+    private const int DURATION_MULTIPLIER = 3;
 
     public int min_animation_duration { get; construct; }
     public int max_animation_duration { get; construct; }
 
-    public bool running { get; set; default = false; }
-    public bool canceling { get; set; default = false; }
-    
+    /**
+     * Property to control when event signals are emitted or not.
+     */
+    public bool enabled { get; set; default = true; }
+
+
+    /**
+     * Emitted when a new gesture is detected.
+     * If the receiving code needs to handle this gesture, it should call to connect_handlers to
+     * start receiving updates.
+     * @param gesture Information about the gesture.
+     */
     public signal void on_gesture_detected (Gesture gesture);
-    public signal void on_animation_begin (double percentage);
-    public signal void on_animation_update (double percentage);
-    public signal void on_animation_end (double percentage, bool cancel_action, int calculated_duration);
+
+    /**
+     * Emitted right after on_gesture_detected with the initial gesture information.
+     * @param percentage Value between 0 and 1.
+     */
+    public signal void on_begin (double percentage);
+
+    /**
+     * Called every time the percentage changes.
+     * @param percentage Value between 0 and 1.
+     */
+    public signal void on_update (double percentage);
+
+    /**
+     * @param percentage Value between 0 and 1.
+     * @param cancel_action
+     * @param calculated_duration
+     */
+    public signal void on_end (double percentage, bool cancel_action, int calculated_duration);
 
     public delegate void OnBegin (double percentage);
     public delegate void OnUpdate (double percentage);
     public delegate void OnEnd (double percentage, bool cancel_action, int calculated_duration);
 
+    /**
+     * Scroll backend used if enable_scroll is called.
+     */
     private ScrollBackend scroll_backend;
 
     private Gee.ArrayList<ulong> handlers;
@@ -81,30 +130,30 @@ public class Gala.GestureTracker : Object {
      */
     public void enable_scroll (Clutter.Actor actor, Clutter.Orientation orientation) {
         scroll_backend = new ScrollBackend (actor, orientation);
-        scroll_backend.on_gesture_detected.connect ((gesture) => on_gesture_detected(gesture));
-        scroll_backend.on_begin.connect (update_animation_begin);
-        scroll_backend.on_update.connect (update_animation_update);
-        scroll_backend.on_end.connect (update_animation_end);
+        scroll_backend.on_gesture_detected.connect (gesture_detected);
+        scroll_backend.on_begin.connect (gesture_begin);
+        scroll_backend.on_update.connect (gesture_update);
+        scroll_backend.on_end.connect (gesture_end);
     }
 
-    public void connect_handlers (owned OnBegin? on_begin, owned OnUpdate? on_update, owned OnEnd? on_end) {
-        if (on_begin != null) {
-            ulong handler_id = on_animation_begin.connect ((percentage) => on_begin (percentage));
+    public void connect_handlers (owned OnBegin? on_begin_handler, owned OnUpdate? on_update_handler, owned OnEnd? on_end_handler) {
+        if (on_begin_handler != null) {
+            ulong handler_id = on_begin.connect ((percentage) => on_begin_handler (percentage));
             handlers.add (handler_id);
         }
 
-        if (on_update != null) {
-            ulong handler_id = on_animation_update.connect ((percentage) => on_update (percentage));
+        if (on_update_handler != null) {
+            ulong handler_id = on_update.connect ((percentage) => on_update_handler (percentage));
             handlers.add (handler_id);
         }
 
-        if (on_end != null) {
-            ulong handler_id = on_animation_end.connect ((percentage, cancel_action, duration) => on_end (percentage, cancel_action, duration));
+        if (on_end_handler != null) {
+            ulong handler_id = on_end.connect ((percentage, cancel_action, duration) => on_end_handler (percentage, cancel_action, duration));
             handlers.add (handler_id);
         }
     }
 
-    public void disconnect_all_handlers () {
+    private void disconnect_all_handlers () {
         foreach (var handler in handlers) {
             disconnect (handler);
         }
@@ -135,14 +184,30 @@ public class Gala.GestureTracker : Object {
         return value;
     }
 
-    private void update_animation_begin (double percentage, uint64 elapsed_time) {
-        on_animation_begin (percentage);
+    private void gesture_detected (Gesture gesture) {
+        if (!enabled) {
+            return;
+        }
+
+        on_gesture_detected (gesture);
+    }
+
+    private void gesture_begin (double percentage, uint64 elapsed_time) {
+        if (!enabled) {
+            return;
+        }
+
+        on_begin (percentage);
 
         previous_percentage = percentage;
         previous_time = elapsed_time;
     }
 
-    private void update_animation_update (double percentage, uint64 elapsed_time) {
+    private void gesture_update (double percentage, uint64 elapsed_time) {
+        if (!enabled) {
+            return;
+        }
+
         if (elapsed_time != previous_time) {
             double distance = percentage - previous_percentage;
             double time = (double)(elapsed_time - previous_time);
@@ -155,19 +220,24 @@ public class Gala.GestureTracker : Object {
             }
         }
 
-        on_animation_update (applied_percentage (percentage, percentage_delta));
+        on_update (applied_percentage (percentage, percentage_delta));
 
         previous_percentage = percentage;
         previous_time = elapsed_time;
     }
 
-    private void update_animation_end (double percentage, uint64 elapsed_time) {
+    private void gesture_end (double percentage, uint64 elapsed_time) {
+        if (!enabled) {
+            return;
+        }
+
         double end_percentage = applied_percentage (percentage, percentage_delta);
         bool cancel_action = (end_percentage < SUCCESS_PERCENTAGE_THRESHOLD)
             && ((end_percentage <= previous_percentage) && (velocity < SUCCESS_VELOCITY_THRESHOLD));
         int calculated_duration = calculate_end_animation_duration (end_percentage, cancel_action);
 
-        on_animation_end (end_percentage, cancel_action, calculated_duration);
+        on_end (end_percentage, cancel_action, calculated_duration);
+        disconnect_all_handlers ();
 
         previous_percentage = 0;
         previous_time = 0;
@@ -189,7 +259,7 @@ public class Gala.GestureTracker : Object {
 
         double pending_percentage = cancel_action ? end_percentage : 1 - end_percentage;
 
-        int duration = ((int)(pending_percentage / animation_velocity).abs ())
+        int duration = ((int)(pending_percentage / animation_velocity).abs () * DURATION_MULTIPLIER)
             .clamp (min_animation_duration, max_animation_duration);
         return duration;
     }

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -59,6 +59,7 @@ public class Gala.GestureTracker : Object {
      */
     private const int DURATION_MULTIPLIER = 3;
 
+    public GestureSettings settings { get; construct; }
     public int min_animation_duration { get; construct; }
     public int max_animation_duration { get; construct; }
 
@@ -66,7 +67,6 @@ public class Gala.GestureTracker : Object {
      * Property to control when event signals are emitted or not.
      */
     public bool enabled { get; set; default = true; }
-
 
     /**
      * Emitted when a new gesture is detected.
@@ -112,6 +112,8 @@ public class Gala.GestureTracker : Object {
     private double velocity;
 
     construct {
+        settings = new GestureSettings ();
+
         handlers = new Gee.ArrayList<ulong> ();
         previous_percentage = 0;
         previous_time = 0;

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- public class Gala.GestureTracker : Object {
+public class Gala.GestureTracker : Object {
     /**
      * Percentage of the animation to be completed to apply the action.
      */
@@ -38,7 +38,6 @@
      */
     private const double MAX_VELOCITY = 0.5;
 
-    public Clutter.Actor actor { get; construct; }
     public int min_animation_duration { get; construct; }
     public int max_animation_duration { get; construct; }
 
@@ -71,11 +70,16 @@
         velocity = 0;
     }
 
-    public GestureTracker (Clutter.Actor actor, int min_animation_duration, int max_animation_duration, Clutter.Orientation orientation) {
-        Object (actor: actor, min_animation_duration: min_animation_duration,
-            max_animation_duration: max_animation_duration);
+    public GestureTracker (int min_animation_duration, int max_animation_duration) {
+        Object (min_animation_duration: min_animation_duration, max_animation_duration: max_animation_duration);
+    }
 
-        // TODO Use the scroll backend only if required (pass a config or something)
+    /**
+     * Allow to receive scroll gestures.
+     * @param actor Clutter actor that will receive the scroll events.
+     * @param orientation If we are interested in the horizontal or vertical axis.
+     */
+    public void enable_scroll (Clutter.Actor actor, Clutter.Orientation orientation) {
         scroll_backend = new ScrollBackend (actor, orientation);
         scroll_backend.on_gesture_detected.connect ((gesture) => on_gesture_detected(gesture));
         scroll_backend.on_begin.connect (update_animation_begin);
@@ -129,25 +133,6 @@
         }
 
         return value;
-    }
-
-    public void update_animation (HashTable<string,Variant> hints) {
-        string event = hints.get ("event").get_string ();
-        double percentage = hints.get ("percentage").get_double ();
-        uint64 elapsed_time = hints.get ("elapsed_time").get_uint64 ();
-
-        switch (event) {
-            case "begin":
-                update_animation_begin (percentage, elapsed_time);
-                break;
-            case "update":
-                update_animation_update (percentage, elapsed_time);
-                break;
-            case "end":
-            default:
-                update_animation_end (percentage, elapsed_time);
-                break;
-        }
     }
 
     private void update_animation_begin (double percentage, uint64 elapsed_time) {

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -104,10 +104,10 @@ public class Gala.ScrollBackend : Object {
         }
 
         return new Gesture () {
-            type = GestureType.SCROLL,
+            type = Gdk.EventType.SCROLL,
             direction = direction,
             fingers = 2,
-            performed_on_device_type = DeviceType.TOUCHPAD
+            performed_on_device_type = Gdk.InputSource.TOUCHPAD
         };
     }
 

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -47,9 +47,9 @@ public class Gala.ScrollBackend : Object {
     }
 
     public ScrollBackend (Clutter.Actor actor, Clutter.Orientation orientation) {
-        Object(actor: actor, orientation: orientation);
+        Object (actor: actor, orientation: orientation);
 
-        actor.scroll_event.connect(on_scroll_event);
+        actor.scroll_event.connect (on_scroll_event);
     }
 
     private bool on_scroll_event (Clutter.ScrollEvent event) {
@@ -102,7 +102,7 @@ public class Gala.ScrollBackend : Object {
         } else {
             direction = delta_y > 0 ? GestureDirection.DOWN : GestureDirection.UP;
         }
-        
+
         return new Gesture () {
             type = GestureType.SCROLL,
             direction = direction,

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -98,9 +98,9 @@ public class Gala.ScrollBackend : Object {
     private static Gesture build_gesture (double delta_x, double delta_y, Clutter.Orientation orientation) {
         GestureDirection direction;
         if (orientation == Clutter.Orientation.HORIZONTAL) {
-            direction = delta_x > 0 ? GestureDirection.LEFT : GestureDirection.RIGHT;
+            direction = delta_x > 0 ? GestureDirection.RIGHT : GestureDirection.LEFT;
         } else {
-            direction = delta_y > 0 ? GestureDirection.UP : GestureDirection.DOWN;
+            direction = delta_y > 0 ? GestureDirection.DOWN : GestureDirection.UP;
         }
         
         return new Gesture () {
@@ -116,7 +116,7 @@ public class Gala.ScrollBackend : Object {
         double used_delta = is_horizontal ? delta_x : delta_y;
         double finish_delta = is_horizontal ? FINISH_DELTA_HORIZONTAL : FINISH_DELTA_VERTICAL;
 
-        bool is_positive = (direction == GestureDirection.LEFT || direction == GestureDirection.UP);
+        bool is_positive = (direction == GestureDirection.RIGHT || direction == GestureDirection.DOWN);
         double clamp_low = is_positive ? 0 : -1;
         double clamp_high = is_positive ? 1 : 0;
 

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -64,11 +64,12 @@ public class Gala.ScrollBackend : Object {
         uint64 time = event.get_time ();
 
         if (!started) {
-            // TODO The first time the gesture starts the direction is incorrect
-            started = true;
-            Gesture gesture = build_gesture (delta_x, delta_y, orientation);
-            on_gesture_detected (gesture);
-            on_begin (delta, time);
+            if (delta_x != 0 || delta_y != 0) {
+                started = true;
+                Gesture gesture = build_gesture (delta_x, delta_y, orientation);
+                on_gesture_detected (gesture);
+                on_begin (delta, time);
+            }
         } else if (x == 0 && y == 0) {
             started = false;
             delta_x = 0;
@@ -102,7 +103,7 @@ public class Gala.ScrollBackend : Object {
     private static Gesture build_gesture (double delta_x, double delta_y, Clutter.Orientation orientation) {
         GestureDirection direction;
         if (orientation == Clutter.Orientation.HORIZONTAL) {
-            direction = delta_x > 0 ? GestureDirection.RIGHT : GestureDirection.LEFT;
+            direction = delta_x > 0 ? GestureDirection.LEFT : GestureDirection.RIGHT;
         } else {
             direction = delta_y > 0 ? GestureDirection.UP : GestureDirection.DOWN;
         }

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 elementary, Inc (https://elementary.io)
+ *           2021 José Expósito <jose.exposito89@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This gesture backend transforms the touchpad scroll events received by an actor into gestures.
+ */
+public class Gala.ScrollBackend : Object {
+    // Mutter does not expose the size of the touchpad, so we use the same values as GTK apps.
+    // From GNOME Shell, TOUCHPAD_BASE_[WIDTH|HEIGHT] / SCROLL_MULTIPLIER
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/master/js/ui/swipeTracker.js
+    private const double FINISH_DELTA_HORIZONTAL = 40;
+    private const double FINISH_DELTA_VERTICAL = 30;
+
+    public signal void on_begin (double delta, uint64 time);
+    public signal void on_update (double delta, uint64 time);
+    public signal void on_end (double delta, uint64 time);
+
+    public Clutter.Actor actor { get; construct; }
+    public Clutter.Orientation orientation { get; construct; }
+
+    private bool started;
+    private double delta_x;
+    private double delta_y;
+
+    construct {
+        started = false;
+        delta_x = 0;
+        delta_y = 0;
+    }
+
+    public ScrollBackend (Clutter.Actor actor, Clutter.Orientation orientation) {
+        Object(actor: actor, orientation: orientation);
+
+        actor.scroll_event.connect(on_scroll_event);
+    }
+
+    private bool on_scroll_event (Clutter.ScrollEvent event) {
+        if (!can_handle_event (event)) {
+            return false;
+        }
+
+        double x, y;
+        event.get_scroll_delta (out x, out y);
+        delta_x += x;
+        delta_y += y;
+
+        double delta = calculate_delta (delta_x, delta_y, orientation);
+        uint64 time = event.get_time ();
+
+        if (!started) {
+            started = true;            
+            on_begin (delta, time);
+        } else if (x == 0 && y == 0) {
+            started = false;
+            delta_x = 0;
+            delta_y = 0;
+            on_end (delta, time);
+        } else {
+            on_update (delta, time);
+        }
+
+        return true;
+    }
+
+    private static bool can_handle_event (Clutter.ScrollEvent event) {
+        return event.get_type () == Clutter.EventType.SCROLL
+            && event.get_source_device ().get_device_type () == Clutter.InputDeviceType.TOUCHPAD_DEVICE
+            && event.get_scroll_direction () == Clutter.ScrollDirection.SMOOTH;
+    }
+
+    private static double calculate_delta (double delta_x, double delta_y, Clutter.Orientation orientation) {
+        double used_delta = (orientation == Clutter.Orientation.HORIZONTAL)
+            ? delta_x
+            : delta_y;
+        double finish_delta = (orientation == Clutter.Orientation.HORIZONTAL)
+            ? FINISH_DELTA_HORIZONTAL
+            : FINISH_DELTA_VERTICAL;
+        double normalized_delta = (used_delta / finish_delta).clamp (-1, 1);
+        return normalized_delta;
+    }
+}

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -213,9 +213,6 @@ namespace Gala {
         }
 
         private void switch_workspace_with_gesture (Meta.MotionDirection direction) {
-            // TODO Move this duration to a constant an share it with wm.play_nudge_animation
-            int NUDGE_ANIMATION_DURATION = 360;
-
             unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
             var num_workspaces = manager.get_n_workspaces ();
             var active_workspace_index = manager.get_active_workspace ().index ();
@@ -259,7 +256,7 @@ namespace Gala {
             GestureAnimationDirector.OnEnd on_animation_end = (percentage, cancel_action, calculated_duration) => {
                 gesture_tracker.enabled = false;
 
-                var duration = is_nudge_animation ? (NUDGE_ANIMATION_DURATION / 2) : calculated_duration;
+                var duration = is_nudge_animation ? (AnimationDuration.NUDGE / 2) : calculated_duration;
                 workspaces.set_easing_duration (duration);
                 workspaces.x = (is_nudge_animation || cancel_action) ? initial_x : target_x;
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -228,7 +228,7 @@ namespace Gala {
                 var nudge_delta = (direction == Meta.MotionDirection.LEFT)
                     ? WindowManagerGala.NUDGE_GAP
                     : -WindowManagerGala.NUDGE_GAP;
-                target_x = initial_x + nudge_delta;
+                target_x = initial_x + nudge_delta * InternalUtils.get_ui_scaling_factor ();
             } else {
                 foreach (var child in workspaces.get_children ()) {
                     unowned WorkspaceClone workspace_clone = (WorkspaceClone) child;

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -225,8 +225,9 @@ namespace Gala {
             bool is_nudge_animation = (target_workspace_index < 0 || target_workspace_index >= num_workspaces);
 
             if (is_nudge_animation) {
-                // TODO Move this to a constant and share it with wm.play_nudge_animation
-                var nudge_delta = (direction == Meta.MotionDirection.LEFT ? 32.0f : -32.0f);
+                var nudge_delta = (direction == Meta.MotionDirection.LEFT) 
+                    ? WindowManagerGala.NUDGE_GAP
+                    : -WindowManagerGala.NUDGE_GAP;
                 target_x = initial_x + nudge_delta;
             } else {
                 foreach (var child in workspaces.get_children ()) {
@@ -248,7 +249,6 @@ namespace Gala {
             debug ("Target X: %f", target_x);
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {
-                // TODO Once https://github.com/elementary/gala/pull/1036 gets merged, apply the same multiplier
                 var x = GestureTracker.animation_value (initial_x, target_x, percentage, true);
                 workspaces.x = x;
             };

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -204,7 +204,7 @@ namespace Gala {
         }
 
         private void on_gesture_detected (Gesture gesture) {
-            if (gesture.type == GestureType.SCROLL) {
+            if (gesture.type == Gdk.EventType.SCROLL) {
                 Meta.MotionDirection direction = (gesture.direction == GestureDirection.LEFT)
                     ? Meta.MotionDirection.LEFT
                     : Meta.MotionDirection.RIGHT;

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -225,7 +225,7 @@ namespace Gala {
             bool is_nudge_animation = (target_workspace_index < 0 || target_workspace_index >= num_workspaces);
 
             if (is_nudge_animation) {
-                var nudge_delta = (direction == Meta.MotionDirection.LEFT) 
+                var nudge_delta = (direction == Meta.MotionDirection.LEFT)
                     ? WindowManagerGala.NUDGE_GAP
                     : -WindowManagerGala.NUDGE_GAP;
                 target_x = initial_x + nudge_delta;
@@ -241,7 +241,7 @@ namespace Gala {
             }
 
             debug ("Starting MultitaskingView switch workspace animation:");
-            debug ("Active workspace index: %d",  active_workspace_index);
+            debug ("Active workspace index: %d", active_workspace_index);
             debug ("Target workspace index: %d", target_workspace_index);
             debug ("Total number of workspaces: %d", num_workspaces);
             debug ("Is nudge animation: %s", is_nudge_animation ? "Yes" : "No");

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -204,13 +204,11 @@ namespace Gala {
         }
 
         private void on_gesture_detected (Gesture gesture) {
-            // TODO Follow natural scroll settings
             if (gesture.type == GestureType.SCROLL) {
-                if (gesture.direction == GestureDirection.LEFT) {
-                    switch_workspace_with_gesture (Meta.MotionDirection.LEFT);
-                } else if (gesture.direction == GestureDirection.RIGHT) {
-                    switch_workspace_with_gesture (Meta.MotionDirection.RIGHT);
-                }
+                Meta.MotionDirection direction = (gesture.direction == GestureDirection.LEFT)
+                    ? Meta.MotionDirection.LEFT
+                    : Meta.MotionDirection.RIGHT;
+                switch_workspace_with_gesture (direction);
             }
         }
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -61,7 +61,9 @@ namespace Gala {
             display = wm.get_display ();
 
             gesture_animation_director = new GestureAnimationDirector (ANIMATION_DURATION, ANIMATION_DURATION);
-            gesture_tracker = new GestureTracker (this, AnimationDuration.WORKSPACE_SWITCH_MIN, AnimationDuration.WORKSPACE_SWITCH, Clutter.Orientation.HORIZONTAL);
+
+            gesture_tracker = new GestureTracker (AnimationDuration.WORKSPACE_SWITCH_MIN, AnimationDuration.WORKSPACE_SWITCH);
+            gesture_tracker.enable_scroll (this, Clutter.Orientation.HORIZONTAL);
             gesture_tracker.on_gesture_detected.connect (on_gesture_detected);
 
             workspaces = new Actor ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -505,7 +505,7 @@ namespace Gala {
 
             GestureAnimationDirector.OnEnd on_animation_end = (percentage, cancel_action) => {
                 var nudge_gesture = new Clutter.PropertyTransition ("x") {
-                    duration = (duration / 2),
+                    duration = (AnimationDuration.NUDGE / 2),
                     remove_on_complete = true,
                     progress_mode = Clutter.AnimationMode.LINEAR
                 };
@@ -523,7 +523,7 @@ namespace Gala {
                 GLib.Value[] x = { dest };
 
                 var nudge = new Clutter.KeyframeTransition ("translation-x") {
-                    duration = duration,
+                    duration = AnimationDuration.NUDGE,
                     remove_on_complete = true,
                     progress_mode = Clutter.AnimationMode.EASE_IN_QUAD
                 };

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -101,6 +101,11 @@ namespace Gala {
         private GestureAnimationDirector gesture_animation_director;
 
         /**
+         * Amount of pixels to move on the nudge animation.
+         */
+        public const float NUDGE_GAP = 32;
+
+        /**
          * Gap to show between workspaces while switching between them.
          */
         public const int WORKSPACE_GAP = 24;
@@ -496,7 +501,7 @@ namespace Gala {
 
         private void play_nudge_animation (Meta.MotionDirection direction) {
             int duration = 360;
-            var dest = (direction == Meta.MotionDirection.LEFT ? 32.0f : -32.0f);
+            var dest = (direction == Meta.MotionDirection.LEFT ? NUDGE_GAP : -NUDGE_GAP);
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {
                 var x = GestureAnimationDirector.animation_value (0.0f, dest, percentage, true);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -500,7 +500,6 @@ namespace Gala {
         }
 
         private void play_nudge_animation (Meta.MotionDirection direction) {
-            int duration = 360;
             var dest = (direction == Meta.MotionDirection.LEFT ? NUDGE_GAP : -NUDGE_GAP);
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -501,6 +501,7 @@ namespace Gala {
 
         private void play_nudge_animation (Meta.MotionDirection direction) {
             var dest = (direction == Meta.MotionDirection.LEFT ? NUDGE_GAP : -NUDGE_GAP);
+            dest *= InternalUtils.get_ui_scaling_factor ();
 
             GestureAnimationDirector.OnUpdate on_animation_update = (percentage) => {
                 var x = GestureAnimationDirector.animation_value (0.0f, dest, percentage, true);

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ gala_bin_sources = files(
     'Background/BackgroundSource.vala',
     'Background/SystemBackground.vala',
     'Gestures/Gesture.vala',
+    'Gestures/GestureSettings.vala',
     'Gestures/GestureTracker.vala',
     'Gestures/ScrollBackend.vala',
     'Widgets/IconGroup.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,8 @@ gala_bin_sources = files(
     'Background/BackgroundManager.vala',
     'Background/BackgroundSource.vala',
     'Background/SystemBackground.vala',
+    'Gestures/GestureTracker.vala',
+    'Gestures/ScrollBackend.vala',
     'Widgets/IconGroup.vala',
     'Widgets/IconGroupContainer.vala',
     'Widgets/MonitorClone.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,7 @@ gala_bin_sources = files(
     'Background/BackgroundManager.vala',
     'Background/BackgroundSource.vala',
     'Background/SystemBackground.vala',
+    'Gestures/Gesture.vala',
     'Gestures/GestureTracker.vala',
     'Gestures/ScrollBackend.vala',
     'Widgets/IconGroup.vala',


### PR DESCRIPTION
Partially solves  #993

When the multitasking view is opened, the switch workspace animation is not 1:1 at the moment.
As a user, I'd expect this view to respond to scroll events (like in libhandy) and also to my configured multi-touch gesture (3 or 4 fingers swipe).

At the moment we don't have a way to handle scroll events, so my goal here is to unify how scroll events and multi-touch events are handled in a single interface (`GestureTracker`) that will replace the current `GestureAnimationDirector`.
`GestureTracker` allows to configure different backends, at the moment scroll and in a follow up branch, Touchégg. In the future we can add touch and, when Wayland is ready, get rid of Touchégg.

The diff is already quite big, so I'm going to split this in 2 pull request:

 1 - This PR. Add support for smooth scrolling, already works on its own
 2 - In a follow up PR I'll unify how multi-touch events are handled