### PR TITLE
build: add systemduserunitdir option

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -45,7 +45,10 @@ install_data('icons/64x64/multitasking-view.svg', install_dir: join_paths(icons_
 
 if get_option('systemd')
     dep_systemd = dependency('systemd', required: true)
-    systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir')
+    systemd_userunitdir = get_option('systemduserunitdir')
+    if systemd_userunitdir == ''
+        systemd_userunitdir = dep_systemd.get_pkgconfig_variable('systemduserunitdir', define_variable: ['prefix', get_option('prefix')])
+    endif
 
     bindir = join_paths(get_option('prefix'), get_option('bindir'))
     unit_conf = configuration_data()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option ('documentation', type : 'boolean', value : false)
 option ('systemd', type : 'boolean', value : true)
+option ('systemduserunitdir', type : 'string', value : '')


### PR DESCRIPTION
On NixOS, `dep_systemd.get_pkgconfig_variable('systemduserunitdir')` returns a path we cannot write 😭

