### PR TITLE
Control: Remove plank build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Build-Depends: debhelper (>= 10.5.1),
                libgranite-dev (>= 5.4.0),
                libgtk-3-dev (>= 3.10.0),
                libmutter-8-dev | libmutter-7-dev | libmutter-6-dev | libmutter-5-dev | libmutter-4-dev | libmutter-3-dev | libmutter-2-dev (>= 3.27.91) | libmutter-1-dev (>= 3.25.90) | libmutter-0-dev (>= 3.24.0) | libmutter-dev (>= 3.18.3),
-               libplank-dev (>= 0.11.0),
                libxml2-utils,
                meson,
                valac (>= 0.28.0)


### PR DESCRIPTION
After merging the new alt+tab we don't use this anymore