### PR TITLE
[Regression] PiP: Hide close and resize badges after dragging

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -200,6 +200,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     }
 
     private void on_move_end () {
+        reactive = true;
         update_screen_position ();
     }
 

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -95,13 +95,13 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
         move_action.drag_begin.connect (on_move_begin);
         move_action.drag_canceled.connect (on_move_end);
         move_action.actor_clicked.connect (activate);
-        add_action (move_action);
 
         container = new Clutter.Actor ();
         container.reactive = true;
         container.set_scale (0.35f, 0.35f);
         container.add_effect (new ShadowEffect (SHADOW_SIZE, 2));
         container.add_child (clone);
+        container.add_action (move_action);
 
         update_size ();
         update_container_position ();


### PR DESCRIPTION
I noticed I introduced a bug in https://github.com/elementary/gala/commit/3c47d9dc54cb424ff2aaea0a4f0463963a5f118c: The window click event was triggered on the close/resize button common surface.

Revert that commit and fix the issue in a different way.