### PR TITLE
screenshot: Include server side decorations

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -137,7 +137,8 @@ namespace Gala {
             window_actor.get_position (out actor_x, out actor_y);
 
             var rect = window.get_frame_rect ();
-            if (include_frame) {
+            if ((include_frame && window.is_client_decorated ()) ||
+                (!include_frame && !window.is_client_decorated ())) {
                 rect = window.frame_rect_to_client_rect (rect);
             }
 


### PR DESCRIPTION
When a window screenshot is taken with the include frame flag set to
true, include the window decoration for SSD and the shadows for CSD.

If the include frame flag is set to false, remove the window decoration
for SSD and the shadows for CSD.
Notice that it is not possible to remove the window decoration for CSD.

Fix #1191