### PR TITLE
1323: Always subtract from nat_width the scaled padding over children count

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -278,9 +278,7 @@ namespace Gala {
             float nat_width, nat_height;
             container.get_preferred_size (null, null, out nat_width, null);
 
-            if (container.get_n_children () == 1) {
-                nat_width -= WRAPPER_PADDING * scaling_factor;
-            }
+            nat_width -= (WRAPPER_PADDING * scaling_factor) / container.get_n_children ();
 
             container.get_preferred_size (null, null, null, out nat_height);
 


### PR DESCRIPTION
Resolves #1323 . This fixes an off-by-one adjacent error that left the indicator off by an amount based on the scale factor times the children.

The fix can be verified by logging the values for the container.width - (indicator.x + indicator.width) for the final item in the window, and ensuring it is the same as the indicator.x value for the first item in the window.

We will never divide by zero due to the check at the top of the function exiting if the children count is zero.