### PR TITLE
Enable "Alt" + "~" to switch between windows of the same application #888

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -16,6 +16,7 @@
         <ul>
           <li>Support for high-resolution scroll events</li>
           <li>Redesigned Alt + Tab switcher</li>
+          <li>Enable switch group shortcuts from mutter (Alt + AboveTab)</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -276,9 +276,6 @@ namespace Gala {
             Meta.KeyBinding.set_custom_handler ("move-to-workspace-left", (Meta.KeyHandlerFunc) handle_move_to_workspace);
             Meta.KeyBinding.set_custom_handler ("move-to-workspace-right", (Meta.KeyHandlerFunc) handle_move_to_workspace);
 
-            Meta.KeyBinding.set_custom_handler ("switch-group", () => {});
-            Meta.KeyBinding.set_custom_handler ("switch-group-backward", () => {});
-
             /*shadows*/
             InternalUtils.reload_shadow ();
             var shadow_settings = new GLib.Settings (Config.SCHEMA + ".shadows");


### PR DESCRIPTION
Supersedes #888
Fixes #536

Switching between different instances of the same applications via <kbd>Alt</kbd><kbd>Above_tab</kbd> is already implemented in mutter, but is - at least to my understanding - disabled by the following lines:

https://github.com/elementary/gala/blob/517748bcac9484df6a1f03c84f77c9a066ed8793/src/WindowManager.vala#L296-L297

Is there a reason behind this? 

This PR just enables the switch group shortcuts from mutter by removing these empty custom handlers.
