### PR TITLE
Play the shutter after taking a screenshot

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ gtk_version_required = '3.10.0'
 plank_version_required = '0.11.0'
 gsd_version_required = '3.15.2'
 
+canberra_dep = dependency('libcanberra')
 glib_dep = dependency('glib-2.0', version: '>= @0@'.format(glib_version_required))
 gobject_dep = dependency('gobject-2.0', version: '>= @0@'.format(glib_version_required))
 gio_dep = dependency('gio-2.0', version: '>= @0@'.format(glib_version_required))
@@ -134,7 +135,7 @@ mutter_typelib_dir = libmutter_dep.get_pkgconfig_variable('typelibdir')
 add_project_arguments(vala_flags, language: 'vala')
 add_project_link_arguments(['-Wl,-rpath,@0@'.format(mutter_typelib_dir)], language: 'c')
 
-gala_base_dep = [glib_dep, gobject_dep, gio_dep, gmodule_dep, gee_dep, gtk_dep, plank_dep, mutter_dep, granite_dep, gnome_desktop_dep, m_dep, gexiv2_dep, config_dep]
+gala_base_dep = [canberra_dep, glib_dep, gobject_dep, gio_dep, gmodule_dep, gee_dep, gtk_dep, plank_dep, mutter_dep, granite_dep, gnome_desktop_dep, m_dep, gexiv2_dep, config_dep]
 
 subdir('data')
 subdir('lib')

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -90,6 +90,10 @@ namespace Gala {
             }
 
             success = yield save_image (image, filename, out filename_used);
+
+            if (success) {
+                play_shutter_sound ();
+            }
         }
 
         public async void screenshot_area (int x, int y, int width, int height, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
@@ -109,8 +113,12 @@ namespace Gala {
             }
 
             success = yield save_image (image, filename, out filename_used);
-            if (!success)
+
+            if (success) {
+                play_shutter_sound ();
+            } else {
                 throw new DBusError.FAILED ("Failed to save image");
+            }
         }
 
         public async void screenshot_window (bool include_frame, bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
@@ -146,6 +154,10 @@ namespace Gala {
             }
 
             success = yield save_image (image, filename, out filename_used);
+
+            if (success) {
+                play_shutter_sound ();
+            }
         }
 
         public async void select_area (out int x, out int y, out int width, out int height) throws DBusError, IOError {
@@ -310,6 +322,20 @@ namespace Gala {
 
             clipboard.set_image (screenshot);
             return true;
+        }
+
+        private void play_shutter_sound () {
+            Canberra.Context context;
+            Canberra.Proplist props;
+
+            Canberra.Context.create (out context);
+            Canberra.Proplist.create (out props);
+
+            props.sets (Canberra.PROP_EVENT_ID, "screen-capture");
+            props.sets (Canberra.PROP_EVENT_DESCRIPTION, _("Screenshot taken"));
+            props.sets (Canberra.PROP_CANBERRA_CACHE_CONTROL, "permanent");
+
+            context.play_full (0, props, null);
         }
 
         Cairo.ImageSurface take_screenshot (int x, int y, int width, int height, bool include_cursor) {


### PR DESCRIPTION
We currently rely on Screenshot to play the shutter sound. This means that it needs pulseaudio permissions in Flatpak and depending on the app taking the screenshot you might not get a sound when a screenshot is taken.

In addition, no sound was played when a screenshot was copied directly to the clipboard.

Play the shutter sound in Gala to avoid this problems.

**This PR:** Play the shutter after taking a screenshot.

Fix https://github.com/elementary/gala/issues/944
Needs https://github.com/elementary/screenshot/pull/215
Needs https://github.com/elementary/screenshot/pull/216