### PR TITLE
Dialogs: Improve force quit string

### DIFF
--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -154,7 +154,7 @@ namespace Gala {
                 title = _("Application is not responding");
             }
 
-            body = _("You may choose to wait a short while for it to continue or force the application quit entirely.");
+            body = _("You may choose to wait a short while for it to continue or force the application to quit entirely.");
             accept_label = _("Force Quit");
             deny_label = _("Wait");
 


### PR DESCRIPTION
I don't think this makes grammatical sense currently, does this improve things?