### PR TITLE
Multitasking view: Animate the dock when small size is selected

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -649,7 +649,7 @@ namespace Gala {
 
             unowned GLib.List<Meta.WindowActor> window_actors = display.get_window_actors ();
             foreach (unowned Meta.WindowActor actor in window_actors) {
-                const int MAX_OFFSET = 100;
+                const int MAX_OFFSET = 85;
 
                 if (actor.is_destroyed ())
                     continue;


### PR DESCRIPTION
On elementary OS 6, the offset used to calculate if a dock/panel is
placed in the top or bottom of the screen was too high to pick the
dock when the small size is selected in system settings.

Adjust the offset used for Odin.

Fix #1134