### PR TITLE
Add systemd units

### DIFF
--- a/data/gala-x11.service.in
+++ b/data/gala-x11.service.in
@@ -1,0 +1,28 @@
+[Unit]
+Description=Gala on X11
+# On X11, try to show the fail whale screen
+OnFailure=gnome-session-failed.target
+OnFailureJobMode=replace
+CollectMode=inactive-or-failed
+RefuseManualStart=on
+RefuseManualStop=on
+
+After=gnome-session-manager.target
+
+Requisite=gnome-session-initialized.target
+PartOf=gnome-session-initialized.target
+Before=gnome-session-initialized.target
+
+# Limit startup frequency more than the default
+StartLimitIntervalSec=15s
+StartLimitBurst=3
+
+[Service]
+Type=notify
+ExecStart=@bindir@/gala
+Restart=always
+# Do not wait before restarting
+RestartSec=0ms
+# Kill any stubborn child processes after this long
+TimeoutStopSec=5
+

--- a/data/gala-x11.target
+++ b/data/gala-x11.target
@@ -1,0 +1,10 @@
+[Unit]
+Description=Gala on X11
+DefaultDependencies=no
+
+Requisite=gnome-session-initialized.target
+PartOf=gnome-session-initialized.target
+Before=gnome-session-initialized.target
+
+Requires=gala-x11.service
+After=gala-x11.service

--- a/data/meson.build
+++ b/data/meson.build
@@ -42,3 +42,25 @@ icons_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')
 install_data('icons/32x32/multitasking-view.svg', install_dir: join_paths(icons_dir, '32x32', 'apps'))
 install_data('icons/48x48/multitasking-view.svg', install_dir: join_paths(icons_dir, '48x48', 'apps'))
 install_data('icons/64x64/multitasking-view.svg', install_dir: join_paths(icons_dir, '64x64', 'apps'))
+
+if get_option('systemd')
+    dep_systemd = dependency('systemd', required: true)
+    systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir')
+
+    bindir = join_paths(get_option('prefix'), get_option('bindir'))
+    unit_conf = configuration_data()
+    unit_conf.set('bindir', bindir)
+
+    configure_file(
+        input: 'gala-x11.service.in',
+        output: 'gala-x11.service',
+        install: true,
+        install_dir: systemd_userunitdir,
+        configuration: unit_conf
+    )
+
+    install_data(
+        'gala-x11.target',
+        install_dir: systemd_userunitdir
+    )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gala',
     'c', 'vala',
     version: '6.0.1',
-    meson_version: '>= 0.49.0',
+    meson_version: '>= 0.50.0',
     license: 'GPL3',
 )
 
@@ -98,6 +98,9 @@ gsd_dep = dependency('gnome-settings-daemon', version: '>= @0@'.format(gsd_versi
 m_dep = cc.find_library('m', required: false)
 posix_dep = vala.find_library('posix', required: false)
 gexiv2_dep = dependency('gexiv2')
+if get_option('systemd')
+    systemd_dep = cc.find_library('libsystemd', required: false)
+endif
 
 mutter_dep = []
 libmutter_dep = []
@@ -164,6 +167,11 @@ add_project_arguments(vala_flags, language: 'vala')
 add_project_link_arguments(['-Wl,-rpath,@0@'.format(mutter_typelib_dir)], language: 'c')
 
 gala_base_dep = [canberra_dep, glib_dep, gobject_dep, gio_dep, gmodule_dep, gee_dep, gtk_dep, plank_dep, mutter_dep, granite_dep, gnome_desktop_dep, m_dep, posix_dep, gexiv2_dep, config_dep]
+
+if get_option('systemd')
+    gala_base_dep += systemd_dep
+    vala_flags += ['--define', 'WITH_SYSTEMD']
+endif
 
 subdir('data')
 subdir('lib')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option ('documentation', type : 'boolean', value : false)
+option ('systemd', type : 'boolean', value : true)

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -350,6 +350,9 @@ namespace Gala {
 
             Idle.add (() => {
                 // let the session manager move to the next phase
+#if WITH_SYSTEMD
+                Systemd.Daemon.notify (true, "READY=1");
+#endif
 #if HAS_MUTTER41
                 display.get_context ().notify_ready ();
 #else

--- a/vapi/systemd.vapi
+++ b/vapi/systemd.vapi
@@ -1,0 +1,18 @@
+[CCode (cheader_filename = "systemd/sd-daemon.h")]
+namespace Systemd.Daemon {
+    [CCode (cname="sd_notify")]
+    int notify([CCode (type="int")]bool unset_environment, string state);
+
+    [CCode (cname="sd_notifyf")]
+    int notifyf([CCode (type="int")]bool unset_environment, string format, ...);
+
+    [CCode (cname="sd_pid_notify")]
+    int pid_notify(Posix.pid_t pid, [CCode (type="int")]bool unset_environment, string state);
+
+    [CCode (cname="sd_pid_notifyf")]
+    int pid_notifyf(Posix.pid_t pid, [CCode (type="int")]bool unset_environment, string format, ...);
+
+    [CCode (cname="sd_pid_notify_with_fds")]
+    int pid_notify_with_fds(Posix.pid_t pid, [CCode (type="int")]bool unset_environment, string state, int[] fds);
+}
+


### PR DESCRIPTION
Adds support for launching gala via the new systemd support in `gnome-session`. This has no effect on the current way of doing things as we're still using the `--builtin` flag on our session in session settings, but it prepares us for the future.

I've made this an option in meson so that distributions without systemd can use the old XDG autostarts way of launching gala in the future if they wish.

This can be tested in conjunction with https://github.com/elementary/gala/pull/1255 and https://github.com/elementary/session-settings/pull/55. If you remove the `--builtin` flag from `/usr/share/xsessions/pantheon.desktop`, `gnome-session` will launch Pantheon using the systemd units instead of the XDG autostarts.