### PR TITLE
WindowManager: explicitly dim and undim

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -727,7 +727,7 @@ namespace Gala {
                 var ancestor = window.find_root_ancestor ();
                 if (ancestor != null && ancestor != window) {
                     var win = (Meta.WindowActor) ancestor.get_compositor_private ();
-                    // We can't necessarily rely on win.has_effects. Possible race condition
+                    // Can't rely on win.has_effects since other effects could be applied
                     if (dim) {
                         var dark_effect = new Clutter.BrightnessContrastEffect ();
                         dark_effect.set_brightness (-0.4f);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -722,18 +722,19 @@ namespace Gala {
                 out x, out y);
         }
 
-        private void toggle_dim_parent (Meta.Window window) {
+        private void dim_parent_window (Meta.Window window, bool dim) {
             if (window.window_type == Meta.WindowType.MODAL_DIALOG) {
                 var ancestor = window.find_root_ancestor ();
                 if (ancestor != null && ancestor != window) {
                     var win = (Meta.WindowActor) ancestor.get_compositor_private ();
-                    if (win.has_effects ()) {
-                        win.clear_effects ();
-                    } else {
+                    // We can't necessarily rely on win.has_effects. Possible race condition
+                    if (dim) {
                         var dark_effect = new Clutter.BrightnessContrastEffect ();
                         dark_effect.set_brightness (-0.4f);
 
                         win.add_effect (dark_effect);
+                    } else {
+                        win.clear_effects ();
                     }
                 }
             }
@@ -1387,7 +1388,7 @@ namespace Gala {
                         }
                     });
 
-                    toggle_dim_parent (window);
+                    dim_parent_window (window, true);
 
                     break;
                 case Meta.WindowType.NOTIFICATION:
@@ -1465,7 +1466,7 @@ namespace Gala {
                         destroy_completed (actor);
                     });
 
-                    toggle_dim_parent (window);
+                    dim_parent_window (window, false);
 
                     break;
                 case Meta.WindowType.MENU:


### PR DESCRIPTION
I've got into a situation a couple times where no dim effect is applied and then when the window is closed the dim is added. Oops