### PR TITLE
Rewrite gesture schemas

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -359,17 +359,5 @@
       <summary>Four-finger horizontal swipe gesture</summary>
       <description>The action that corresponds to performing a horizontal swipe gesture with four fingers</description>
     </key>
-
-    <key type="b" name="workspaces-gesture-enabled">
-      <default>true</default>
-      <summary>Switch workspace gesture</summary>
-      <description>If enabled, swipe left/right with the number of fingers set in io.elementary.desktop.wm.gestures.workspaces-gesture-fingers to switch between workspaces</description>
-    </key>
-    <key type="i" name="workspaces-gesture-fingers">
-      <default>3</default>
-      <range min="3" max="4"/>
-      <summary>Switch workspace gesture fingers</summary>
-      <description>Number of fingers used in the switch workspaces gesture</description>
-    </key>
   </schema>
 </schemalist>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <enum id="GalaActionType">
-    <value nick='none' value="0" />
+    <value nick="none" value="0" />
     <value nick="show-workspace-view" value="1" />
     <value nick="maximize-current" value="2" />
     <value nick="minimize-current" value="3" />
@@ -26,7 +26,7 @@
 
   <schema path="/org/pantheon/desktop/gala/behavior/" id="org.pantheon.desktop.gala.behavior">
     <key enum="GalaActionType" name="hotcorner-topleft">
-      <default>'none'</default>
+      <default>"none"</default>
       <summary>Action for the top left corner</summary>
       <description></description>
     </key>
@@ -36,17 +36,17 @@
       <description>Choose the algorithm used for exposing the windows.</description>
     </key>
     <key enum="GalaActionType" name="hotcorner-topright">
-      <default>'none'</default>
+      <default>"none"</default>
       <summary>Action for the top right corner</summary>
       <description></description>
     </key>
     <key enum="GalaActionType" name="hotcorner-bottomleft">
-      <default>'none'</default>
+      <default>"none"</default>
       <summary>Action for the bottom left corner</summary>
       <description></description>
     </key>
     <key enum="GalaActionType" name="hotcorner-bottomright">
-      <default>'none'</default>
+      <default>"none"</default>
       <summary>Action for the bottom right corner</summary>
       <description></description>
     </key>
@@ -314,7 +314,53 @@
     </key>
   </schema>
 
+  <enum id="GesturePinch">
+    <value nick="none" value="0" />
+    <value nick="zoom" value="1" />
+  </enum>
+  <enum id="GestureSwipeHorizontal">
+    <value nick="none" value="0" />
+    <value nick="switch-to-workspace" value="1" />
+  </enum>
+  <enum id="GestureSwipeUp">
+    <value nick="none" value="0" />
+    <value nick="multitasking-view" value="1" />
+    <value nick="toggle-maximized" value="2" />
+  </enum>
+
   <schema path="/io/elementary/desktop/wm/gestures/" id="io.elementary.desktop.wm.gestures">
+    <key name="three-finger-pinch" enum="GesturePinch">
+      <default>"none"</default>
+      <summary>Three-finger pinch gesture</summary>
+      <description>The action that corresponds to performing a pinch gesture with three fingers</description>
+    </key>
+    <key name="four-finger-pinch" enum="GesturePinch">
+      <default>"none"</default>
+      <summary>Four-finger pinch gesture</summary>
+      <description>The action that corresponds to performing a pinch gesture with four fingers</description>
+    </key>
+    <key name="three-finger-swipe-up" enum="GestureSwipeUp">
+      <default>"multitasking-view"</default>
+      <summary>Three-finger up-swipe gesture</summary>
+      <description>The action that corresponds to swiping up with three fingers</description>
+    </key>
+    <key name="four-finger-swipe-up" enum="GestureSwipeUp">
+      <default>"none"</default>
+      <summary>Four-finger up-swipe gesture</summary>
+      <description>The action that corresponds to swiping up with four fingers</description>
+    </key>
+    <key name="three-finger-swipe-horizontal" enum="GestureSwipeHorizontal">
+      <default>"switch-to-workspace"</default>
+      <summary>Three-finger horizontal swipe gesture</summary>
+      <description>The action that corresponds to performing a horizontal swipe gesture with three fingers</description>
+    </key>
+    <key name="four-finger-swipe-horizontal" enum="GestureSwipeHorizontal">
+      <default>"none"</default>
+      <summary>Four-finger horizontal swipe gesture</summary>
+      <description>The action that corresponds to performing a horizontal swipe gesture with four fingers</description>
+    </key>
+
+
     <key type="b" name="multitasking-gesture-enabled">
       <default>true</default>
       <summary>Multitasking view gesture</summary>
