### PR TITLE
Allow the notification stack to be moved using DBus

### DIFF
--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -166,6 +166,14 @@ namespace Gala {
         public abstract void perform_action (ActionType type);
 
         /**
+         * Tells the window manager to move the Notifications Stack down
+         * by the given number of pixels, to make room for menus.
+         *
+         * @param offset The amount of pixels by which to move the notifications stack
+         */
+        public abstract void offset_notifications (int32 offset);
+
+        /**
          * Moves the window to the workspace next to its current workspace in the given direction.
          * Gala currently only supports LEFT and RIGHT.
          *

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -91,6 +91,10 @@ namespace Gala {
             wm.perform_action (type);
         }
 
+        public void offset_notifications (int32 offset) throws DBusError, Error {
+            wm.offset_notifications (offset);
+        }
+
         private const double SATURATION_WEIGHT = 1.5;
         private const double WEIGHT_THRESHOLD = 1.0;
 

--- a/src/NotificationStack.vala
+++ b/src/NotificationStack.vala
@@ -22,7 +22,7 @@ public class Gala.NotificationStack : Object {
 
     // we need to keep a small offset to the top, because we clip the container to
     // its allocations and the close button would be off for the first notification
-    private const int TOP_OFFSET = 2;
+    private int TOP_OFFSET = 2;
     private const int ADDITIONAL_MARGIN = 12;
     private const int MARGIN = 12;
 
@@ -144,6 +144,11 @@ public class Gala.NotificationStack : Object {
             y += window.get_frame_rect ().height;
             iterator++;
         }
+    }
+
+    public void offset_notifications (int32 offset) {
+        TOP_OFFSET = 2 + offset;
+        update_positions (true);
     }
 
     public void destroy_notification (Meta.WindowActor notification, bool animate) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -901,6 +901,10 @@ namespace Gala {
             }
         }
 
+        public void offset_notifications (int32 offset) {
+            notification_stack.offset_notifications (offset);
+        }
+
         public override void show_window_menu (Meta.Window window, Meta.WindowMenuType menu, int x, int y) {
             switch (menu) {
                 case Meta.WindowMenuType.WM:


### PR DESCRIPTION
Adds a DBUS interface to move the notifications stack. This can be called by WingPanel to move the notifications stack out of the way when indicator menus are opened. This can be used to close #91.

Please see https://github.com/elementary/wingpanel/pull/481 for more details.
