### PR TITLE
Fix session crash when taking screenshots with mutter 3.38

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -354,12 +354,11 @@ namespace Gala {
                 paint_flags |= Clutter.PaintFlag.FORCE_CURSORS;
             }
 
-            unowned var data = image.get_data ();
             if (GLib.ByteOrder.HOST == GLib.ByteOrder.LITTLE_ENDIAN) {
                 wm.stage.paint_to_buffer (
                     {x, y, width, height},
                     scale,
-                    ref data,
+                    image.get_data (),
                     image.get_stride (),
                     Cogl.PixelFormat.BGRA_8888_PRE,
                     paint_flags
@@ -368,7 +367,7 @@ namespace Gala {
                 wm.stage.paint_to_buffer (
                     {x, y, width, height},
                     scale,
-                    ref data,
+                    image.get_data (),
                     image.get_stride (),
                     Cogl.PixelFormat.ARGB_8888_PRE,
                     paint_flags

--- a/vapi/mutter-clutter.vapi
+++ b/vapi/mutter-clutter.vapi
@@ -7336,7 +7336,7 @@ namespace Clutter {
 		[Version (since = "1.2")]
 		public bool get_use_alpha ();
 #if HAS_MUTTER338
-		public bool paint_to_buffer (Cairo.RectangleInt rect, float scale, [CCode (array_length = false)] ref unowned uint8[] data, int stride, Cogl.PixelFormat format, Clutter.PaintFlag paint_flags) throws GLib.Error;
+		public bool paint_to_buffer (Cairo.RectangleInt rect, float scale, [CCode (array_length = false, type = "uint8_t*")] uint8[] data, int stride, Cogl.PixelFormat format, Clutter.PaintFlag paint_flags) throws GLib.Error;
 		public void paint_to_framebuffer (Cogl.Framebuffer framebuffer, Cairo.RectangleInt rect, float scale, Clutter.PaintFlag paint_flags);
 #else
 		[Version (since = "0.4")]


### PR DESCRIPTION
This partly reverts mutter 3.38 changes introduced in 87d51c50fbd5a28d2d0d6c3872b4e15e39c9131a.

#### Problem description

- https://github.com/NixOS/nixpkgs/issues/139404

#### Related PR

- https://github.com/NixOS/nixpkgs/pull/139163
- https://github.com/elementary/gala/pull/980

---

@davidak I think this should work, would you like to test this (by adding [this patch](https://patch-diff.githubusercontent.com/raw/elementary/gala/pull/1259.patch) to gala and rebuild your system) and maybe provide some logs for the upstream?

Update: Downstream PR available at https://github.com/NixOS/nixpkgs/pull/139491.
