### PR TITLE
Control: runtime depend on elementary portals

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Package: gala
 Architecture: any
 Depends: gnome-settings-daemon (>= 3.15.2),
          gsettings-desktop-schemas,
+         io.elementary.portals (>=1.1.0),
          libgala0 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Since we're now using the access portal for display settings confirmation and force quit dialogs, we should runtime depend on it