### PR TITLE
WindowClone: Fix shadows

### DIFF
--- a/data/gala.css
+++ b/data/gala.css
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2014 Gala Developers
+ *  Copyright 2014 Gala Developers
+ *  Copyright 2022 elementary, Inc. (https://elementary.io)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,14 +30,6 @@
 }
 
 .decoration {
-    border-radius: 4px 4px 0 0;
-    box-shadow:
-        0 0 0 1px alpha(#000, 0.3),
-        0 14px 20px rgba(0, 0, 0, 0.35),
-        0 10px 10px rgba(0, 0, 0, 0.22);
-}
-
-.workspace.decoration {
     border-radius: 4px;
     box-shadow:
         0 0 0 1px alpha(#000, 0.2),

--- a/data/gala.css
+++ b/data/gala.css
@@ -37,6 +37,14 @@
         0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
+.window-clone.decoration {
+    border-radius: 0;
+    box-shadow:
+        0 0 0 1px alpha(#000, 0.3),
+        0 14px 20px rgba(0, 0, 0, 0.35),
+        0 10px 10px rgba(0, 0, 0, 0.22);
+}
+
 .workspace.decoration {
     border-radius: 4px;
     box-shadow:

--- a/data/gala.css
+++ b/data/gala.css
@@ -30,6 +30,14 @@
 }
 
 .decoration {
+    border-radius: 4px 4px 0 0;
+    box-shadow:
+        0 0 0 1px alpha(#000, 0.3),
+        0 14px 20px rgba(0, 0, 0, 0.35),
+        0 10px 10px rgba(0, 0, 0, 0.22);
+}
+
+.workspace.decoration {
     border-radius: 4px;
     box-shadow:
         0 0 0 1px alpha(#000, 0.2),

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -224,7 +224,7 @@ public class Gala.WindowClone : Clutter.Actor {
 
         if (window.fullscreen || window.maximized_horizontally && window.maximized_vertically) {
             if (shadow_effect == null) {
-                shadow_effect = new WindowShadowEffect (window, 40, 5);
+                shadow_effect = new WindowShadowEffect (window, 40);
                 clone.add_effect_with_name ("shadow", shadow_effect);
             }
         } else {
@@ -824,13 +824,13 @@ public class Gala.WindowClone : Clutter.Actor {
     private class WindowShadowEffect : ShadowEffect {
         public unowned Meta.Window window { get; construct; }
 
-        public WindowShadowEffect (Meta.Window window, int shadow_size, int shadow_spread) {
-            Object (window: window, shadow_size: shadow_size, shadow_spread: shadow_spread, shadow_opacity: 255);
+        public WindowShadowEffect (Meta.Window window, int shadow_size) {
+            Object (window: window, shadow_size: shadow_size);
         }
 
         public override Clutter.ActorBox get_bounding_box () {
             var scale_factor = InternalUtils.get_ui_scaling_factor ();
-            var size = (shadow_size + shadow_spread) * scale_factor;
+            var size = shadow_size * scale_factor;
 
             var input_rect = window.get_buffer_rect ();
             var outer_rect = window.get_frame_rect ();

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -825,7 +825,7 @@ public class Gala.WindowClone : Clutter.Actor {
         public unowned Meta.Window window { get; construct; }
 
         public WindowShadowEffect (Meta.Window window, int shadow_size) {
-            Object (window: window, shadow_size: shadow_size);
+            Object (window: window, shadow_size: shadow_size, css_class: "window-clone");
         }
 
         public override Clutter.ActorBox get_bounding_box () {

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -55,10 +55,8 @@ namespace Gala {
             // Carry out the initial draw
             create_components ();
 
-            // FIXME: Kind of abusing the style class here for a smaller shadow
-            var effect = new ShadowEffect (30, 1) {
-                shadow_opacity = 200,
-                css_class = "workspace"
+            var effect = new ShadowEffect (30) {
+                shadow_opacity = 200
             };
 
             add_effect (effect);

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -56,7 +56,8 @@ namespace Gala {
             create_components ();
 
             var effect = new ShadowEffect (30) {
-                shadow_opacity = 200
+                shadow_opacity = 200,
+                css_class = "workspace"
             };
 
             add_effect (effect);

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -55,6 +55,7 @@ namespace Gala {
             // Carry out the initial draw
             create_components ();
 
+            // FIXME: Kind of abusing the style class here for a smaller shadow
             var effect = new ShadowEffect (30) {
                 shadow_opacity = 200,
                 css_class = "workspace"

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -39,7 +39,9 @@ namespace Gala {
             var primary = display.get_primary_monitor ();
             var monitor_geom = display.get_monitor_geometry (primary);
 
-            var effect = new ShadowEffect (40);
+            var effect = new ShadowEffect (40) {
+                css_class = "workspace"
+            };
             add_effect (effect);
         }
 

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -39,9 +39,7 @@ namespace Gala {
             var primary = display.get_primary_monitor ();
             var monitor_geom = display.get_monitor_geometry (primary);
 
-            var effect = new ShadowEffect (40, 5) {
-                css_class = "workspace"
-            };
+            var effect = new ShadowEffect (40);
             add_effect (effect);
         }
 


### PR DESCRIPTION
Fixes #1203

Before:

![Screenshot from 2022-12-26 17 15 04](https://user-images.githubusercontent.com/80143868/209523573-003a87ef-776e-42fb-91b3-73458674cc43.png)

After:

![Screenshot from 2022-12-26 17 14 41](https://user-images.githubusercontent.com/80143868/209523561-6a56420b-3ce0-4d21-8cb9-d11d1737e14d.png)


Remove unused `window_spread` property.
Introduce a new `window-clone` css class with `border-radius: 0;` corners for WindowClone
Reuse values from `get_bounding_box` in `modify_paint_volume`
