### PR TITLE
MenuDaemon: re-order window menuitems

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -190,15 +190,18 @@ namespace Gala {
             });
 
             window_menu = new Gtk.Menu ();
-            window_menu.append (hide);
-            window_menu.append (maximize);
-            window_menu.append (move);
-            window_menu.append (resize);
+            window_menu.append (screenshot);
+            window_menu.append (new Gtk.SeparatorMenuItem ());
             window_menu.append (always_on_top);
             window_menu.append (on_visible_workspace);
             window_menu.append (move_left);
             window_menu.append (move_right);
-            window_menu.append (screenshot);
+            window_menu.append (new Gtk.SeparatorMenuItem ());
+            window_menu.append (move);
+            window_menu.append (resize);
+            window_menu.append (maximize);
+            window_menu.append (new Gtk.SeparatorMenuItem ());
+            window_menu.append (hide);
             window_menu.append (close);
             window_menu.show_all ();
         }
@@ -251,13 +254,13 @@ namespace Gala {
             SignalHandler.unblock (always_on_top, always_on_top_sid);
             SignalHandler.unblock (on_visible_workspace, on_visible_workspace_sid);
 
-            move_right.visible = !on_visible_workspace.active;
-            if (move_right.visible) {
+            move_right.sensitive = !on_visible_workspace.active;
+            if (move_right.sensitive) {
                 move_right_accellabel.accel_string = keybind_settings.get_strv ("move-to-workspace-right")[0];
             }
 
-            move_left.visible = !on_visible_workspace.active;
-            if (move_left.visible) {
+            move_left.sensitive = !on_visible_workspace.active;
+            if (move_left.sensitive) {
                 move_left_accellabel.accel_string = keybind_settings.get_strv ("move-to-workspace-left")[0];
             }
 
@@ -296,7 +299,7 @@ namespace Gala {
                         message_dialog.destroy ();
                     }
                 });
-    
+
                 var display_settings = new Gtk.MenuItem.with_label (_("Display Settings…"));
                 display_settings.activate.connect (() => {
                     try {
@@ -313,7 +316,7 @@ namespace Gala {
                         message_dialog.destroy ();
                     }
                 });
-    
+
                 var system_settings = new Gtk.MenuItem.with_label (_("System Settings…"));
                 system_settings.activate.connect (() => {
                     try {
@@ -330,13 +333,11 @@ namespace Gala {
                         message_dialog.destroy ();
                     }
                 });
-    
-                var separator = new Gtk.SeparatorMenuItem ();
-    
+
                 desktop_menu = new Gtk.Menu ();
                 desktop_menu.append (change_wallpaper);
                 desktop_menu.append (display_settings);
-                desktop_menu.append (separator);
+                desktop_menu.append (new Gtk.SeparatorMenuItem ());
                 desktop_menu.append (system_settings);
                 desktop_menu.show_all ();
             }


### PR DESCRIPTION
Tried to group these a little better. Open to suggestions

Also, thought it might be better to make the move items insensitive instead of visible to tie the relationship closer with that checkbox, but I can revert that change if it's weird

## BEFORE
![Screenshot from 2021-03-22 12 59 16](https://user-images.githubusercontent.com/7277719/112051071-b9ec3480-8b0e-11eb-9cd6-fe80cad241b8.png) ![Screenshot from 2021-03-22 12 59 37](https://user-images.githubusercontent.com/7277719/112051078-bbb5f800-8b0e-11eb-9e06-b3076094cc6c.png)

## AFTER
![Screenshot from 2021-03-22 12 58 05](https://user-images.githubusercontent.com/7277719/112051047-b35dbd00-8b0e-11eb-9ba1-34a67eba6e74.png) ![Screenshot from 2021-03-22 12 58 14](https://user-images.githubusercontent.com/7277719/112051060-b789da80-8b0e-11eb-91ed-455e6b01110e.png)
