### PR TITLE
Screenshot: Fix copy to clipboard using shortcuts

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -254,7 +254,9 @@ namespace Gala {
         }
 
         static async bool save_image (Cairo.ImageSurface image, string filename, out string used_filename) {
-            return yield save_image_to_file (image, filename, out used_filename);
+            return (filename != "")
+                ? yield save_image_to_file (image, filename, out used_filename)
+                : save_image_to_clipboard (image, filename, out used_filename);
         }
 
         static async bool save_image_to_file (Cairo.ImageSurface image, string filename, out string used_filename) {
@@ -292,6 +294,22 @@ namespace Gala {
                 warning ("could not save file: %s", e.message);
                 return false;
             }
+        }
+
+        static bool save_image_to_clipboard (Cairo.ImageSurface image, string filename, out string used_filename) {
+            used_filename = filename;
+
+            unowned Gdk.Display display = Gdk.Display.get_default ();
+            unowned Gtk.Clipboard clipboard = Gtk.Clipboard.get_default (display);
+
+            var screenshot = Gdk.pixbuf_get_from_surface (image, 0, 0, image.get_width (), image.get_height ());
+            if (screenshot == null) {
+                warning ("could not save screenshot to clipboard: null pixbuf");
+                return false;
+            }
+
+            clipboard.set_image (screenshot);
+            return true;
         }
 
         Cairo.ImageSurface take_screenshot (int x, int y, int width, int height, bool include_cursor) {

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -254,6 +254,10 @@ namespace Gala {
         }
 
         static async bool save_image (Cairo.ImageSurface image, string filename, out string used_filename) {
+            return yield save_image_to_file (image, filename, out used_filename);
+        }
+
+        static async bool save_image_to_file (Cairo.ImageSurface image, string filename, out string used_filename) {
             used_filename = filename;
 
             // We only alter non absolute filename because absolute


### PR DESCRIPTION
In previous versions of GNOME Settings daemon (elementary OS <= 5), saving to clipboard was handled by the daemon. The daemon used to request Gala to save the screenshot in a temp path like "/tmp/gnome-settings-daemon-screenshot-XXXX" and copied the image to the  clipboard from there.

More information: #474

Now, Gala is in charge of copying to clipboard when the take screenshot methods receive an empty filename.

Allow to save screenshot to clipboard when the filename received is empty.

Not changing the save_image_to_file to keep backward compatibility.

Fix #1137
Fix #1122 

Note - Please don't squash and merge or this information will be lost from the git log. Or if squashing, keep both commit messages, please.