### PR TITLE
DragDropAction: Check that actor was actually clicked

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -214,7 +214,7 @@ namespace Gala {
                         actor.get_transformed_position (out x, out y);
 
                         // release has happened within bounds of actor
-                        if (x < ex && x + actor.width > ex && y < ey && y + actor.height > ey) {
+                        if (clicked && x < ex && x + actor.width > ex && y < ey && y + actor.height > ey) {
                             actor_clicked (event.get_button ());
                         }
 

--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -218,9 +218,11 @@ namespace Gala {
                             actor_clicked (event.get_button ());
                         }
 
-                        ungrab_actor ();
-                        clicked = false;
-                        dragging = false;
+                        if (clicked) {
+                            ungrab_actor ();
+                            clicked = false;
+                        }
+
                         return Gdk.EVENT_STOP;
                     } else if (dragging) {
                         if (hovered != null) {


### PR DESCRIPTION
In master `actor_clicked` is triggered even if you only release mouse button on actor without actually clicking it.