### PR TITLE
WindowSwitcher: draw from Gtk.StyleContext

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -22,7 +22,7 @@
 namespace Gala {
     public class WindowSwitcher : Clutter.Actor {
         public const int ICON_SIZE = 64;
-        public const int WRAPPER_BORDER_RADIUS = 12;
+        public const int WRAPPER_BORDER_RADIUS = 3;
         public const int WRAPPER_PADDING = 12;
         public const string CAPTION_FONT_NAME = "Inter";
 
@@ -280,8 +280,8 @@ namespace Gala {
             canvas.invalidate ();
 
             set_position (
-                geom.x + (geom.width - width) / 2,
-                geom.y + (geom.height - height) / 2
+                (int) (geom.x + (geom.width - width) / 2),
+                (int) (geom.y + (geom.height - height) / 2)
             );
 
             save_easing_state ();
@@ -376,7 +376,10 @@ namespace Gala {
 
             // Make caption smaller than the wrapper, so it doesn't overflow.
             caption.width = width - WRAPPER_PADDING * 2 * scaling_factor;
-            caption.set_position (WRAPPER_PADDING * scaling_factor, height - caption_height / 2 - (WRAPPER_PADDING * scaling_factor * 2));
+            caption.set_position (
+                WRAPPER_PADDING * scaling_factor,
+                (int) (height - caption_height / 2 - (WRAPPER_PADDING * scaling_factor * 2))
+            );
         }
 
         void update_indicator_position (bool initial = false) {

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -83,20 +83,21 @@ namespace Gala {
             }
 
             // Set the colours based on the person’s light/dark scheme preference.
-            var wrapper_background_color = "red";
-            var active_icon_color = "blue";
-            var caption_color = "green";
+            var wrapper_background_color = "#fafafa";
+            var caption_color = "#2e2e31";
 
-            if (granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.LIGHT || granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.NO_PREFERENCE) {
-                // Light mode.
-                wrapper_background_color = "#EAEAEAC8";
-                active_icon_color = "#5e5e6448";
-                caption_color = "#2e2e31";
-            } else {
-                // Dark mode.
-                wrapper_background_color = "#5e5e64C8";
-                active_icon_color = "#EAEAEA48";
-                caption_color = "#ffffff";
+            var rgba = InternalUtils.get_theme_accent_color ();
+            var accent_color = new Clutter.Color ();
+            accent_color.init (
+                (uint8) (rgba.red * 255),
+                (uint8) (rgba.green * 255),
+                (uint8) (rgba.blue * 255),
+                (uint8) (rgba.alpha * 255)
+            );
+
+            if (granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK) {
+                wrapper_background_color = "#333333";
+                caption_color = "#fafafa";
             }
 
             back_color = Clutter.Color.from_string (wrapper_background_color);
@@ -109,7 +110,7 @@ namespace Gala {
             container.button_press_event.connect (container_mouse_press);
             container.motion_event.connect (container_motion_event);
 
-            indicator = new RoundedActor (Clutter.Color.from_string (active_icon_color), WRAPPER_BORDER_RADIUS * scaling_factor);
+            indicator = new RoundedActor (accent_color, WRAPPER_BORDER_RADIUS * scaling_factor);
 
             indicator.margin_left = indicator.margin_top =
                 indicator.margin_right = indicator.margin_bottom = 0;


### PR DESCRIPTION
Draw the background of the switcher from a Gtk.StyleContext instead of hardcoding background/foreground/radius information

While here:
* Change the icon size to supported size
* Make sure we're drawing at integer values