### PR TITLE
WindowClone: Add click action only in overview mode

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -99,14 +99,14 @@ public class Gala.WindowClone : Clutter.Actor {
         window.notify["maximized-horizontally"].connect (check_shadow_requirements);
         window.notify["maximized-vertically"].connect (check_shadow_requirements);
 
-        var click_action = new Clutter.ClickAction ();
-        click_action.clicked.connect (() => {
-            actor_clicked (click_action.get_button ());
-        });
+        if (overview_mode) {
+            var click_action = new Clutter.ClickAction ();
+            click_action.clicked.connect (() => {
+                actor_clicked (click_action.get_button ());
+            });
 
-        add_action (click_action);
-
-        if (!overview_mode) {
+            add_action (click_action);
+        } else {
             drag_action = new DragDropAction (DragDropActionType.SOURCE, "multitaskingview-window");
             drag_action.drag_begin.connect (drag_begin);
             drag_action.destination_crossed.connect (drag_destination_crossed);


### PR DESCRIPTION
This was added in #1464 to _fix_ #1442 while (I think) the actual solution was in #1468.

Fixes the issue where clicking windows on other workspaces in multitasking view triggers them instead of changing workspace.