### PR TITLE
MultitaskingView: don't set custom easing mode

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -26,7 +26,6 @@ namespace Gala {
      */
     public class MultitaskingView : Actor, ActivatableComponent {
         public const int ANIMATION_DURATION = 250;
-        public const AnimationMode ANIMATION_MODE = AnimationMode.EASE_OUT_QUAD;
 
         private GestureTracker multitasking_gesture_tracker;
         private GestureTracker workspace_gesture_tracker;
@@ -715,7 +714,7 @@ namespace Gala {
 
                 GestureTracker.OnBegin on_animation_begin = () => {
                     clone.set_position (initial_x, initial_y);
-                    clone.set_easing_mode (0);
+                    clone.set_easing_mode (AnimationMode.LINEAR);
                 };
 
                 GestureTracker.OnUpdate on_animation_update = (percentage) => {
@@ -724,7 +723,7 @@ namespace Gala {
                 };
 
                 GestureTracker.OnEnd on_animation_end = (percentage, cancel_action) => {
-                    clone.set_easing_mode (ANIMATION_MODE);
+                    clone.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
 
                     if (cancel_action) {
                         return;
@@ -763,7 +762,7 @@ namespace Gala {
                     }
 
                     dock.set_easing_duration (ANIMATION_DURATION);
-                    dock.set_easing_mode (ANIMATION_MODE);
+                    dock.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                     dock.y = target_y;
                 };
 

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -230,7 +230,7 @@ namespace Gala {
             window_icon.opacity = 0;
             window_icon.set_pivot_point (0.5f, 0.5f);
             window_icon.set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-            window_icon.set_easing_mode (MultitaskingView.ANIMATION_MODE);
+            window_icon.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
             set_window_icon_position (window_frame_rect.width, window_frame_rect.height);
 
             window_title = new Tooltip ();
@@ -390,7 +390,7 @@ namespace Gala {
                 }
 
                 save_easing_state ();
-                set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                 set_easing_duration (animate ? MultitaskingView.ANIMATION_DURATION : 0);
 
                 set_position (target_x, target_y);
@@ -462,7 +462,7 @@ namespace Gala {
 
                 save_easing_state ();
                 set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-                set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                set_easing_mode (AnimationMode.EASE_OUT_QUAD);
 
                 set_size (rect.width, rect.height);
                 set_position (rect.x, rect.y);
@@ -612,7 +612,7 @@ namespace Gala {
             var shadow_transition = new PropertyTransition ("shadow-opacity") {
                 duration = MultitaskingView.ANIMATION_DURATION,
                 remove_on_complete = true,
-                progress_mode = MultitaskingView.ANIMATION_MODE
+                progress_mode = AnimationMode.EASE_OUT_QUAD
             };
 
             if (show)

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -355,13 +355,13 @@ namespace Gala {
 
                 save_easing_state ();
                 set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-                set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                 set_x (target_x);
                 restore_easing_state ();
 
                 background.save_easing_state ();
                 background.set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-                background.set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                background.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                 background.set_scale (scale, scale);
                 background.restore_easing_state ();
             };
@@ -425,13 +425,13 @@ namespace Gala {
 
                 save_easing_state ();
                 set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-                set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                 set_x (target_x);
                 restore_easing_state ();
 
                 background.save_easing_state ();
                 background.set_easing_duration (MultitaskingView.ANIMATION_DURATION);
-                background.set_easing_mode (MultitaskingView.ANIMATION_MODE);
+                background.set_easing_mode (AnimationMode.EASE_OUT_QUAD);
                 background.set_scale (1, 1);
                 background.restore_easing_state ();
             };


### PR DESCRIPTION
This fixes a terminal error about setting a non-existant custom easing mode. Presumably the original author intended to have "no" easing mode, which should mean `LINEAR`

Also removed the constant `ANIMATION_MODE` while we're here since that just obfuscates what the actual easing we're setting here is