### PR TITLE
Fix awkward two-finger scroll in multitasking view

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -316,8 +316,10 @@ namespace Gala {
                                (uint) (AnimationDuration.NUDGE / 2) :
                                (uint) calculated_duration;
 
+                workspaces.save_easing_state ();
                 workspaces.set_easing_duration (duration);
                 workspaces.x = (is_nudge_animation || cancel_action) ? initial_x : target_x;
+                workspaces.restore_easing_state ();
 
                 workspaces.get_transition ("x").completed.connect (() => {
                     workspace_gesture_tracker.enabled = true;
@@ -325,6 +327,8 @@ namespace Gala {
                     if (!is_nudge_animation && !cancel_action) {
                         manager.get_workspace_by_index (target_workspace_index).activate (display.get_current_time ());
                         update_positions (false);
+                    } else {
+                        reset_easing_parameters ();
                     }
                 });
             };
@@ -366,6 +370,14 @@ namespace Gala {
             workspaces.x = -active_x;
 
             reposition_icon_groups (animate);
+        }
+
+        /**
+         * Reset easing parameters to whatever they were before the animation started.
+         */
+
+        void reset_easing_parameters () {
+            workspaces.set_easing_duration (0);
         }
 
         void reposition_icon_groups (bool animate) {

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -328,7 +328,9 @@ namespace Gala {
                         manager.get_workspace_by_index (target_workspace_index).activate (display.get_current_time ());
                         update_positions (false);
                     } else {
-                        reset_easing_parameters ();
+                        // Reset easing parameters either way.
+                        // This stops the animation from causing touch events to "lag" behind.
+                        workspaces.set_easing_duration (0);
                     }
                 });
             };
@@ -370,14 +372,6 @@ namespace Gala {
             workspaces.x = -active_x;
 
             reposition_icon_groups (animate);
-        }
-
-        /**
-         * Reset easing parameters to whatever they were before the animation started.
-         */
-
-        void reset_easing_parameters () {
-            workspaces.set_easing_duration (0);
         }
 
         void reposition_icon_groups (bool animate) {


### PR DESCRIPTION
Easing wasn't being correctly used when scrolling between workspaces with the touchpad in the multitasking view. There were two problems with this: scrolling seemed to lag behind the user's fingers sometimes, and letting go of the touchpad would almost always cause a jarring jump.

This little patch fixes both of these issues, making everything silky smooth.

If someone's not clear on what specifically we're solving here, I could record my screen and my hand on my touchpad before & after this patch. It really is night and day.