### PR TITLE
Remove redundant test

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -123,11 +123,10 @@ namespace Gala {
                     rects = {topleft, topright, bottomleft, bottomright};
 
                     // add plugin's requested areas
-                    if (area == InputArea.FULLSCREEN || area == InputArea.DEFAULT) {
-                        foreach (var rect in PluginManager.get_default ().regions) {
-                            rects += rect;
-                        }
+                    foreach (var rect in PluginManager.get_default ().regions) {
+                        rects += rect;
                     }
+
                     break;
                 case InputArea.NONE:
                 default:


### PR DESCRIPTION
While studying Gala code it was noticed that an if clause contained an `OR` statement where one condition could never be `true` since it already been dealt with earlier in a switch clause.

In order to keep the behaviour the same as at present, the redundant if statement is just removed. Plugin areas are still not added in the case of InputArea.FULLSCREEN.