### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/Plugin.vala
+++ b/lib/Plugin.vala
@@ -86,23 +86,23 @@ namespace Gala {
          * It is calculated by the system whenever update_region is called.
          * You can influce it with the custom_region and the track_actor function.
          */
-        public Meta.Rectangle[] region { get; private set; }
-
+        private Meta.Rectangle[] region;
+        public Meta.Rectangle[] get_region () {
+            return region;
+        }
         /**
          * This list will be merged with the region property. See region for
          * more details. Changing this property will cause update_region to be
          * called. Default to null.
          */
-        protected Meta.Rectangle[]? custom_region {
-            get {
-                return _custom_region;
-            }
-            protected set {
-                _custom_region = value;
-                update_region ();
-            }
+        private Meta.Rectangle[]? _custom_region = null;
+        protected Meta.Rectangle[]? get_custom_region () {
+            return _custom_region;
         }
-
+        protected void set_custom_region (Meta.Rectangle[]? custom_region) {
+            _custom_region = custom_region;
+            update_region ();
+        }
         /**
          * Set this property to true while animating an actor if you have tracked
          * actors to prevent constant recalculations of the regions during an
@@ -121,7 +121,6 @@ namespace Gala {
         }
 
         private bool _freeze_track = false;
-        private Meta.Rectangle[]? _custom_region = null;
         private List<Clutter.Actor> tracked_actors = new List<Clutter.Actor> ();
 
         /**
@@ -174,6 +173,7 @@ namespace Gala {
          * wm aware of the new position of the actor in question.
          */
         public void update_region () {
+            var custom_region = get_custom_region ();
             var has_custom = custom_region != null;
             var len = tracked_actors.length () + (has_custom ? custom_region.length : 0);
 

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -66,7 +66,14 @@ namespace Gala {
          * Defaults to blocking all.
          * @see KeybindingFilter
          */
-        public KeybindingFilter? keybinding_filter { get; owned set; default = () => true; }
+        private KeybindingFilter? _keybinding_filter = () => true;
+        public KeybindingFilter? get_keybinding_filter () {
+            return _keybinding_filter;
+        }
+
+        public void set_keybinding_filter (KeybindingFilter? filter) {
+            _keybinding_filter = filter;
+        }
 
         public ModalProxy () {
         }
@@ -75,7 +82,7 @@ namespace Gala {
          * Small utility to allow all keybindings
          */
         public void allow_all_keybindings () {
-            keybinding_filter = null;
+            _keybinding_filter = null;
         }
     }
 

--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -127,7 +127,7 @@ namespace Gala {
             background.set_data<ulong> ("background-loaded-handler", handler);
         }
 
-        public void set_size (float width, float height) {
+        public new void set_size (float width, float height) {
             if (width != background_actor.width || height != background_actor.height) {
                 update_background_actor (false);
             }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -124,7 +124,7 @@ namespace Gala {
 
                     // add plugin's requested areas
                     if (area == InputArea.FULLSCREEN || area == InputArea.DEFAULT) {
-                        foreach (var rect in PluginManager.get_default ().regions) {
+                        foreach (var rect in PluginManager.get_default ().get_regions ()) {
                             rects += rect;
                         }
                     }

--- a/src/PluginManager.vala
+++ b/src/PluginManager.vala
@@ -31,7 +31,10 @@ namespace Gala {
 
         public bool initialized { get; private set; default = false; }
 
-        public X.Xrectangle[] regions { get; private set; }
+        private X.Xrectangle[] _regions = {};
+        public X.Xrectangle[] get_regions () {
+            return _regions;
+        }
 
         public string? window_switcher_provider { get; private set; default = null; }
         public string? desktop_provider { get; private set; default = null; }
@@ -201,7 +204,7 @@ namespace Gala {
             X.Xrectangle[] regions = {};
 
             plugins.@foreach ((name, plugin) => {
-                foreach (var region in plugin.region) {
+                foreach (var region in plugin.get_region ()) {
                     X.Xrectangle rect = {
                         (short) region.x,
                         (short) region.y,
@@ -213,7 +216,7 @@ namespace Gala {
                 }
             });
 
-            this.regions = regions;
+            this._regions = regions;
             regions_changed ();
         }
     }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -590,7 +590,7 @@ namespace Gala {
 
             if (opening) {
                 modal_proxy = wm.push_modal ();
-                modal_proxy.keybinding_filter = keybinding_filter;
+                modal_proxy.set_keybinding_filter (keybinding_filter);
 
                 wm.background_group.hide ();
                 wm.window_group.hide ();

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -321,7 +321,10 @@ namespace Gala {
             GestureTracker.OnEnd on_animation_end = (percentage, cancel_action, calculated_duration) => {
                 workspace_gesture_tracker.enabled = false;
 
-                var duration = is_nudge_animation ? (AnimationDuration.NUDGE / 2) : calculated_duration;
+                var duration = is_nudge_animation ?
+                               (uint)(AnimationDuration.NUDGE / 2) :
+                               (uint)(calculated_duration.clamp (0, AnimationDuration.WORKSPACE_SWITCH));
+
                 workspaces.set_easing_duration (duration);
                 workspaces.x = (is_nudge_animation || cancel_action) ? initial_x : target_x;
 

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -158,7 +158,7 @@ namespace Gala {
             grab_key_focus ();
 
             modal_proxy = wm.push_modal ();
-            modal_proxy.keybinding_filter = keybinding_filter;
+            modal_proxy.set_keybinding_filter (keybinding_filter);
 
             visible = true;
 

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -332,7 +332,7 @@ namespace Gala {
 
         void push_modal () {
             modal_proxy = wm.push_modal ();
-            modal_proxy.keybinding_filter = (binding) => {
+            modal_proxy.set_keybinding_filter ((binding) => {
                 // if it's not built-in, we can block it right away
                 if (!binding.is_builtin ())
                     return true;
@@ -342,7 +342,7 @@ namespace Gala {
 
                 return !(name == "switch-applications" || name == "switch-applications-backward"
                     || name == "switch-windows" || name == "switch-windows-backward");
-            };
+            });
 
             grab_key_focus ();
         }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2042,10 +2042,14 @@ namespace Gala {
                 return false;
 
             var modal_proxy = modal_stack.peek_head ();
+            if (modal_proxy != null) {
+                var filter = modal_proxy.get_keybinding_filter ();
+                if (filter != null) {
+                    return filter (binding);
+                }
+            }
 
-            return (modal_proxy != null
-                && modal_proxy.keybinding_filter != null
-                && modal_proxy.keybinding_filter (binding));
+            return false;
         }
 
         public override void confirm_display_change () {


### PR DESCRIPTION
Silences warnings when compiling.

Unclear whether these warnings might be having any practical effect on the operation of Gala or causing any bugs.

Running with this PR has not caused any regressions so far.