### PR TITLE
AppSystem: make wmclass nullable

### DIFF
--- a/lib/AppSystem.vala
+++ b/lib/AppSystem.vala
@@ -39,7 +39,11 @@ public class Gala.AppSystem : GLib.Object {
         return app;
     }
 
-    public unowned Gala.App? lookup_startup_wmclass (string wmclass) {
+    public unowned Gala.App? lookup_startup_wmclass (string? wmclass) {
+        if (wmclass == null) {
+            return null;
+        }
+
         GLib.DesktopAppInfo? info = app_cache.lookup_startup_wmclass (wmclass);
         if (info == null) {
             return null;
@@ -74,7 +78,11 @@ public class Gala.AppSystem : GLib.Object {
         return null;
     }
 
-    public unowned Gala.App? lookup_desktop_wmclass (string wmclass) {
+    public unowned Gala.App? lookup_desktop_wmclass (string? wmclass) {
+        if (wmclass == null) {
+            return null;
+        }
+
         /* First try without changing the case (this handles
         org.example.Foo.Bar.desktop applications)
 


### PR DESCRIPTION
`get_wm_class` and `get_wm_class_instance` in Mutter can return `null` which we were passing to our non-nullable methods. So I was getting a bunch of criticals in my logs.