### PR TITLE
Allow super key in multitasking view

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -785,6 +785,7 @@ namespace Gala {
                 case KeyBindingAction.WORKSPACE_LEFT:
                 case KeyBindingAction.WORKSPACE_RIGHT:
                 case KeyBindingAction.SHOW_DESKTOP:
+                case KeyBindingAction.OVERLAY_KEY:
                     return false;
                 default:
                     return true;


### PR DESCRIPTION
This works well in conjunction with https://github.com/elementary/switchboard-plug-keyboard/pull/400 , allowing the multitasking view to be closed again with another Super keypress.

There doesn't seem to be any additional work needed to get it to play nice with the other options for the Super key. Opening either the applications menu or the shortcut overlay with the super key also closes the multitasking view, which I guess is what we would expect.