@@ -336,17 +382,6 @@
       <range min="3" max="4"/>
       <summary>Switch workspace gesture fingers</summary>
       <description>Number of fingers used in the switch workspaces gesture</description>
-    </key>
-    <key type="b" name="zoom-gesture-enabled">
-      <default>false</default>
-      <summary>Zoom gesture</summary>
-      <description>If enabled, pinch with the number of fingers set in io.elementary.desktop.wm.gestures.multitasking-gesture-fingers to zoom in/out the entire desktop</description>
-    </key>
-    <key type="i" name="zoom-gesture-fingers">
-      <default>3</default>
-      <range min="3" max="4"/>
-      <summary>Zoom gesture fingers</summary>
-      <description>Number of fingers used in the zoom gesture</description>
     </key>
   </schema>
 </schemalist>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -360,18 +360,6 @@
       <description>The action that corresponds to performing a horizontal swipe gesture with four fingers</description>
     </key>
 
-
-    <key type="b" name="multitasking-gesture-enabled">
-      <default>true</default>
-      <summary>Multitasking view gesture</summary>
-      <description>If enabled, swipe up with the number of fingers set in io.elementary.desktop.wm.gestures.multitasking-gesture-fingers to show the multitasking view</description>
-    </key>
-    <key type="i" name="multitasking-gesture-fingers">
-      <default>3</default>
-      <range min="3" max="4"/>
-      <summary>Multitasking view gesture fingers</summary>
-      <description>Number of fingers used in the multitasking view gesture</description>
-    </key>
     <key type="b" name="workspaces-gesture-enabled">
       <default>true</default>
       <summary>Switch workspace gesture</summary>

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -29,9 +29,6 @@ public class Gala.GestureSettings : Object {
     public const string WORKSPACE_ENABLED = "workspaces-gesture-enabled";
     public const string WORKSPACE_FINGERS = "workspaces-gesture-fingers";
 
-    public const string ZOOM_ENABLED = "zoom-gesture-enabled";
-    public const string ZOOM_FINGERS = "zoom-gesture-fingers";
-
     static construct {
         gala_settings = new GLib.Settings ("io.elementary.desktop.wm.gestures");
         touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
@@ -73,6 +70,10 @@ public class Gala.GestureSettings : Object {
             default:
                 return null;
         }
+    }
+
+    public static string get_string (string setting_id) {
+        return gala_settings.get_string (setting_id);
     }
 
     public bool is_gesture_enabled (string setting_id) {

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -23,9 +23,6 @@ public class Gala.GestureSettings : Object {
     private static GLib.Settings gala_settings;
     private static GLib.Settings touchpad_settings;
 
-    public const string WORKSPACE_ENABLED = "workspaces-gesture-enabled";
-    public const string WORKSPACE_FINGERS = "workspaces-gesture-fingers";
-
     static construct {
         gala_settings = new GLib.Settings ("io.elementary.desktop.wm.gestures");
         touchpad_settings = new GLib.Settings ("org.gnome.desktop.peripherals.touchpad");
@@ -71,13 +68,5 @@ public class Gala.GestureSettings : Object {
 
     public static string get_string (string setting_id) {
         return gala_settings.get_string (setting_id);
-    }
-
-    public bool is_gesture_enabled (string setting_id) {
-        return gala_settings.get_boolean (setting_id);
-    }
-
-    public int gesture_fingers (string setting_id) {
-        return gala_settings.get_int (setting_id);
     }
 }

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -23,9 +23,6 @@ public class Gala.GestureSettings : Object {
     private static GLib.Settings gala_settings;
     private static GLib.Settings touchpad_settings;
 
-    public const string MULTITASKING_ENABLED = "multitasking-gesture-enabled";
-    public const string MULTITASKING_FINGERS = "multitasking-gesture-fingers";
-
     public const string WORKSPACE_ENABLED = "workspaces-gesture-enabled";
     public const string WORKSPACE_FINGERS = "workspaces-gesture-fingers";
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -229,16 +229,14 @@ namespace Gala {
                 return;
             }
 
-            var enabled = workspace_gesture_tracker.settings.is_gesture_enabled (GestureSettings.WORKSPACE_ENABLED);
-            var fingers = workspace_gesture_tracker.settings.gesture_fingers (GestureSettings.WORKSPACE_FINGERS);
+            var fingers = (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-horizontal") == "switch-to-workspace") ||
+                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-horizontal") == "switch-to-workspace");
 
-            bool can_handle_scroll = gesture.type == Gdk.EventType.SCROLL;
-            bool can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE
-                && (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT)
-                && gesture.fingers == fingers;
-            bool can_handle_gesture = enabled && (can_handle_scroll || can_handle_swipe);
+            var can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE &&
+                (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT) &&
+                fingers;
 
-            if (can_handle_gesture) {
+            if (gesture.type == Gdk.EventType.SCROLL || can_handle_swipe) {
                 var direction = workspace_gesture_tracker.settings.get_natural_scroll_direction (gesture);
                 switch_workspace_with_gesture (direction);
             }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -229,14 +229,13 @@ namespace Gala {
                 return;
             }
 
+            var can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE &&
+                (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT);
+
             var fingers = (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-horizontal") == "switch-to-workspace") ||
                 (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-horizontal") == "switch-to-workspace");
 
-            var can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE &&
-                (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT) &&
-                fingers;
-
-            if (gesture.type == Gdk.EventType.SCROLL || can_handle_swipe) {
+            if (gesture.type == Gdk.EventType.SCROLL || (can_handle_swipe && fingers)) {
                 var direction = workspace_gesture_tracker.settings.get_natural_scroll_direction (gesture);
                 switch_workspace_with_gesture (direction);
             }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -207,12 +207,9 @@ namespace Gala {
         }
 
         private void on_multitasking_gesture_detected (Gesture gesture) {
-            if (gesture.type != Gdk.EventType.TOUCHPAD_SWIPE) {
-                return;
-            }
-
-            if ((gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-up") != "multitasking-view") ||
-                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-up") != "multitasking-view")
+            if (gesture.type != Gdk.EventType.TOUCHPAD_SWIPE ||
+                (gesture.fingers == 3 && GestureSettings.get_string ("three-finger-swipe-up") != "multitasking-view") ||
+                (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-swipe-up") != "multitasking-view")
             ) {
                 return;
             }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -207,22 +207,20 @@ namespace Gala {
         }
 
         private void on_multitasking_gesture_detected (Gesture gesture) {
-            var enabled = workspace_gesture_tracker.settings.is_gesture_enabled (GestureSettings.MULTITASKING_ENABLED);
-            var fingers = workspace_gesture_tracker.settings.gesture_fingers (GestureSettings.MULTITASKING_FINGERS);
+            if (gesture.type != Gdk.EventType.TOUCHPAD_SWIPE) {
+                return;
+            }
 
-            bool up = gesture.direction == GestureDirection.UP;
-            bool down = gesture.direction == GestureDirection.DOWN;
-            bool can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE
-                && (up || down)
-                && gesture.fingers == fingers;
-            bool can_handle_gesture = enabled && can_handle_swipe;
+            if ((gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-up") != "multitasking-view") ||
+                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-up") != "multitasking-view")
+            ) {
+                return;
+            }
 
-            if (can_handle_gesture) {
-                if (up && !opened) {
-                    toggle (true, false);
-                } else if (down && opened) {
-                    toggle (true, false);
-                }
+            if (gesture.direction == GestureDirection.UP && !opened) {
+                toggle (true, false);
+            } else if (gesture.direction == GestureDirection.DOWN && opened) {
+                toggle (true, false);
             }
         }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -481,14 +481,13 @@ namespace Gala {
                 return;
             }
 
-            var enabled = gesture_tracker.settings.is_gesture_enabled (GestureSettings.WORKSPACE_ENABLED);
-            var fingers = gesture_tracker.settings.gesture_fingers (GestureSettings.WORKSPACE_FINGERS);
+            var can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE &&
+                (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT);
 
-            bool can_handle_gesture = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE
-                && (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT)
-                && gesture.fingers == fingers;
+            var fingers = (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-horizontal") == "switch-to-workspace") ||
+                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-horizontal") == "switch-to-workspace");
 
-            switch_workspace_with_gesture = enabled && can_handle_gesture;
+            switch_workspace_with_gesture = can_handle_swipe && fingers;
             if (switch_workspace_with_gesture) {
                 var direction = gesture_tracker.settings.get_natural_scroll_direction (gesture);
                 switch_to_next_workspace (direction);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -484,8 +484,8 @@ namespace Gala {
             var can_handle_swipe = gesture.type == Gdk.EventType.TOUCHPAD_SWIPE &&
                 (gesture.direction == GestureDirection.LEFT || gesture.direction == GestureDirection.RIGHT);
 
-            var fingers = (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-swipe-horizontal") == "switch-to-workspace") ||
-                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-swipe-horizontal") == "switch-to-workspace");
+            var fingers = (gesture.fingers == 3 && GestureSettings.get_string ("three-finger-swipe-horizontal") == "switch-to-workspace") ||
+                (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-swipe-horizontal") == "switch-to-workspace");
 
             switch_workspace_with_gesture = can_handle_swipe && fingers;
             if (switch_workspace_with_gesture) {

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -71,14 +71,19 @@ namespace Gala {
         }
 
         private void on_gesture_detected (Gesture gesture) {
-            var enabled = gesture_tracker.settings.is_gesture_enabled (GestureSettings.ZOOM_ENABLED);
-            var fingers = gesture_tracker.settings.gesture_fingers (GestureSettings.ZOOM_FINGERS);
+            if (gesture.type != Gdk.EventType.TOUCHPAD_PINCH) {
+                return;
+            }
 
-            bool can_handle_gesture = gesture.type == Gdk.EventType.TOUCHPAD_PINCH
-                && (gesture.direction == GestureDirection.IN || gesture.direction == GestureDirection.OUT)
-                && gesture.fingers == fingers;
+            if (gesture.direction != GestureDirection.IN && gesture.direction != GestureDirection.OUT) {
+                return;
+            }
 
-            if (enabled && can_handle_gesture) {
+            if (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-pinch") == "zoom") {
+                zoom_with_gesture (gesture.direction);
+            }
+
+            if (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-pinch") == "zoom") {
                 zoom_with_gesture (gesture.direction);
             }
         }

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -71,16 +71,14 @@ namespace Gala {
         }
 
         private void on_gesture_detected (Gesture gesture) {
-            if (gesture.type != Gdk.EventType.TOUCHPAD_PINCH) {
+            if (gesture.type != Gdk.EventType.TOUCHPAD_PINCH ||
+                (gesture.direction != GestureDirection.IN && gesture.direction != GestureDirection.OUT)
+            ) {
                 return;
             }
 
-            if (gesture.direction != GestureDirection.IN && gesture.direction != GestureDirection.OUT) {
-                return;
-            }
-
-            if ((gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-pinch") == "zoom") ||
-                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-pinch") == "zoom")
+            if ((gesture.fingers == 3 && GestureSettings.get_string ("three-finger-pinch") == "zoom") ||
+                (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-pinch") == "zoom")
             ) {
                 zoom_with_gesture (gesture.direction);
             }

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -79,11 +79,9 @@ namespace Gala {
                 return;
             }
 
-            if (gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-pinch") == "zoom") {
-                zoom_with_gesture (gesture.direction);
-            }
-
-            if (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-pinch") == "zoom") {
+            if ((gesture.fingers == 3 && Gala.GestureSettings.get_string ("three-finger-pinch") == "zoom") ||
+                (gesture.fingers == 4 && Gala.GestureSettings.get_string ("four-finger-pinch") == "zoom")
+            ) {
                 zoom_with_gesture (gesture.direction);
             }
         }


### PR DESCRIPTION
Fixes #1093 

Gsettings schemas now use gestures for the key and actions for the values. This should allow us to add many many more actions without adding many more keys. It also ensures that a given gesture cannot be assigned to more than one action. But an action can be assigned to several gestures.

We'll need to update Switchboard either in parallel or after this branch