### PR TITLE
Don't connect to Meta.Display.restacked

### DIFF
--- a/src/Widgets/MonitorClone.vala
+++ b/src/Widgets/MonitorClone.vala
@@ -46,7 +46,6 @@ namespace Gala {
 
             window_container = new WindowCloneContainer (wm, gesture_tracker);
             window_container.window_selected.connect ((w) => { window_selected (w); });
-            display.restacked.connect (window_container.restack_windows);
 
             display.window_entered_monitor.connect (window_entered);
             display.window_left_monitor.connect (window_left);
@@ -74,7 +73,6 @@ namespace Gala {
         ~MonitorClone () {
             display.window_entered_monitor.disconnect (window_entered);
             display.window_left_monitor.disconnect (window_left);
-            display.restacked.disconnect (window_container.restack_windows);
         }
 
         /**
@@ -92,16 +90,16 @@ namespace Gala {
          * Animate the windows from their old location to a tiled layout
          */
         public void open (bool with_gesture = false, bool is_cancel_animation = false) {
+            window_container.restack_windows ();
             window_container.open (null, with_gesture, is_cancel_animation);
-            // background.opacity = 0; TODO consider this option
         }
 
         /**
          * Animate the windows back to their old location
          */
         public void close (bool with_gesture = false, bool is_cancel_animation = false) {
+            window_container.restack_windows ();
             window_container.close (with_gesture, is_cancel_animation);
-            background.opacity = 255;
         }
 
         private void window_left (int window_monitor, Meta.Window window) {

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -182,7 +182,6 @@ namespace Gala {
             window_container = new WindowCloneContainer (wm, gesture_tracker);
             window_container.window_selected.connect ((w) => { window_selected (w); });
             window_container.set_size (monitor_geometry.width, monitor_geometry.height);
-            display.restacked.connect (window_container.restack_windows);
 
             icon_group = new IconGroup (wm, workspace);
             icon_group.selected.connect (() => selected (true));
@@ -233,8 +232,6 @@ namespace Gala {
 
         ~WorkspaceClone () {
             unowned Meta.Display display = workspace.get_display ();
-
-            display.restacked.disconnect (window_container.restack_windows);
 
             display.window_entered_monitor.disconnect (window_entered_monitor);
             display.window_left_monitor.disconnect (window_left_monitor);
@@ -340,6 +337,8 @@ namespace Gala {
 
             opened = true;
 
+            window_container.restack_windows ();
+
             var scale_factor = InternalUtils.get_ui_scaling_factor ();
             var display = workspace.get_display ();
 
@@ -419,6 +418,8 @@ namespace Gala {
             }
 
             opened = false;
+
+            window_container.restack_windows ();
 
             var initial_x = is_cancel_animation ? x : multitasking_view_x ();
             var target_x = multitasking_view_x () + current_x_overlap ();


### PR DESCRIPTION
We need to restack clones only for correct animation, so instead of restacking our clones every single time windows are restacked, restack them before animating.