### PR TITLE
WindowClone: Include spread in bounding box

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -12,6 +12,10 @@
   <releases>
     <release version="6.2.2" date="2021-10-21" urgency="medium">
       <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Fix shadow clipping on server-side decorated windows</li>
+        </ul>
         <p>Improvements:</p>
         <ul>
           <li>Support for high-resolution scroll events</li>

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -28,7 +28,7 @@ namespace Gala {
 
         public override ActorBox get_bounding_box () {
             var scale_factor = InternalUtils.get_ui_scaling_factor ();
-            var size = shadow_size * scale_factor;
+            var size = shadow_size + shadow_spread * scale_factor;
 
             var input_rect = window.get_buffer_rect ();
             var outer_rect = window.get_frame_rect ();

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -28,7 +28,7 @@ namespace Gala {
 
         public override ActorBox get_bounding_box () {
             var scale_factor = InternalUtils.get_ui_scaling_factor ();
-            var size = shadow_size + shadow_spread * scale_factor;
+            var size = (shadow_size + shadow_spread) * scale_factor;
 
             var input_rect = window.get_buffer_rect ();
             var outer_rect = window.get_frame_rect ();


### PR DESCRIPTION
this seems to solve an issue where the shadows of SSD windows (like Gtk.FileChooser) were being clipped