### PR TITLE
WindowSwitcher: Follow accent color

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -43,6 +43,7 @@ namespace Gala {
         }
 
         construct {
+            var gtk_settings = Gtk.Settings.get_default ();
             granite_settings = Granite.Settings.get_default ();
 
             scaling_factor = InternalUtils.get_ui_scaling_factor ();
@@ -64,6 +65,11 @@ namespace Gala {
 
             // Redraw the components if the colour scheme changes.
             granite_settings.notify["prefers-color-scheme"].connect (() => {
+                canvas.invalidate ();
+                create_components ();
+            });
+
+            gtk_settings.notify["gtk-theme-name"].connect (() => {
                 canvas.invalidate ();
                 create_components ();
             });


### PR DESCRIPTION
Repaint the window switcher indicator when the accent color changes.

Fix #1316

---------------------------------

cc @danrabbit 

Because I think she is working on the GTK 4 style sheet. I'd be nice to know if this approach will work on a GTK 4 world or we'd need to add a new API to Granite similar to `prefers-color-scheme` but for accent colours.