### PR TITLE
Tooltip: null check text_actor before removing

### DIFF
--- a/src/Widgets/Tooltip.vala
+++ b/src/Widgets/Tooltip.vala
@@ -95,7 +95,9 @@ public class Gala.Tooltip : Clutter.Actor {
         }
 
         // First set the text
-        remove_child (text_actor);
+        if (text_actor != null) {
+            remove_child (text_actor);
+        }
 
         text_actor = new Clutter.Text () {
             color = text_color,


### PR DESCRIPTION
Fixes a crit in Terminal:
```
(gala:297380): Clutter-CRITICAL **: 10:48:57.281: clutter_actor_remove_child: assertion 'CLUTTER_IS_ACTOR (child)' failed
```