### PR TITLE
Multitasking View: Show nudge animation only on the primary display

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -472,7 +472,11 @@ namespace Gala {
                 neighbor.activate (display.get_current_time ());
             } else {
                 // if we didnt switch, show a nudge-over animation if one is not already in progress
-                play_nudge_animation (direction);
+                if (workspace_view.is_opened () && workspace_view is MultitaskingView) {
+                    ((MultitaskingView) workspace_view).play_nudge_animation (direction);
+                } else {
+                    play_nudge_animation (direction);
+                }
             }
         }
 


### PR DESCRIPTION
Requires https://github.com/elementary/gala/pull/1270

----------------------

When the multitasking view is opened and a the keyboard shortcuts are used to switch between workspaces, avoid showing the nudge/bump animation on the non-primary display.

Partially address #927