### PR TITLE
Add Take Screenshot to the header context menu

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -38,6 +38,7 @@ namespace Gala {
         private Granite.AccelLabel move_right_accellabel;
         private Granite.AccelLabel on_visible_workspace_accellabel;
         private Granite.AccelLabel resize_accellabel;
+        private Granite.AccelLabel screenshot_accellabel;
         Gtk.Menu? window_menu = null;
         Gtk.MenuItem hide;
         Gtk.MenuItem maximize;
@@ -48,6 +49,7 @@ namespace Gala {
         Gtk.MenuItem move_left;
         Gtk.MenuItem move_right;
         Gtk.MenuItem close;
+        Gtk.MenuItem screenshot;
 
         // Desktop Menu
         Gtk.Menu? desktop_menu = null;
@@ -58,9 +60,11 @@ namespace Gala {
         ulong on_visible_workspace_sid = 0U;
 
         private static GLib.Settings keybind_settings;
+        private static GLib.Settings media_keys_settings;
 
         static construct {
             keybind_settings = new GLib.Settings ("org.gnome.desktop.wm.keybindings");
+            media_keys_settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.media-keys");
         }
 
         [DBus (visible = false)]
@@ -169,6 +173,14 @@ namespace Gala {
                 perform_action (Gala.ActionType.MOVE_CURRENT_WORKSPACE_RIGHT);
             });
 
+            screenshot_accellabel = new Granite.AccelLabel (_("Take Screenshot"));
+
+            screenshot = new Gtk.MenuItem ();
+            screenshot.add (screenshot_accellabel);
+            screenshot.activate.connect (() => {
+                perform_action (Gala.ActionType.SCREENSHOT_CURRENT);
+            });
+
             close_accellabel = new Granite.AccelLabel (_("Close"));
 
             close = new Gtk.MenuItem ();
@@ -186,6 +198,7 @@ namespace Gala {
             window_menu.append (on_visible_workspace);
             window_menu.append (move_left);
             window_menu.append (move_right);
+            window_menu.append (screenshot);
             window_menu.append (close);
             window_menu.show_all ();
         }
@@ -247,6 +260,8 @@ namespace Gala {
             if (move_left.visible) {
                 move_left_accellabel.accel_string = keybind_settings.get_strv ("move-to-workspace-left")[0];
             }
+
+            screenshot_accellabel.accel_string = media_keys_settings.get_strv ("window-screenshot")[0];
 
             close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
             if (close.visible) {

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -32,7 +32,8 @@ namespace Gala {
         TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT,
         MOVE_CURRENT_WORKSPACE_LEFT,
         MOVE_CURRENT_WORKSPACE_RIGHT,
-        CLOSE_CURRENT
+        CLOSE_CURRENT,
+        SCREENSHOT_CURRENT
     }
 
     [Flags]
@@ -169,6 +170,6 @@ namespace Gala {
          *
          * @param direction The direction in which to switch
          */
-        public abstract void switch_to_next_workspace (Meta.MotionDirection direction);
+         public abstract void switch_to_next_workspace (Meta.MotionDirection direction);
     }
 }

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -170,6 +170,6 @@ namespace Gala {
          *
          * @param direction The direction in which to switch
          */
-         public abstract void switch_to_next_workspace (Meta.MotionDirection direction);
+        public abstract void switch_to_next_workspace (Meta.MotionDirection direction);
     }
 }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -886,6 +886,9 @@ namespace Gala {
                     var workspace = manager.get_workspace_by_index (manager.get_n_workspaces () - 1);
                     workspace.activate (display.get_current_time ());
                     break;
+                case ActionType.SCREENSHOT_CURRENT:
+                    screenshot_current_window ();
+                    break;
                 default:
                     warning ("Trying to run unknown action");
                     break;
@@ -2099,6 +2102,21 @@ namespace Gala {
 
         public override unowned Meta.PluginInfo? plugin_info () {
             return info;
+        }
+
+        private async void screenshot_current_window () {
+            try {
+                var date_time = new GLib.DateTime.now_local ().format ("%Y-%m-%d %H.%M.%S");
+                /// TRANSLATORS: %s represents a timestamp here
+                string file_name = _("Screenshot from %s").printf (date_time);
+    
+                bool success = false;
+                string filename_used = "";
+                var screenshot_manager = ScreenshotManager.init (this);
+                yield screenshot_manager.screenshot_window (true, false, true, file_name, out success, out filename_used);
+            } catch (Error e) {
+                // Ignore this error
+            }
         }
 
         /**


### PR DESCRIPTION
Fix https://github.com/elementary/gala/issues/955

There are some design decisions that need to be taken, so invoking @cassidyjames here:

 - We need to decide if we want to flash the window when the screenshot is taken or not
 - The screenshot sound is not being played, but the screenshot app doesn't play it for window screenshots :thinking: 
 - Maybe we should send a notification when the screenshot is taken indicating the path it is saved at. Extra points if there is a way to open Files when clicking on the notification
 - Menu order:
![Screenshot from 2021-03-02 07 53 30](https://user-images.githubusercontent.com/1335948/109610190-b4fa1d80-7b2c-11eb-8e41-5956be0ee2d5.png)

And one quick technical question: Is there a way to share the code that sets the file name with the screenshots app? I'd like to move the generation of the string `_("Screenshot from %s").printf (date_time);` to the D-Bus interface and share that code.