### PR TITLE
WindowManager: dialogs fall down

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -17,6 +17,7 @@
           <li>Support for high-resolution scroll events</li>
           <li>Redesigned Alt + Tab switcher</li>
           <li>Dim the parents of modal dialogs</li>
+          <li>Dialogs fall down on parents instead of shooting out</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1366,12 +1366,12 @@ namespace Gala {
                     mapping.add (actor);
 
                     actor.set_pivot_point (0.5f, 0.5f);
-                    actor.set_scale (0.9f, 0.9f);
+                    actor.set_scale (1.05f, 1.05f);
                     actor.opacity = 0;
 
                     actor.save_easing_state ();
                     actor.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    actor.set_easing_duration (150);
+                    actor.set_easing_duration (200);
                     actor.set_scale (1.0f, 1.0f);
                     actor.opacity = 255U;
                     actor.restore_easing_state ();
@@ -1453,8 +1453,8 @@ namespace Gala {
                     actor.set_pivot_point (0.5f, 0.5f);
                     actor.save_easing_state ();
                     actor.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    actor.set_easing_duration (100);
-                    actor.set_scale (0.9f, 0.9f);
+                    actor.set_easing_duration (150);
+                    actor.set_scale (1.05f, 1.05f);
                     actor.opacity = 0U;
                     actor.restore_easing_state ();
 


### PR DESCRIPTION
dialogs fall down on top of windows instead of shooting out of them

https://user-images.githubusercontent.com/7277719/140624875-111a582f-d703-4383-b6cf-1a5a2abe3dc6.mp4