### PR TITLE
Minor screen shield fixes

### DIFF
--- a/src/Widgets/ScreenShield.vala
+++ b/src/Widgets/ScreenShield.vala
@@ -157,7 +157,7 @@ namespace Gala {
                         in_greeter = false;
                     });
 
-                    login_session.notify.connect (sync_inhibitor);
+                    ((DBusProxy)login_session).g_properties_changed.connect (sync_inhibitor);
                     sync_inhibitor ();
                 }
             } catch (Error e) {
@@ -273,10 +273,10 @@ namespace Gala {
                 cancel_animation ();
                 try {
                     display_manager.switch_to_greeter ();
+                    in_greeter = true;
                 } catch (Error e) {
                     critical ("Unable to switch to greeter to unlock: %s", e.message);
                 }
-                in_greeter = true;
             // Otherwise, we're in screensaver mode, just deactivate
             } else if (!is_locked) {
                 debug ("user became active in unlocked session, closing screensaver");
@@ -340,6 +340,8 @@ namespace Gala {
                 animate_and_lock (animation_time);
             } else {
                 _set_active (true);
+
+                opacity = 255;
 
                 if (screensaver_settings.get_boolean (LOCK_ENABLED_KEY)) {
                     @lock (false);


### PR DESCRIPTION
`notify` doesn't work on the `DBusProxy` so we weren't updating the sleep inhibitor in all cases. This may have been preventing the screen shield from inhibiting sleep for long enough to lock first, potentially increasing the duration of the flash of the desktop some people see when waking.

In non animated lock cases (suspend due to lid close), we weren't setting the screen shield to be fully opaque, again potentially increasing the duration of the desktop flash.

We were setting `in_greeter` to true regardless of whether the DBus call to the greeter succeeded. If we catch an error, we'll leave this as false, so more attempts can be made.

Personally, I don't see any improvements on my machine, but these changes may improve things for some people. I've always had a flash of the desktop on waking and it used to be worse with light locker, and I've not personally experienced any problems with unlocking after suspend, but this may help.