### PR TITLE
Move screenshot shortcuts in-house

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -60,11 +60,11 @@ namespace Gala {
         ulong on_visible_workspace_sid = 0U;
 
         private static GLib.Settings keybind_settings;
-        private static GLib.Settings media_keys_settings;
+        private static GLib.Settings gala_keybind_settings;
 
         static construct {
             keybind_settings = new GLib.Settings ("org.gnome.desktop.wm.keybindings");
-            media_keys_settings = new GLib.Settings ("org.gnome.settings-daemon.plugins.media-keys");
+            gala_keybind_settings = new GLib.Settings ("org.pantheon.desktop.gala.keybindings");
         }
 
         [DBus (visible = false)]
@@ -269,7 +269,7 @@ namespace Gala {
                 move_left_accellabel.accel_string = keybind_settings.get_strv ("move-to-workspace-left")[0];
             }
 
-            screenshot_accellabel.accel_string = media_keys_settings.get_strv ("window-screenshot")[0];
+            screenshot_accellabel.accel_string = gala_keybind_settings.get_strv ("window-screenshot")[0];
 
             close.visible = Gala.WindowFlags.CAN_CLOSE in flags;
             if (close.visible) {

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -159,6 +159,30 @@
       <default><![CDATA[['<Super>space','<Alt>F2']]]></default>
       <summary>Open the applications menu</summary>
     </key>
+    <key name="screenshot" type="as">
+      <default><![CDATA[['Print']]]></default>
+      <summary>Take a screenshot</summary>
+    </key>
+    <key name="window-screenshot" type="as">
+      <default><![CDATA[['<Alt>Print']]]></default>
+      <summary>Take a screenshot of a window</summary>
+    </key>
+    <key name="area-screenshot" type="as">
+      <default><![CDATA[['<Shift>Print']]]></default>
+      <summary>Take a screenshot of an area</summary>
+    </key>
+    <key name="screenshot-clip" type="as">
+      <default><![CDATA[['<Control>Print']]]></default>
+      <summary>Copy a screenshot to clipboard</summary>
+    </key>
+    <key name="window-screenshot-clip" type="as">
+      <default><![CDATA[['<Control><Alt>Print']]]></default>
+      <summary>Copy a screenshot of a window to clipboard</summary>
+    </key>
+    <key name="area-screenshot-clip" type="as">
+      <default><![CDATA[['<Control><Shift>Print']]]></default>
+      <summary>Copy a screenshot of an area to clipboard</summary>
+    </key>
     <key type="as" name="switch-input-source">
       <default><![CDATA[['<Alt>space']]]></default>
       <summary>Cycle to next keyboard layout</summary>


### PR DESCRIPTION
Fixes #1410 

Since GNOME 42, `gnome-shell` handles the screenshot keybinding and it has been removed from GSD, so we have to re-implement it here.