### PR TITLE
Dialogs: add AccessDialog class

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -10,6 +10,15 @@
     <p>A window &amp; compositing manager based on libmutter and designed by elementary for use with Pantheon.</p>
   </description>
   <releases>
+    <release version="6.3.1" date="2021-12-01" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Use access portal for display settings confirmation dialog</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.3.0" date="2021-11-23" urgency="medium">
       <description>
         <p>Fixes:</p>

--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+namespace Gala {
+    [DBus (name = "org.freedesktop.impl.portal.Access")]
+    public interface AccessPortal : Object {
+        public abstract async void access_dialog (
+            ObjectPath request_path,
+            string app_id,
+            string window_handle,
+            string title,
+            string sub_title,
+            string body,
+            HashTable<string, Variant> options,
+            out uint response
+        ) throws IOError, DBusError;
+    }
+
+    [DBus (name = "org.freedesktop.impl.portal.Request")]
+    public interface Request : Object {
+        public abstract void close () throws DBusError, IOError;
+    }
+
+    public class AccessDialog : Object {
+        public Meta.Window parent { owned get; construct set; }
+
+        public string title { get; construct; }
+        public string body { get; construct; }
+        public string icon { get; construct; }
+        public string accept_label { get; set; }
+        public string deny_label { get; set; }
+
+        public signal void response (uint response);
+
+        const string PANTHEON_PORTAL_NAME = "org.freedesktop.impl.portal.desktop.pantheon";
+        const string FDO_PORTAL_PATH = "/org/freedesktop/portal/desktop";
+        const string GALA_DIALOG_PATH = "/io/elementary/gala/dialog";
+
+        protected static AccessPortal? portal = null;
+        protected ObjectPath? path = null;
+
+        public static void watch_portal () {
+            Bus.watch_name (BusType.SESSION, PANTHEON_PORTAL_NAME, BusNameWatcherFlags.NONE,
+                () => {
+                    try {
+                        portal = Bus.get_proxy_sync (BusType.SESSION, PANTHEON_PORTAL_NAME, FDO_PORTAL_PATH);
+                    } catch (Error e) {
+                        warning ("can't reach portal session: %s", e.message);
+                    }
+                },
+                () => {
+                    portal = null;
+                }
+            );
+        }
+
+        public AccessDialog (string title, string body, string icon) {
+            Object (title: title, body: body, icon: icon);
+        }
+
+        public virtual signal void show () {
+            path = new ObjectPath (GALA_DIALOG_PATH + "/%i".printf (Random.int_range (0, int.MAX)));
+            string parent_handler = "";
+            var app_id = "";
+
+            if (parent != null) {
+                if (parent.get_client_type () == Meta.WindowClientType.X11) {
+                    //TODO: wayland support
+                    parent_handler = "x11:%x".printf ((uint) parent.get_xwindow ());
+                }
+
+                app_id = parent.get_sandboxed_app_id () ?? "";
+            }
+
+            var options = new HashTable<string, Variant> (str_hash, str_equal);
+            options["grant_label"] = accept_label;
+            options["deny_label"] = deny_label;
+            options["icon"] = icon;
+
+            portal.access_dialog.begin (path, app_id, parent_handler, title, body, "", options, on_response);
+        }
+
+        public void close () {
+            if (path != null) {
+                try {
+                    Request request = Bus.get_proxy_sync (BusType.SESSION, PANTHEON_PORTAL_NAME, path);
+                    request.close ();
+                } catch (Error e) {
+                    warning (e.message);
+                }
+
+                path = null;
+            }
+        }
+
+        protected virtual void on_response (Object? obj, AsyncResult? res) {
+            uint ret;
+
+            try {
+                portal.access_dialog.end (res, out ret);
+            } catch (Error e) {
+                warning (e.message);
+                ret = 2;
+            }
+
+            response (ret);
+            close ();
+        }
+    }
+}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2056,7 +2056,6 @@ namespace Gala {
 
             dialog.show.connect (() => {
                 Timeout.add_seconds (30, () => {
-                    dialog.response (Gtk.ResponseType.CANCEL);
                     dialog.close ();
 
                     return Source.REMOVE;
@@ -2064,7 +2063,7 @@ namespace Gala {
             });
 
             dialog.response.connect ((res) => {
-                complete_display_change (res == Gtk.ResponseType.OK);
+                complete_display_change (res == 0);
             });
 
             dialog.show ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -138,6 +138,7 @@ namespace Gala {
             show_stage ();
 
             Bus.watch_name (BusType.SESSION, DAEMON_DBUS_NAME, BusNameWatcherFlags.NONE, daemon_appeared, lost_daemon);
+            AccessDialog.watch_portal ();
 
             unowned Meta.Display display = get_display ();
             display.gl_video_memory_purged.connect (() => {
@@ -2048,24 +2049,25 @@ namespace Gala {
         }
 
         public override void confirm_display_change () {
-            var pid = Meta.Util.show_dialog ("--question",
-                _("Does the display look OK?"),
-                "30",
-                null,
-                _("Keep This Configuration"),
-                _("Restore Previous Configuration"),
-                "preferences-desktop-display",
-                0,
-                null, null);
+            var dialog = new AccessDialog (_("Does the display look OK?"), "", "preferences-desktop-display") {
+                accept_label = _("Keep This Configuration"),
+                deny_label = _("Restore Previous Configuration")
+            };
 
-            ChildWatch.add (pid, (pid, status) => {
-                var ok = false;
-                try {
-                    ok = Process.check_exit_status (status);
-                } catch (Error e) {}
+            dialog.show.connect (() => {
+                Timeout.add_seconds (30, () => {
+                    dialog.response (Gtk.ResponseType.CANCEL);
+                    dialog.close ();
 
-                complete_display_change (ok);
+                    return Source.REMOVE;
+                });
             });
+
+            dialog.response.connect ((res) => {
+                complete_display_change (res == Gtk.ResponseType.OK);
+            });
+
+            dialog.show ();
         }
 
         public override unowned Meta.PluginInfo? plugin_info () {

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 gala_bin_sources = files(
     'DBus.vala',
     'DBusAccelerator.vala',
+    'Dialogs.vala',
     'GalaAccountsServicePlugin.vala',
     'InternalUtils.vala',
     'KeyboardManager.vala',


### PR DESCRIPTION
Use our implementation of  `org.freedesktop.impl.Portal.Access` to show the display change dialog. there's a issue when switchboard-plug-display is open that makes all dialogs  spawn at (0,0). i don't know if it is fixable here or in the plug.

![Screenshot from 2021-11-30 19 00 20](https://user-images.githubusercontent.com/21296444/144258596-6656af3c-4dc1-424e-983c-2a3d06470614.png)

we can make this a sort of "frontend" by getting the backend bus name the same way xdg-desktop-portal gets it, if wanted.

fixes #1306
