### PR TITLE
[OS 7] Tooltip: Remove text size workaround for Mutter 10

### DIFF
--- a/src/Widgets/Tooltip.vala
+++ b/src/Widgets/Tooltip.vala
@@ -119,10 +119,14 @@ public class Gala.Tooltip : Clutter.Actor {
             color = text_color,
             x = padding.left,
             y = padding.top,
-            ellipsize = Pango.EllipsizeMode.MIDDLE,
-            use_markup = true
+            ellipsize = Pango.EllipsizeMode.MIDDLE
         };
+#if HAS_MUTTER42
+        text_actor.text = text;
+#else
+        text_actor.use_markup = true;
         text_actor.set_markup (Markup.printf_escaped ("<span size='large'>%s</span>", text));
+#endif
 
         if ((text_actor.width + padding.left + padding.right) > max_width) {
             text_actor.width = max_width - padding.left - padding.right;


### PR DESCRIPTION
Hi! This is a elementary OS 7 bug. I'm not sure whether we are already focusing on v7 on the `master` branch or if I should add a `#ifdef`. 

---------------------------

Previous to Mutter 10 it was necessary to set the text size to large in order to avoid displaying a tiny text in a Clutter.Text.

With Mutter 10, the default text size matches the system font size and the workaround is no longer necessary.

Before:

![tooltip-before](https://user-images.githubusercontent.com/1335948/163053780-0d76a749-20b8-46c5-9656-abb9d9230bd0.png)

After:

![tooltip-after](https://user-images.githubusercontent.com/1335948/163053801-7c6af3ab-32e3-4eb9-b7df-baa7eb93435b.png)

