### PR TITLE
Fix #1094: Zoom doesn't respect animations key

### DIFF
--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -40,7 +40,7 @@ namespace Gala {
             display.add_keybinding ("zoom-in", schema, 0, (Meta.KeyHandlerFunc) zoom_in);
             display.add_keybinding ("zoom-out", schema, 0, (Meta.KeyHandlerFunc) zoom_out);
 
-            gesture_tracker = new GestureTracker (AnimationDuration.WORKSPACE_SWITCH_MIN, AnimationDuration.WORKSPACE_SWITCH);
+            gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
             gesture_tracker.enable_touchpad ();
             gesture_tracker.on_gesture_detected.connect (on_gesture_detected);
         }
@@ -92,6 +92,15 @@ namespace Gala {
             GestureTracker.OnUpdate on_animation_update = (percentage) => {
                 var zoom_level = GestureTracker.animation_value (initial_zoom, target_zoom, percentage);
                 var delta = zoom_level - current_zoom;
+
+                if (!wm.enable_animations) {
+                    if (delta.abs () >= SHORTCUT_DELTA) {
+                        delta = (delta > 0) ? SHORTCUT_DELTA : -SHORTCUT_DELTA;
+                    } else {
+                        delta = 0;
+                    }
+                }
+
                 zoom (delta, false, false);
             };
 

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -61,13 +61,13 @@ namespace Gala {
         [CCode (instance_pos = -1)]
         void zoom_in (Meta.Display display, Meta.Window? window,
             Clutter.KeyEvent event, Meta.KeyBinding binding) {
-            zoom (SHORTCUT_DELTA, true, true);
+            zoom (SHORTCUT_DELTA, true, wm.enable_animations);
         }
 
         [CCode (instance_pos = -1)]
         void zoom_out (Meta.Display display, Meta.Window? window,
             Clutter.KeyEvent event, Meta.KeyBinding binding) {
-            zoom (-SHORTCUT_DELTA, true, true);
+            zoom (-SHORTCUT_DELTA, true, wm.enable_animations);
         }
 
         private void on_gesture_detected (Gesture gesture) {


### PR DESCRIPTION
Fix https://github.com/elementary/gala/issues/1094

Follow the user animation settings to enable or disable zoom animations.
Split in 2 commits, one for keyboard shortcuts and the other one for gestures.