### PR TITLE
MultitaskingView: Remove key_focus_out override

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -165,15 +165,6 @@ namespace Gala {
         }
 
         /**
-         * We generally assume that when the key-focus-out signal is emitted
-         * a different component was opened, so we close in that case.
-         */
-        public override void key_focus_out () {
-            if (opened && !contains (get_stage ().key_focus))
-                toggle ();
-        }
-
-        /**
          * Scroll through workspaces with the mouse wheel. Smooth scrolling is handled by
          * GestureTracker.
          */


### PR DESCRIPTION
Removing this fixes a bug where scrolling in multitasking view closes it in OS 7.

I'm not really sure what the original intention here was. I tried to get back through get history to get a clearer picture:
* https://github.com/elementary/gala/commit/5adb6566f6f42bb6affa548ba66b0c996e6bc79c
* https://github.com/elementary/gala/commit/4ec9f2e6b6b5c7bd7f59e22affdb289299ab3756
* https://github.com/elementary/gala/commit/96748eededb0fa82456396aad79409d67578aceb

Afaict all keyboard interaction still works as expected without this