### PR TITLE
WindowSwitcher: Clear indicator background

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -140,12 +140,15 @@ namespace Gala {
             indicator_canvas.scale_factor = scaling_factor;
             indicator_canvas.draw.connect ((ctx, width, height) => {
                 ctx.save ();
+                ctx.set_operator (Cairo.Operator.CLEAR);
+                ctx.paint ();
                 ctx.clip ();
                 ctx.reset_clip ();
 
                 // draw rect
                 Clutter.cairo_set_source_color (ctx, accent_color);
                 Granite.Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, rect_radius);
+                ctx.set_operator (Cairo.Operator.SOURCE);
                 ctx.fill ();
 
                 ctx.restore ();


### PR DESCRIPTION
Since 0c64b60729002131e08bf5ce4e489f7a05a9e135 the window switcher indicator shows artifacts as background.

Clear it before painting to make sure the background is properly displayed.

Here is what I mean with artifacts:

https://user-images.githubusercontent.com/1335948/143718603-48191fd5-34e1-456a-b9c9-64e966bec042.mp4


