### PR TITLE
Draft: Fix PiP window being undraggable

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -316,8 +316,6 @@ namespace Gala {
                             ungrab_actor ();
                             grab_actor (handle, event.get_device ());
 
-                            handle.reactive = false;
-
                             var source_list = sources.@get (drag_id);
                             if (source_list != null) {
                                 var dest_list = destinations[drag_id];


### PR DESCRIPTION
Dragging PiP views was practically impossible on my end; once I started dragging a PiP window, it would stop listening for any further drag events and I'd need to let go and start dragging again if I wanted to move it more than ~30px.

I assume there was a good reason reactivity was being disabled here, so that's why I'm marking this as a draft. I haven't noticed any adverse effects from removing this line, and PiP is now usable on my end.

Before:

https://user-images.githubusercontent.com/1385480/209759009-eacb95ed-a828-465b-a185-a62d448a523b.mp4

After:

https://user-images.githubusercontent.com/1385480/209759019-743772ff-051c-491f-868b-08122f841953.mp4

