### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/daemon/Main.vala
+++ b/daemon/Main.vala
@@ -134,6 +134,11 @@ namespace Gala {
     }
 
     public static int main (string[] args) {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (Config.GETTEXT_PACKAGE);
+
         Gtk.init (ref args);
 
         var ctx = new OptionContext ("Gala Daemon");

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -7,5 +7,6 @@ gala_daemon_bin = executable(
     'gala-daemon',
     gala_daemon_sources,
     dependencies: [gala_dep, gala_base_dep],
+    include_directories: config_inc_dir,
     install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -22,12 +22,15 @@ endif
 
 vapi_dir = meson.current_source_dir() / 'vapi'
 
+locale_dir = join_paths(get_option('prefix'), get_option('localedir'))
 data_dir = join_paths(get_option('prefix'), get_option('datadir'))
 plugins_dir = join_paths(get_option('prefix'), get_option('libdir'), meson.project_name(), 'plugins')
 pkgdata_dir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 pkglib_dir = join_paths(get_option('prefix'), get_option('libdir'), meson.project_name())
 
 conf = configuration_data()
+conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf.set_quoted('LOCALEDIR', locale_dir)
 conf.set_quoted('DATADIR', data_dir)
 conf.set_quoted('PKGDATADIR', pkgdata_dir)
 conf.set_quoted('PLUGINDIR', plugins_dir)

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -27,6 +27,11 @@ namespace Gala {
     }
 
     public static int main (string[] args) {
+        GLib.Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (Config.GETTEXT_PACKAGE);
+
         unowned OptionContext ctx = Meta.get_option_context ();
         ctx.add_main_entries (Gala.OPTIONS, null);
         try {

--- a/vapi/config.vapi
+++ b/vapi/config.vapi
@@ -18,6 +18,8 @@
 [CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
 namespace Config
 {
+	public const string GETTEXT_PACKAGE;
+	public const string LOCALEDIR;
 	public const string DATADIR;
 	public const string PKGDATADIR;
 	public const string VERSION;


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)