### PR TITLE
Don't animate workspaces behind multitasking view

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1752,7 +1752,8 @@ namespace Gala {
             if (!enable_animations
                 || AnimationDuration.WORKSPACE_SWITCH == 0
                 || (direction != Meta.MotionDirection.LEFT && direction != Meta.MotionDirection.RIGHT)
-                || animating_switch_workspace) {
+                || animating_switch_workspace
+                || workspace_view.is_opened ()) {
                 animating_switch_workspace = false;
                 switch_workspace_completed ();
                 return;


### PR DESCRIPTION
Fixes #1354

The multitasking view has its own cloned view of the workspaces and windows that it animates, so we don't need to be animating the actual workspaces and windows behind it, which messes up our window clones.