### PR TITLE
fix workspace clone not resizing on monitor change

### DIFF
--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -61,6 +61,10 @@ namespace Gala {
         }
 
         public virtual signal void show () {
+            if (portal == null) {
+                return;
+            }
+
             path = new ObjectPath (GALA_DIALOG_PATH + "/%i".printf (Random.int_range (0, int.MAX)));
             string parent_handler = "";
             var app_id = "";

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -157,6 +157,11 @@ namespace Gala {
 
             set_position (primary_geometry.x, primary_geometry.y);
             set_size (primary_geometry.width, primary_geometry.height);
+
+            foreach (var child in workspaces.get_children ()) {
+                unowned WorkspaceClone workspace_clone = (WorkspaceClone) child;
+                workspace_clone.update_size (primary_geometry);
+            }
         }
 
         /**

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -409,10 +409,16 @@ namespace Gala {
                 window_icon.opacity = 0;
                 set_window_icon_position (outer_rect.width, outer_rect.height);
 
-                window_icon.get_transition ("opacity").completed.connect (() => {
+                var transition = window_icon.get_transition ("opacity");
+                if (transition != null) {
+                    transition.completed.connect (() => {
+                        in_slot_animation = false;
+                        place_widgets (outer_rect.width, outer_rect.height);
+                    });
+                } else {
                     in_slot_animation = false;
                     place_widgets (outer_rect.width, outer_rect.height);
-                });
+                }
             };
 
             if (!animate || gesture_tracker == null || !with_gesture) {

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -603,7 +603,7 @@ namespace Gala {
             close_button.opacity = show ? 255 : 0;
             window_title.opacity = close_button.opacity;
 
-            window_title.set_text (window.get_title (), false);
+            window_title.set_text (window.get_title () ?? "", false);
             window_title.set_max_width (dest_width - (TITLE_MAX_WIDTH_MARGIN * scale_factor));
             set_window_title_position (dest_width, dest_height);
 

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -266,7 +266,7 @@ namespace Gala {
                 remove_window (window);
         }
 
-        void update_size (Meta.Rectangle monitor_geometry) {
+        public void update_size (Meta.Rectangle monitor_geometry) {
             if (window_container.width != monitor_geometry.width || window_container.height != monitor_geometry.height) {
                 window_container.set_size (monitor_geometry.width, monitor_geometry.height);
                 background.set_size (window_container.width, window_container.height);


### PR DESCRIPTION
Workspace clones in the multitasking view haven't been resizing when monitors change (as for example reported in  #484). This should fix it.

Note: the PR contains two unrelated fixes:
* there was a segfault on monitor changes when gala was started from a context where the portal could not be acquired (e.g. when started from a TTY for debugging purposes)
* windows can apparently have NULL titles, e.g. spotify creates a somewhat broken window. Adding the empty string as fallback removes a lot of noise from the output for failed assertions.