### PR TITLE
Unify move to workspace behaviour

### DIFF
--- a/data/gala.appdata.xml.in
+++ b/data/gala.appdata.xml.in
@@ -26,6 +26,7 @@
         <issue url="https://github.com/elementary/gala/issues/510">PiP doesn't respect animations key</issue>
         <issue url="https://github.com/elementary/gala/issues/849">Picture-in-Picture area selection being offset</issue>
         <issue url="https://github.com/elementary/gala/issues/975">Accidental middle click to close workspace</issue>
+        <issue url="https://github.com/elementary/gala/issues/1081">"Move to Workspace" window menu action doesn't match what the Keyboard Shortcut do</issue>
         <issue url="https://github.com/elementary/gala/issues/1185">Unmaximize effect not working with mutter >= 3.38</issue>
         <issue url="https://github.com/elementary/gala/issues/1203">Artifact around non native apps in the overview mode</issue>
         <issue url="https://github.com/elementary/gala/issues/1478">PiP: Log spam on elementary OS 7.0</issue>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -684,7 +684,7 @@ namespace Gala {
             unowned var active = manager.get_active_workspace ();
             unowned var next = active.get_neighbor (direction);
 
-            //don't allow empty workspaces to be created by moving, if we have dynamic workspaces
+            // don't allow empty workspaces to be created by moving, if we have dynamic workspaces
             if (Meta.Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () == manager.n_workspaces - 1) {
                 Utils.bell (display);
                 return;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -674,25 +674,33 @@ namespace Gala {
          * {@inheritDoc}
          */
         public void move_window (Meta.Window? window, Meta.MotionDirection direction) {
-            if (window == null)
+            if (window == null) {
                 return;
+            }
 
             unowned Meta.Display display = get_display ();
             unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
 
-            var active = manager.get_active_workspace ();
-            var next = active.get_neighbor (direction);
+            unowned var active = manager.get_active_workspace ();
+            unowned var next = active.get_neighbor (direction);
 
-            //dont allow empty workspaces to be created by moving, if we have dynamic workspaces
+            //don't allow empty workspaces to be created by moving, if we have dynamic workspaces
             if (Meta.Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () == manager.n_workspaces - 1) {
+                Utils.bell (display);
+                return;
+            }
+
+            // don't allow moving into non-existing workspaces
+            if (active == next) {
                 Utils.bell (display);
                 return;
             }
 
             moving = window;
 
-            if (!window.is_on_all_workspaces ())
+            if (!window.is_on_all_workspaces ()) {
                 window.change_workspace (next);
+            }
 
             next.activate_with_focus (window, display.get_current_time ());
         }
@@ -837,18 +845,10 @@ namespace Gala {
                         current.stick ();
                     break;
                 case ActionType.MOVE_CURRENT_WORKSPACE_LEFT:
-                    if (current != null) {
-                        var wp = current.get_workspace ().get_neighbor (Meta.MotionDirection.LEFT);
-                        if (wp != null)
-                            current.change_workspace (wp);
-                    }
+                    move_window (current, Meta.MotionDirection.LEFT);
                     break;
                 case ActionType.MOVE_CURRENT_WORKSPACE_RIGHT:
-                    if (current != null) {
-                        var wp = current.get_workspace ().get_neighbor (Meta.MotionDirection.RIGHT);
-                        if (wp != null)
-                            current.change_workspace (wp);
-                    }
+                    move_window (current, Meta.MotionDirection.RIGHT);
                     break;
                 case ActionType.CLOSE_CURRENT:
                     if (current != null && current.can_close ())


### PR DESCRIPTION
Resolves #1081

Also fixes a bug where trying to move window to non-existing workspaces resulted it stuck to top when switching workspace afterwards.