### PR TITLE
switcher: fix container staying reactive in scene

### DIFF
--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -332,7 +332,7 @@ namespace Gala {
             container.reactive = show;
         }
 
-        void push_modal() {
+        void push_modal () {
             modal_proxy = wm.push_modal ();
             modal_proxy.keybinding_filter = (binding) => {
                 // if it's not built-in, we can block it right away

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -304,7 +304,7 @@ namespace Gala {
                 (int) (geom.y + (geom.height - height) / 2)
             );
 
-            toggle_display(true);
+            toggle_display (true);
 
             // if we did not have the grab before the key was released, close immediately
             if ((get_current_modifiers () & modifier_mask) == 0) {
@@ -312,14 +312,14 @@ namespace Gala {
             }
         }
 
-        void toggle_display(bool show) {
+        void toggle_display (bool show) {
             if (opened == show) {
                 return;
             }
 
             opened = show;
             if (show) {
-                push_modal();
+                push_modal ();
             } else {
                 wm.pop_modal (modal_proxy);
             }
@@ -368,7 +368,7 @@ namespace Gala {
                 }
             }
 
-            toggle_display(false);
+            toggle_display (false);
         }
 
         void next_window (Meta.Display display, Meta.Workspace? workspace, bool backward) {

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -304,11 +304,35 @@ namespace Gala {
                 (int) (geom.y + (geom.height - height) / 2)
             );
 
+            toggle_display(true);
+
+            // if we did not have the grab before the key was released, close immediately
+            if ((get_current_modifiers () & modifier_mask) == 0) {
+                close_switcher (wm.get_display ().get_current_time ());
+            }
+        }
+
+        void toggle_display(bool show) {
+            if (opened == show) {
+                return;
+            }
+
+            opened = show;
+            if (show) {
+                push_modal();
+            } else {
+                wm.pop_modal (modal_proxy);
+            }
+
             save_easing_state ();
             set_easing_duration (200);
-            opacity = 255;
+            opacity = show ? 255 : 0;
             restore_easing_state ();
 
+            container.reactive = show;
+        }
+
+        void push_modal() {
             modal_proxy = wm.push_modal ();
             modal_proxy.keybinding_filter = (binding) => {
                 // if it's not built-in, we can block it right away
@@ -322,23 +346,13 @@ namespace Gala {
                     || name == "switch-windows" || name == "switch-windows-backward");
             };
 
-            opened = true;
-
             grab_key_focus ();
-
-            // if we did not have the grab before the key was released, close immediately
-            if ((get_current_modifiers () & modifier_mask) == 0) {
-                close_switcher (wm.get_display ().get_current_time ());
-            }
         }
 
         void close_switcher (uint32 time, bool cancel = false) {
             if (!opened) {
                 return;
             }
-
-            wm.pop_modal (modal_proxy);
-            opened = false;
 
             var window = cur_icon.window;
             if (window == null) {
@@ -354,10 +368,7 @@ namespace Gala {
                 }
             }
 
-            save_easing_state ();
-            set_easing_duration (100);
-            opacity = 0;
-            restore_easing_state ();
+            toggle_display(false);
         }
 
         void next_window (Meta.Display display, Meta.Workspace? workspace, bool backward) {


### PR DESCRIPTION
I noticed that I was not able to click some windows underneath the new alt-tab switcher.

Here is my hypothesis why this was only rarely noticed (one other report here: https://github.com/elementary/gala/issues/1322 but seemingly with a different cause?):

The container of the switcher stays reactive, however it is pushed underneath the **active** window, meaning no harm is done. However, **inactive** windows are not raised above the switcher, meaning clicks on inactive windows get absorbed by the invisible switcher.

As part of this PR, I extracted all logic that concerns showing/hiding into a toggle_display method, mostly for my own sanity that all "show things" are also properly undone when hiding. The minimal change to fix this behavior would have been to set `container.reactive = true/false` at each `opened = true/false`.