### PR TITLE
Fix PiP positioning offset

### DIFF
--- a/plugins/pip/Main.vala
+++ b/plugins/pip/Main.vala
@@ -79,6 +79,12 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin {
                 int point_x = x - (int)active.x;
                 int point_y = y - (int)active.y;
 
+                // Compensate for server-side window decorations
+                var input_rect = active.get_meta_window().get_buffer_rect ();
+                var outer_rect = active.get_meta_window().get_frame_rect ();
+                point_x -= outer_rect.x - input_rect.x;
+                point_y -= outer_rect.y - input_rect.y;
+
                 var rect = Graphene.Rect.alloc ();
                 rect.init (point_x, point_y, width, height);
 

--- a/plugins/pip/Main.vala
+++ b/plugins/pip/Main.vala
@@ -80,8 +80,8 @@ public class Gala.Plugins.PIP.Plugin : Gala.Plugin {
                 int point_y = y - (int)active.y;
 
                 // Compensate for server-side window decorations
-                var input_rect = active.get_meta_window().get_buffer_rect ();
-                var outer_rect = active.get_meta_window().get_frame_rect ();
+                var input_rect = active.get_meta_window ().get_buffer_rect ();
+                var outer_rect = active.get_meta_window ().get_frame_rect ();
                 point_x -= outer_rect.x - input_rect.x;
                 point_y -= outer_rect.y - input_rect.y;
 


### PR DESCRIPTION
Fixes #849 

When choosing a PiP region for certain windows with server-side decorations (such as shadows), the clipped window we displayed in the PiP overlay would be ultimately offset by (what I believe is) the Gala-side decorated area of the window - that is, the window shadow.

What this means is that for most apps, users would see a slightly different region of the window than they chose. This didn't happen for all applications, but it did happen for some very common ones (Firefox, Chrome, Terminal...)

This patch makes it so that we now take this into account before setting the clip rect for the PiP view.