### PR TITLE
Move panel-main-menu schema in house

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -155,6 +155,10 @@
       <default><![CDATA[['<Super><Shift>Tab']]]></default>
       <summary>Cycle to the next workspace to the right or to back to the first</summary>
     </key>
+    <key type="as" name="panel-main-menu">
+      <default><![CDATA[['<Super>space','<Alt>F2']]]></default>
+      <summary>Open the applications menu</summary>
+    </key>
     <key type="as" name="switch-input-source">
       <default><![CDATA[['<Alt>space']]]></default>
       <summary>Cycle to next keyboard layout</summary>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -242,13 +242,10 @@ namespace Gala {
             display.add_keybinding ("move-to-workspace-last", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_move_to_workspace_end);
             display.add_keybinding ("cycle-workspaces-next", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
             display.add_keybinding ("cycle-workspaces-previous", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
+            display.add_keybinding ("panel-main-menu", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_applications_menu);
 
             display.overlay_key.connect (() => {
                 launch_action ("overlay-action");
-            });
-
-            Meta.KeyBinding.set_custom_handler ("panel-main-menu", () => {
-                launch_action ("panel-main-menu-action");
             });
 
             Meta.KeyBinding.set_custom_handler ("toggle-recording", () => {
@@ -434,6 +431,12 @@ namespace Gala {
             unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
             var index = (binding.get_name () == "switch-to-workspace-first" ? 0 : manager.n_workspaces - 1);
             manager.get_workspace_by_index (index).activate (display.get_current_time ());
+        }
+
+        [CCode (instance_pos = -1)]
+        void handle_applications_menu (Meta.Display display, Meta.Window? window,
+            Clutter.KeyEvent event, Meta.KeyBinding binding) {
+            launch_action ("panel-main-menu-action");
         }
 
         private void on_gesture_detected (Gesture gesture) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -242,7 +242,13 @@ namespace Gala {
             display.add_keybinding ("move-to-workspace-last", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_move_to_workspace_end);
             display.add_keybinding ("cycle-workspaces-next", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
             display.add_keybinding ("cycle-workspaces-previous", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
+#if HAS_MUTTER41
             display.add_keybinding ("panel-main-menu", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_applications_menu);
+#else
+            Meta.KeyBinding.set_custom_handler ("panel-main-menu", () => {
+                launch_action ("panel-main-menu-action");
+            });
+#endif
 
             display.overlay_key.connect (() => {
                 launch_action ("overlay-action");
@@ -433,11 +439,13 @@ namespace Gala {
             manager.get_workspace_by_index (index).activate (display.get_current_time ());
         }
 
+#if HAS_MUTTER41
         [CCode (instance_pos = -1)]
         void handle_applications_menu (Meta.Display display, Meta.Window? window,
             Clutter.KeyEvent event, Meta.KeyBinding binding) {
             launch_action ("panel-main-menu-action");
         }
+#endif
 
         private void on_gesture_detected (Gesture gesture) {
             if (workspace_view.is_opened ()) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -245,9 +245,7 @@ namespace Gala {
 #if HAS_MUTTER41
             display.add_keybinding ("panel-main-menu", keybinding_settings, 0, (Meta.KeyHandlerFunc) handle_applications_menu);
 #else
-            Meta.KeyBinding.set_custom_handler ("panel-main-menu", () => {
-                launch_action ("panel-main-menu-action");
-            });
+            Meta.KeyBinding.set_custom_handler ("panel-main-menu", (Meta.KeyHandlerFunc) handle_applications_menu);
 #endif
 
             display.overlay_key.connect (() => {
@@ -439,13 +437,11 @@ namespace Gala {
             manager.get_workspace_by_index (index).activate (display.get_current_time ());
         }
 
-#if HAS_MUTTER41
         [CCode (instance_pos = -1)]
         void handle_applications_menu (Meta.Display display, Meta.Window? window,
             Clutter.KeyEvent event, Meta.KeyBinding binding) {
             launch_action ("panel-main-menu-action");
         }
-#endif
 
         private void on_gesture_detected (Gesture gesture) {
             if (workspace_view.is_opened ()) {


### PR DESCRIPTION
Fixes #1395 

The GNOME GSettings key we were piggybacking for this was deprecated a long time ago and mutter has finally stopped exposing those events. So, lets set up our own key.

This will require some work in the keyboard plug to change the setting on this key instead.