### PR TITLE
Fix #1074: Window menu says Unmaximize when tiled

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -218,7 +218,7 @@ namespace Gala {
 
             maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
             if (maximize.visible) {
-                string maximize_label;
+                unowned string maximize_label;
                 if (Gala.WindowFlags.IS_MAXIMIZED in flags) {
                     maximize_label = (Gala.WindowFlags.IS_TILED in flags) ? _("Untile") : _("Unmaximize");
                 } else {

--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -218,7 +218,12 @@ namespace Gala {
 
             maximize.visible = Gala.WindowFlags.CAN_MAXIMIZE in flags;
             if (maximize.visible) {
-                var maximize_label = Gala.WindowFlags.IS_MAXIMIZED in flags ? _("Unmaximize") : _("Maximize");
+                string maximize_label;
+                if (Gala.WindowFlags.IS_MAXIMIZED in flags) {
+                    maximize_label = (Gala.WindowFlags.IS_TILED in flags) ? _("Untile") : _("Unmaximize");
+                } else {
+                    maximize_label = _("Maximize");
+                }
 
                 maximize.get_child ().destroy ();
                 maximize.add (

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -46,7 +46,8 @@ namespace Gala {
         ALLOWS_RESIZE,
         ALWAYS_ON_TOP,
         ON_ALL_WORKSPACES,
-        CAN_CLOSE
+        CAN_CLOSE,
+        IS_TILED
     }
 
     /**

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -770,7 +770,8 @@ namespace Gala {
                     if (current == null || current.window_type != Meta.WindowType.NORMAL)
                         break;
 
-                    if (current.get_maximized () == (Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL))
+                    var maximize_flags = current.get_maximized ();
+                    if (Meta.MaximizeFlags.VERTICAL in maximize_flags || Meta.MaximizeFlags.HORIZONTAL in maximize_flags)
                         current.unmaximize (Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
                     else
                         current.maximize (Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
@@ -909,8 +910,14 @@ namespace Gala {
                     if (window.can_maximize ())
                         flags |= WindowFlags.CAN_MAXIMIZE;
 
-                    if (window.get_maximized () > 0)
+                    var maximize_flags = window.get_maximized ();
+                    if (maximize_flags > 0) {
                         flags |= WindowFlags.IS_MAXIMIZED;
+
+                        if (Meta.MaximizeFlags.VERTICAL in maximize_flags && !(Meta.MaximizeFlags.HORIZONTAL in maximize_flags)) {
+                            flags |= WindowFlags.IS_TILED;
+                        }
+                    }
 
                     if (window.allows_move ())
                         flags |= WindowFlags.ALLOWS_MOVE;


### PR DESCRIPTION
Fix https://github.com/elementary/gala/issues/1074:  Show "Untile" instead of "Unmaximize" in the window menu when a window is tiled.

Also, the current behaviour is to maximize the window when it is tiled. Fix it to restore the window when the "Untile" menu option is selected.