### PR TITLE
editorconfig: Add trim_trailing_whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ charset = utf-8
 end_of_line = lf
 indent_size = tab
 indent_style = space
+trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length = 80
 tab_width = 4


### PR DESCRIPTION
Avoid linter issues by automatically removing trailing white spaces.

