### PR TITLE
control: Add newer mutter versions to build depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgnome-desktop-3-dev,
                libgranite-dev (>= 5.4.0),
                libgtk-3-dev (>= 3.10.0),
-               libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev (>= 3.27.91) | libmutter-1-dev (>= 3.25.90) | libmutter-0-dev (>= 3.24.0) | libmutter-dev (>= 3.18.3),
+               libmutter-8-dev | libmutter-7-dev | libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev (>= 3.27.91) | libmutter-1-dev (>= 3.25.90) | libmutter-0-dev (>= 3.24.0) | libmutter-dev (>= 3.18.3),
                libplank-dev (>= 0.11.0),
                libxml2-utils,
                meson,
@@ -57,7 +57,7 @@ Section: libdevel
 Depends: libgala0 (= ${binary:Version}),
          libgdk-pixbuf2.0-dev,
          libglib2.0-dev (>= 2.44),
-         libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev (>= 3.27.91) | libmutter-1-dev (>= 3.25.90) | libmutter-0-dev (>= 3.24.0) | libmutter-dev (>= 3.18.3),
+         libmutter-8-dev | libmutter-7-dev | libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev (>= 3.27.91) | libmutter-1-dev (>= 3.25.90) | libmutter-0-dev (>= 3.24.0) | libmutter-dev (>= 3.18.3),
          ${misc:Depends}
 Description: Library to build plugins for Pantheon Window Manager (development files)
  gala is a window & compositing manager based on libmutter. It manages the


### PR DESCRIPTION
Allows us to start building against newer versions of mutter in the daily PPA