### PR TITLE
Extend list of allowed keybindings in multitasking view

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -12,6 +12,18 @@
   </description>
 
   <releases>
+    <release version="7.0.1" date="2023-02-09" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/gala/issues/24">Workspace switching shortcuts don't work in Multitasking View</issue>
+      </issues>
+    </release>
+
     <release version="7.0.0" date="2023-01-05" urgency="medium">
       <description>
         <p>Improvements:</p>

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -68,11 +68,11 @@ namespace Gala {
             flash_actor.set_background_color (Clutter.Color.get_static (Clutter.StaticColor.WHITE));
             flash_actor.set_opacity (0);
             flash_actor.transitions_completed.connect ((actor) => {
-                wm.top_window_group.remove_child (actor);
+                wm.ui_group.remove_child (actor);
                 actor.destroy ();
             });
 
-            wm.top_window_group.add_child (flash_actor);
+            wm.ui_group.add_child (flash_actor);
             flash_actor.add_transition ("flash", transition);
         }
 

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -68,11 +68,11 @@ namespace Gala {
             flash_actor.set_background_color (Clutter.Color.get_static (Clutter.StaticColor.WHITE));
             flash_actor.set_opacity (0);
             flash_actor.transitions_completed.connect ((actor) => {
-                wm.ui_group.remove_child (actor);
+                wm.top_window_group.remove_child (actor);
                 actor.destroy ();
             });
 
-            wm.ui_group.add_child (flash_actor);
+            wm.top_window_group.add_child (flash_actor);
             flash_actor.add_transition ("flash", transition);
         }
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -810,7 +810,7 @@ namespace Gala {
                 default:
                     break;
             }
-            
+
             switch (binding.get_name ()) {
                 case "screenshot":
                 case "screenshot-clip":

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -814,6 +814,8 @@ namespace Gala {
             switch (binding.get_name ()) {
                 case "screenshot":
                 case "screenshot-clip":
+                case "area-screenshot":
+                case "area-screenshot-clip":
                 case "cycle-workspaces-next":
                 case "cycle-workspaces-previous":
                 case "switch-to-workspace-first":

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -814,8 +814,6 @@ namespace Gala {
             switch (binding.get_name ()) {
                 case "screenshot":
                 case "screenshot-clip":
-                case "area-screenshot":
-                case "area-screenshot-clip":
                 case "cycle-workspaces-next":
                 case "cycle-workspaces-previous":
                 case "switch-to-workspace-first":

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -780,7 +780,7 @@ namespace Gala {
             }
         }
 
-        bool keybinding_filter (KeyBinding binding) {
+        private bool keybinding_filter (KeyBinding binding) {
             var action = Prefs.get_keybinding_action (binding.get_name ());
 
             // allow super key only when it toggles multitasking view
@@ -790,14 +790,40 @@ namespace Gala {
             }
 
             switch (action) {
+                case KeyBindingAction.WORKSPACE_1:
+                case KeyBindingAction.WORKSPACE_2:
+                case KeyBindingAction.WORKSPACE_3:
+                case KeyBindingAction.WORKSPACE_4:
+                case KeyBindingAction.WORKSPACE_5:
+                case KeyBindingAction.WORKSPACE_6:
+                case KeyBindingAction.WORKSPACE_7:
+                case KeyBindingAction.WORKSPACE_8:
+                case KeyBindingAction.WORKSPACE_9:
+                case KeyBindingAction.WORKSPACE_10:
+                case KeyBindingAction.WORKSPACE_11:
+                case KeyBindingAction.WORKSPACE_12:
                 case KeyBindingAction.WORKSPACE_LEFT:
                 case KeyBindingAction.WORKSPACE_RIGHT:
                 case KeyBindingAction.SHOW_DESKTOP:
                 case KeyBindingAction.NONE:
                     return false;
                 default:
-                    return true;
+                    break;
             }
+            
+            switch (binding.get_name ()) {
+                case "screenshot":
+                case "screenshot-clip":
+                case "cycle-workspaces-next":
+                case "cycle-workspaces-previous":
+                case "switch-to-workspace-first":
+                case "switch-to-workspace-last":
+                    return false;
+                default:
+                    break;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -812,8 +812,6 @@ namespace Gala {
             }
 
             switch (binding.get_name ()) {
-                case "screenshot":
-                case "screenshot-clip":
                 case "cycle-workspaces-next":
                 case "cycle-workspaces-previous":
                 case "switch-to-workspace-first":

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -26,6 +26,7 @@ namespace Gala {
      */
     public class MultitaskingView : Actor, ActivatableComponent {
         public const int ANIMATION_DURATION = 250;
+        private const string OPEN_MULTITASKING_VIEW = "dbus-send --session --dest=org.pantheon.gala --print-reply /org/pantheon/gala org.pantheon.gala.PerformAction int32:1";
 
         private GestureTracker multitasking_gesture_tracker;
         private GestureTracker workspace_gesture_tracker;
@@ -45,11 +46,15 @@ namespace Gala {
         Actor workspaces;
         Actor dock_clones;
 
+        private GLib.Settings gala_behavior_settings;
+
         public MultitaskingView (WindowManager wm) {
             Object (wm: wm);
         }
 
         construct {
+            gala_behavior_settings = new GLib.Settings ("org.pantheon.desktop.gala.behavior");
+
             visible = false;
             reactive = true;
             clip_to_allocation = true;
@@ -777,11 +782,17 @@ namespace Gala {
 
         bool keybinding_filter (KeyBinding binding) {
             var action = Prefs.get_keybinding_action (binding.get_name ());
+
+            // allow super key only when it toggles multitasking view
+            if (action == KeyBindingAction.OVERLAY_KEY &&
+                gala_behavior_settings.get_string ("overlay-action") == OPEN_MULTITASKING_VIEW) {
+                return false;
+            }
+
             switch (action) {
                 case KeyBindingAction.WORKSPACE_LEFT:
                 case KeyBindingAction.WORKSPACE_RIGHT:
                 case KeyBindingAction.SHOW_DESKTOP:
-                case KeyBindingAction.OVERLAY_KEY:
                 case KeyBindingAction.NONE:
                     return false;
                 default:


### PR DESCRIPTION
Resolves #24

- Allow switching workspaces using Super+1-9, Super+Tab, Super+Shift+Tab, Super+Home, Super+End
