### PR TITLE
WindowManager: `confirm_display_change()` Fixes

### DIFF
--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -60,6 +60,7 @@ namespace Gala {
             Object (title: title, body: body, icon: icon);
         }
 
+        [Signal (run = "first")]
         public virtual signal void show () {
             if (portal == null) {
                 return;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2122,17 +2122,21 @@ namespace Gala {
 
         public override void confirm_display_change () {
             var timeout = Meta.MonitorManager.get_display_configuration_timeout ();
+            var summary = ngettext (
+                "Changes will automatically revert after %i second.",
+                "Changes will automatically revert after %i seconds.",
+                timeout
+            );
             uint dialog_timeout_id = 0;
 
             var dialog = new AccessDialog (
                 _("Keep new display settings?"),
-                _("Changes will automatically revert after %i seconds.").printf (timeout),
+                summary.printf (timeout),
                 "preferences-desktop-display"
             ) {
                 accept_label = _("Keep Settings"),
                 deny_label = _("Use Previous Settings")
             };
-
 
             dialog.show.connect (() => {
                 dialog_timeout_id = Timeout.add_seconds (timeout, () => {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2121,17 +2121,22 @@ namespace Gala {
         }
 
         public override void confirm_display_change () {
+            var timeout = Meta.MonitorManager.get_display_configuration_timeout ();
+            uint dialog_timeout_id = 0;
+
             var dialog = new AccessDialog (
                 _("Keep new display settings?"),
-                _("Changes will automatically revert after 30 seconds."),
+                _("Changes will automatically revert after %i seconds.").printf (timeout),
                 "preferences-desktop-display"
             ) {
                 accept_label = _("Keep Settings"),
                 deny_label = _("Use Previous Settings")
             };
 
+
             dialog.show.connect (() => {
-                Timeout.add_seconds (30, () => {
+                dialog_timeout_id = Timeout.add_seconds (timeout, () => {
+                    dialog_timeout_id = 0;
                     dialog.close ();
 
                     return Source.REMOVE;
@@ -2139,6 +2144,11 @@ namespace Gala {
             });
 
             dialog.response.connect ((res) => {
+                if (dialog_timeout_id != 0) {
+                    Source.remove (dialog_timeout_id);
+                    dialog_timeout_id = 0;
+                }
+
                 complete_display_change (res == 0);
             });
 


### PR DESCRIPTION
the value of 30 seconds here is wrong, and the dialog was outliving the timeout used by mutter internally. instead of hardcoding the right values here too, use the mutter provided function to query the real timeout.

also, make `AccessDialog.show()` base handler run first than signal callbacks, and that we only call `AccesDialog.close()` when we don't receive a response.