### PR TITLE
WindowClone: Remove Granite.CloseButtonPosition

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -266,7 +266,7 @@ namespace Gala {
          * itself at the location of the original window. Also adds the shadow
          * effect and makes sure the shadow is updated on size changes.
          *
-         * @param was_waiting Internal argument used to indicate that we had to 
+         * @param was_waiting Internal argument used to indicate that we had to
          *                    wait before the window's texture became available.
          */
         void load_clone (bool was_waiting = false) {
@@ -576,8 +576,6 @@ namespace Gala {
          * at their positions inside the actor for a given width and height.
          */
         public void place_widgets (int dest_width, int dest_height) {
-            Granite.CloseButtonPosition pos;
-            Granite.Widgets.Utils.get_default_close_button_position (out pos);
             var scale_factor = InternalUtils.get_ui_scaling_factor ();
 
             close_button.save_easing_state ();
@@ -589,15 +587,9 @@ namespace Gala {
             close_button.set_size (close_button_size, close_button_size);
 
             close_button.y = -close_button.height * 0.33f;
-
-            switch (pos) {
-                case Granite.CloseButtonPosition.RIGHT:
-                    close_button.x = dest_width - close_button.width * 0.5f;
-                    break;
-                case Granite.CloseButtonPosition.LEFT:
-                    close_button.x = -close_button.width * 0.5f;
-                    break;
-            }
+            close_button.x = is_close_button_on_left () ?
+                -close_button.width * 0.5f :
+                dest_width - close_button.width * 0.5f;
 
             bool show = has_pointer && !in_slot_animation;
             close_button.opacity = show ? 255 : 0;
@@ -745,7 +737,7 @@ namespace Gala {
 
         /**
          * When we cross an IconGroup, we animate to an even smaller size and slightly
-         * less opacity and add ourselves as temporary window to the group. When left, 
+         * less opacity and add ourselves as temporary window to the group. When left,
          * we reverse those steps.
          */
         void drag_destination_crossed (Actor destination, bool hovered) {
@@ -907,6 +899,17 @@ namespace Gala {
             var x = InternalUtils.pixel_align ((window_width - window_title.width) / 2);
             var y = InternalUtils.pixel_align (window_height - (WINDOW_ICON_SIZE * scale_factor) * 0.75f - (window_title.height / 2) - (18 * scale_factor));
             window_title.set_position (x, y);
+        }
+
+        private static bool is_close_button_on_left () {
+            var layout = Meta.Prefs.get_button_layout ();
+            foreach (var button_function in layout.right_buttons) {
+                if (button_function == Meta.ButtonFunction.CLOSE) {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
The API Granite.CloseButtonPosition has been deprecated [1].

Remove it from Gala and always place the close button on the left of
the window in the multitasking view.

[1] https://github.com/elementary/granite/pull/568