### PR TITLE
Desktop context menu: Do not show scroll

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -353,7 +353,7 @@ namespace Gala {
                 // Move the menu 1 pixel outside of the pointer or else it closes instantly
                 // on the mouse up event
                 py = (y / scale) + 1;
-                push_in = true;
+                push_in = false;
             }, 3, Gdk.CURRENT_TIME);
         }
     }


### PR DESCRIPTION
Avoid showing scroll when the desktop context menu is displayed close to
the screen bottom edge.

This behavious was caused by the "push_in" param in the popup
GtkMenuPositionFunc callback:

> Note that moving and possibly resizing the menu around will alter the
> scroll position [...]. In practice, this behavior is only useful for
> combobox popups or option menus
https://developer.gnome.org/gtk3/stable/GtkMenu.html#GtkMenuPositionFunc

Fix #1146