### PR TITLE
Improve multitasking view animation performance

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -445,8 +445,19 @@ public class Gala.WindowClone : Clutter.Actor {
             return;
 
         clone.set_scale (scale_factor, scale_factor);
-        clone.set_position ((input_rect.x - outer_rect.x) * scale_factor,
-            (input_rect.y - outer_rect.y) * scale_factor);
+
+        // Scaling happens around the pivot point, so we need to move the clone
+        // to compensate for the difference between the pivot point and the
+        // top left corner of the clone.
+
+        float pivot_x, pivot_y;
+        clone.get_pivot_point (out pivot_x, out pivot_y);
+        var absolute_pivot_x = pivot_x * clone.width;
+        var absolute_pivot_y = pivot_y * clone.height;
+        var x_offset = absolute_pivot_x * (scale_factor - 1);
+        var y_offset = absolute_pivot_y * (scale_factor - 1);
+        clone.set_position ((input_rect.x - outer_rect.x) * scale_factor + x_offset,
+                            (input_rect.y - outer_rect.y) * scale_factor + y_offset);
     }
 
     public override bool button_press_event (Clutter.ButtonEvent event) {

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -430,8 +430,8 @@ public class Gala.WindowClone : Clutter.Actor {
         Clutter.ActorBox shape_alloc = {
             -ACTIVE_SHAPE_SIZE,
             -ACTIVE_SHAPE_SIZE,
-            outer_rect.width + ACTIVE_SHAPE_SIZE * 2,
-            outer_rect.height + ACTIVE_SHAPE_SIZE * 2
+            outer_rect.width * scale_factor + ACTIVE_SHAPE_SIZE,
+            outer_rect.height * scale_factor + ACTIVE_SHAPE_SIZE
         };
 #if HAS_MUTTER338
         active_shape.allocate (shape_alloc);
@@ -899,10 +899,7 @@ public class Gala.WindowClone : Clutter.Actor {
             cr.paint ();
             cr.restore ();
 
-            var corrected_width = ((float) width - ACTIVE_SHAPE_SIZE * 2) * scale_factor;
-            var corrected_height = ((float) height - ACTIVE_SHAPE_SIZE * 2) * scale_factor;
-
-            Drawing.Utilities.cairo_rounded_rectangle (cr, 0, 0, corrected_width + ACTIVE_SHAPE_SIZE, corrected_height + ACTIVE_SHAPE_SIZE, border_radius);
+            Drawing.Utilities.cairo_rounded_rectangle (cr, 0, 0, width, height, border_radius);
             cr.set_source_rgba (color.red, color.green, color.blue, COLOR_OPACITY);
             cr.fill ();
 

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -422,45 +422,13 @@ public class Gala.WindowClone : Clutter.Actor {
         base.allocate (box, flags);
 #endif
 
-        foreach (var child in get_children ()) {
-            if (child != clone && child != active_shape)
-#if HAS_MUTTER338
-                child.allocate_preferred_size (child.fixed_x, child.fixed_y);
-#else
-                child.allocate_preferred_size (flags);
-#endif
-        }
-
-        Clutter.ActorBox shape_alloc = {
-            -ACTIVE_SHAPE_SIZE,
-            -ACTIVE_SHAPE_SIZE,
-            box.get_width () + ACTIVE_SHAPE_SIZE,
-            box.get_height () + ACTIVE_SHAPE_SIZE
-        };
-#if HAS_MUTTER338
-        active_shape.allocate (shape_alloc);
-#else
-        active_shape.allocate (shape_alloc, flags);
-#endif
-
         if (clone == null || dragging)
             return;
 
-        var actor = (Meta.WindowActor) window.get_compositor_private ();
-        var input_rect = window.get_buffer_rect ();
         var outer_rect = window.get_frame_rect ();
         var scale_factor = (float)width / outer_rect.width;
 
-        Clutter.ActorBox alloc = {};
-        alloc.set_origin ((input_rect.x - outer_rect.x) * scale_factor,
-                          (input_rect.y - outer_rect.y) * scale_factor);
-        alloc.set_size (actor.width * scale_factor, actor.height * scale_factor);
-
-#if HAS_MUTTER338
-        clone.allocate (alloc);
-#else
-        clone.allocate (alloc, flags);
-#endif
+        clone.set_scale (scale_factor, scale_factor);
     }
 
     public override bool button_press_event (Clutter.ButtonEvent event) {

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -884,8 +884,7 @@ public class Gala.WindowClone : Clutter.Actor {
         }
 
         public void set_scale_factor (float scale_factor) {
-            if (this.scale_factor != scale_factor)
-            {
+            if (this.scale_factor != scale_factor) {
                 this.scale_factor = scale_factor;
 
                 // perf: don't bother rerendering if we're invisible
@@ -910,8 +909,7 @@ public class Gala.WindowClone : Clutter.Actor {
             return false;
         }
 
-        private bool should_disregard_allocation (int width, int height)
-        {
+        private bool should_disregard_allocation (int width, int height) {
             // TODO: why are width and height sometimes 0?
             return width == 0 || height == 0 || (width == last_width && height == last_height);
         }

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -425,10 +425,13 @@ public class Gala.WindowClone : Clutter.Actor {
         if (clone == null || dragging)
             return;
 
+        var input_rect = window.get_buffer_rect ();
         var outer_rect = window.get_frame_rect ();
         var scale_factor = (float)width / outer_rect.width;
 
         clone.set_scale (scale_factor, scale_factor);
+        clone.set_position ((input_rect.x - outer_rect.x) * scale_factor,
+            (input_rect.y - outer_rect.y) * scale_factor);
     }
 
     public override bool button_press_event (Clutter.ButtonEvent event) {


### PR DESCRIPTION
This animation is currently super stuttery, especially on high-resolution devices. It was getting on my nerves. The reason it's slow is because we constantly reallocate resources instead of just scaling the actors we already have. On top of that, we also allocate a new texture every single time a `FramedBackground` was painted. Allocating stuff in the render loop is generally a bad idea.

So I removed a bunch of seemingly useless code and started caching resources in `FramedBackground` - and now it runs at 240fps on my laptop even with power savings enabled!

This is marked "draft" because I have no idea what I'm doing, and I assume there was a good reason for all the complexity inside `WindowClone.allocate`. That being said, after mercilessly ripping out all that code, everything seems to work OK on my end. Just opening this PR to get some feedback and hopefully understand why/whether this complexity is necessary.