### PR TITLE
Workspaces icons/folders make a weird pattern/shape when changing screen resolution

### DIFF
--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -30,6 +30,7 @@ namespace Gala {
         const int PLUS_SIZE = 8;
         const int PLUS_WIDTH = 24;
 
+        const int CLOSE_BUTTON_SIZE = 36;
         const int SHOW_CLOSE_BUTTON_DELAY = 200;
 
         /**
@@ -178,6 +179,7 @@ namespace Gala {
 
             if (show) {
                 show_close_button_timeout = Timeout.add (SHOW_CLOSE_BUTTON_DELAY, () => {
+                    place_close_button ();
                     close_button.visible = true;
                     close_button.opacity = 255;
                     show_close_button_timeout = 0;
@@ -207,6 +209,9 @@ namespace Gala {
         }
 
         void place_close_button () {
+            var size = CLOSE_BUTTON_SIZE * InternalUtils.get_ui_scaling_factor ();
+            close_button.set_size (size, size);
+
             close_button.x = -Math.floorf (close_button.width * 0.4f);
             close_button.y = -Math.floorf (close_button.height * 0.4f);
         }

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -308,7 +308,9 @@ namespace Gala {
          * Trigger a redraw
          */
         public void redraw () {
-            content.invalidate ();
+            if (!resize_canvas ()) {
+                content.invalidate ();
+            }
         }
 
         /**

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -96,17 +96,12 @@ namespace Gala {
         }
 
         construct {
-            var scale = InternalUtils.get_ui_scaling_factor ();
-            var size = SIZE * scale;
-
-            width = size;
-            height = size;
             reactive = true;
 
             var canvas = new Canvas ();
-            canvas.set_size (size, size);
             canvas.draw.connect (draw);
             content = canvas;
+            resize_canvas ();
 
             dummy_material = new Cogl.Material ();
 
@@ -200,6 +195,16 @@ namespace Gala {
                 });
             else
                 close_button.visible = false;
+        }
+
+        bool resize_canvas () {
+            var scale = InternalUtils.get_ui_scaling_factor ();
+            var size = SIZE * scale;
+
+            width = size;
+            height = size;
+
+            return ((Canvas) content).set_size (size, size);
         }
 
         /**

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -120,8 +120,7 @@ namespace Gala {
             add_child (icon_container);
 
             close_button = Utils.create_close_button ();
-            close_button.x = -Math.floorf (close_button.width * 0.4f);
-            close_button.y = -Math.floorf (close_button.height * 0.4f);
+            place_close_button ();
             close_button.opacity = 0;
             close_button.reactive = true;
             close_button.visible = false;
@@ -205,6 +204,11 @@ namespace Gala {
             height = size;
 
             return ((Canvas) content).set_size (size, size);
+        }
+
+        void place_close_button () {
+            close_button.x = -Math.floorf (close_button.width * 0.4f);
+            close_button.y = -Math.floorf (close_button.height * 0.4f);
         }
 
         /**

--- a/src/Widgets/IconGroupContainer.vala
+++ b/src/Widgets/IconGroupContainer.vala
@@ -128,6 +128,22 @@ namespace Gala {
             return width;
         }
 
+        public void force_reposition () {
+            var children = get_children ();
+
+            foreach (var child in children) {
+                if (child is IconGroup) {
+                    remove_group ((IconGroup) child);
+                }
+            }
+
+            foreach (var child in children) {
+                if (child is IconGroup) {
+                    add_group ((IconGroup) child);
+                }
+            }
+        }
+
         void update_inserter_indices () {
             var current_index = 0;
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -564,6 +564,7 @@ namespace Gala {
                 grab_key_focus ();
 
                 var scale = InternalUtils.get_ui_scaling_factor ();
+                icon_groups.force_reposition ();
                 icon_groups.y = height - WorkspaceClone.BOTTOM_OFFSET * scale + 20 * scale;
             } else {
                 DragDropAction.cancel_all_by_id ("multitaskingview-window");

--- a/src/Widgets/WindowIconActor.vala
+++ b/src/Widgets/WindowIconActor.vala
@@ -27,6 +27,8 @@ namespace Gala {
     public class WindowIconActor : Actor {
         public Window window { get; construct; }
 
+        int icon_scale;
+
         int _icon_size;
         /**
          * The icon size of the WindowIcon. Once set the new icon will be
@@ -37,11 +39,14 @@ namespace Gala {
                 return _icon_size;
             }
             set {
-                if (value == _icon_size)
-                    return;
-
                 var scale = InternalUtils.get_ui_scaling_factor ();
+
+                if (value == _icon_size && scale == icon_scale) {
+                    return;
+                }
+
                 _icon_size = value;
+                icon_scale = scale;
 
                 set_size (_icon_size * scale, _icon_size * scale);
 
@@ -111,6 +116,7 @@ namespace Gala {
             set_easing_duration (800);
 
             window.notify["on-all-workspaces"].connect (on_all_workspaces_changed);
+            icon_scale = InternalUtils.get_ui_scaling_factor ();
         }
 
         ~WindowIconActor () {


### PR DESCRIPTION
Easier to review commit by commit.

I'm not specially happy with the last commit (IconGroupContainer: Force re-layout) but I wasn't able to find a way to force the layout to be recalculated. Suggestions to improve it are welcome.

Fix #1158