### PR TITLE
WindowClone: Always add the click action

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -101,14 +101,14 @@ public class Gala.WindowClone : Clutter.Actor {
         window.notify["maximized-horizontally"].connect (check_shadow_requirements);
         window.notify["maximized-vertically"].connect (check_shadow_requirements);
 
-        if (overview_mode) {
-            var click_action = new Clutter.ClickAction ();
-            click_action.clicked.connect (() => {
-                actor_clicked (click_action.get_button ());
-            });
+        var click_action = new Clutter.ClickAction ();
+        click_action.clicked.connect (() => {
+            actor_clicked (click_action.get_button ());
+        });
 
-            add_action (click_action);
-        } else {
+        add_action (click_action);
+
+        if (!overview_mode) {
             drag_action = new DragDropAction (DragDropActionType.SOURCE, "multitaskingview-window");
             drag_action.drag_begin.connect (drag_begin);
             drag_action.destination_crossed.connect (drag_destination_crossed);


### PR DESCRIPTION
We always want to listen to the click signal.
Fixes #1442