### PR TITLE
autostarts: set hidden under systemd

### DIFF
--- a/data/gala-daemon.desktop
+++ b/data/gala-daemon.desktop
@@ -10,4 +10,5 @@ StartupNotify=true
 X-GNOME-AutoRestart=true
 X-GNOME-Autostart-Notify=true
 X-GNOME-Autostart-Phase=Desktop
+X-GNOME-HiddenUnderSystemd=true
 OnlyShowIn=Pantheon

--- a/data/gala-wayland.desktop
+++ b/data/gala-wayland.desktop
@@ -7,8 +7,9 @@ NoDisplay=true
 X-GNOME-WMSettingsModule=metacity
 # name we put on the WM spec check window
 X-GNOME-WMName=Gala
-# back compat only 
+# back compat only
 X-GnomeWMSettingsLibrary=metacity
 X-GNOME-Autostart-Phase=DisplayServer
 X-GNOME-Autostart-Notify=true
+X-GNOME-HiddenUnderSystemd=true
 X-Ubuntu-Gettext-Domain=gala

--- a/data/gala.desktop
+++ b/data/gala.desktop
@@ -7,9 +7,10 @@ NoDisplay=true
 X-GNOME-WMSettingsModule=metacity
 # name we put on the WM spec check window
 X-GNOME-WMName=Gala
-# back compat only 
+# back compat only
 X-GnomeWMSettingsLibrary=metacity
 X-GNOME-Autostart-Phase=WindowManager
 X-GNOME-Provides=windowmanager
 X-GNOME-Autostart-Notify=true
+X-GNOME-HiddenUnderSystemd=true
 X-Ubuntu-Gettext-Domain=gala


### PR DESCRIPTION
This is a prerequisite for https://github.com/elementary/session-settings/issues/17 but it has no effect on the current way we're doing session management.

See: https://manpages.debian.org/experimental/gnome-session-bin/gnome-session.1.en.html

This just prevents `gnome-session` from autostarting gala if systemd is launching the session instead, which it isn't, currently.

All of the gsd autostarts already have this property and they still function.