### PR TITLE
Fix multitasking view allocation assertions

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -674,9 +674,6 @@ namespace Gala {
         }
 
         void show_docks (bool with_gesture, bool is_cancel_animation) {
-            float clone_offset_x, clone_offset_y;
-            dock_clones.get_transformed_position (out clone_offset_x, out clone_offset_y);
-
             unowned GLib.List<Meta.WindowActor> window_actors = display.get_window_actors ();
             foreach (unowned Meta.WindowActor actor in window_actors) {
                 const int MAX_OFFSET = 85;
@@ -702,11 +699,11 @@ namespace Gala {
                 if (!top && !bottom)
                     continue;
 
-                var initial_x = actor.x - clone_offset_x;
-                var initial_y = actor.y - clone_offset_y;
+                var initial_x = actor.x;
+                var initial_y = actor.y;
                 var target_y = (top)
-                    ? actor.y - actor.height - clone_offset_y
-                    : actor.y + actor.height - clone_offset_y;
+                    ? actor.y - actor.height
+                    : actor.y + actor.height;
 
                 var clone = new SafeWindowClone (window, true);
                 dock_clones.add_child (clone);
@@ -742,13 +739,10 @@ namespace Gala {
         }
 
         void hide_docks (bool with_gesture, bool is_cancel_animation) {
-            float clone_offset_x, clone_offset_y;
-            dock_clones.get_transformed_position (out clone_offset_x, out clone_offset_y);
-
             foreach (var child in dock_clones.get_children ()) {
                 var dock = (Clone) child;
                 var initial_y = dock.y;
-                var target_y = dock.source.y - clone_offset_y;
+                var target_y = dock.source.y;
 
                 GestureTracker.OnUpdate on_animation_update = (percentage) => {
                     var y = GestureTracker.animation_value (initial_y, target_y, percentage);


### PR DESCRIPTION
Fixes the spam of the following assertion that we get when opening and closing the multitasking view:

```
clutter_actor_allocate: assertion '!isnan (real_allocation.x1) && !isnan (real_allocation.x2) && !isnan (real_allocation.y1) && !isnan (real_allocation.y2)' failed
```

This is because `dock_clones` is just an empty actor used to contain the clones of the dock and wingpanel. It initially doesn't have an allocation, and we never change its position, so we don't need to offset by it.

This code is responsible for animating wingpanel and plank in and out during the toggling of multitasking view. It appears to still work manually opening the view, but I haven't tested gestures.