### PR TITLE
Add keybindings for switching input source

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -192,14 +192,14 @@
       <summary>Copy a screenshot of an area to clipboard</summary>
     </key>
     <key type="as" name="switch-input-source">
-      <default><![CDATA[['<Alt>space']]]></default>
+      <default><![CDATA[['']]]></default>
       <summary>Cycle to next keyboard layout</summary>
-      <description>DEPRECATED: This key is deprecated and ignored.</description>
+      <description></description>
     </key>
     <key type="as" name="switch-input-source-backward">
       <default><![CDATA[['']]]></default>
       <summary>Cycle to previous keyboard layout</summary>
-      <description>DEPRECATED: This key is deprecated and ignored.</description>
+      <description></description>
     </key>
     <key type="as" name="pip">
       <default><![CDATA[['<Super>f']]]></default>

--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -51,7 +51,7 @@ public class Gala.KeyboardManager : Object {
         }
 
         var current = settings.get_uint ("current");
-        
+
         if (!backward) {
             settings.set_uint ("current", (current + 1) % n_sources);
         } else {

--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -63,35 +63,35 @@ public class Gala.KeyboardManager : Object {
 
     [CCode (instance_pos = -1)]
     private void set_keyboard_layout (GLib.Settings settings, string key) {
-        if (key != "sources" && key != "xkb-options" && key != "current") {
-            return;
-        }
-        string[] layouts = {}, variants = {};
+        if (key == "sources" || key == "xkb-options") {
+            string[] layouts = {}, variants = {};
 
-        var sources = settings.get_value ("sources");
-        if (!sources.is_of_type (sources_variant_type)) {
-            return;
-        }
-
-        for (int i = 0; i < sources.n_children (); i++) {
-            unowned string? type = null, name = null;
-            sources.get_child (i, "(&s&s)", out type, out name);
-
-            if (type == "xkb") {
-                string[] arr = name.split ("+", 2);
-                layouts += arr[0];
-                variants += arr[1] ?? "";
-
+            var sources = settings.get_value ("sources");
+            if (!sources.is_of_type (sources_variant_type)) {
+                return;
             }
+
+            for (int i = 0; i < sources.n_children (); i++) {
+                unowned string? type = null, name = null;
+                sources.get_child (i, "(&s&s)", out type, out name);
+
+                if (type == "xkb") {
+                    string[] arr = name.split ("+", 2);
+                    layouts += arr[0];
+                    variants += arr[1] ?? "";
+
+                }
+            }
+
+            var xkb_options = settings.get_strv ("xkb-options");
+
+            var layout = string.joinv (",", layouts);
+            var variant = string.joinv (",", variants);
+            var options = string.joinv (",", xkb_options);
+
+            Meta.Backend.get_backend ().set_keymap (layout, variant, options);
+        } else if (key == "current") {
+            Meta.Backend.get_backend ().lock_layout_group (settings.get_uint ("current"));
         }
-
-        var xkb_options = settings.get_strv ("xkb-options");
-
-        var layout = string.joinv (",", layouts);
-        var variant = string.joinv (",", variants);
-        var options = string.joinv (",", xkb_options);
-
-        Meta.Backend.get_backend ().set_keymap (layout, variant, options);
-        Meta.Backend.get_backend ().lock_layout_group (settings.get_uint ("current"));
     }
 }

--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -16,7 +16,7 @@ public class Gala.KeyboardManager : Object {
 
         instance = new KeyboardManager ();
 
-        display.modifiers_accelerator_activated.connect (instance.handle_modifiers_accelerator_activated);
+        display.modifiers_accelerator_activated.connect ((display) => KeyboardManager.handle_modifiers_accelerator_activated (display, false));
     }
 
     static construct {
@@ -37,7 +37,7 @@ public class Gala.KeyboardManager : Object {
     }
 
     [CCode (instance_pos = -1)]
-    private bool handle_modifiers_accelerator_activated (Meta.Display display) {
+    public static bool handle_modifiers_accelerator_activated (Meta.Display display, bool backward) {
         display.ungrab_keyboard (display.get_current_time ());
 
         var sources = settings.get_value ("sources");
@@ -51,42 +51,47 @@ public class Gala.KeyboardManager : Object {
         }
 
         var current = settings.get_uint ("current");
-        settings.set_uint ("current", (current + 1) % n_sources);
+        
+        if (!backward) {
+            settings.set_uint ("current", (current + 1) % n_sources);
+        } else {
+            settings.set_uint ("current", (current - 1) % n_sources);
+        }
 
         return true;
     }
 
     [CCode (instance_pos = -1)]
     private void set_keyboard_layout (GLib.Settings settings, string key) {
-        if (key == "sources" || key == "xkb-options") {
-            string[] layouts = {}, variants = {};
-
-            var sources = settings.get_value ("sources");
-            if (!sources.is_of_type (sources_variant_type)) {
-                return;
-            }
-
-            for (int i = 0; i < sources.n_children (); i++) {
-                unowned string? type = null, name = null;
-                sources.get_child (i, "(&s&s)", out type, out name);
-
-                if (type == "xkb") {
-                    string[] arr = name.split ("+", 2);
-                    layouts += arr[0];
-                    variants += arr[1] ?? "";
-
-                }
-            }
-
-            var xkb_options = settings.get_strv ("xkb-options");
-
-            var layout = string.joinv (",", layouts);
-            var variant = string.joinv (",", variants);
-            var options = string.joinv (",", xkb_options);
-
-            Meta.Backend.get_backend ().set_keymap (layout, variant, options);
-        } else if (key == "current") {
-            Meta.Backend.get_backend ().lock_layout_group (settings.get_uint ("current"));
+        if (key != "sources" && key != "xkb-options" && key != "current") {
+            return;
         }
+        string[] layouts = {}, variants = {};
+
+        var sources = settings.get_value ("sources");
+        if (!sources.is_of_type (sources_variant_type)) {
+            return;
+        }
+
+        for (int i = 0; i < sources.n_children (); i++) {
+            unowned string? type = null, name = null;
+            sources.get_child (i, "(&s&s)", out type, out name);
+
+            if (type == "xkb") {
+                string[] arr = name.split ("+", 2);
+                layouts += arr[0];
+                variants += arr[1] ?? "";
+
+            }
+        }
+
+        var xkb_options = settings.get_strv ("xkb-options");
+
+        var layout = string.joinv (",", layouts);
+        var variant = string.joinv (",", variants);
+        var options = string.joinv (",", xkb_options);
+
+        Meta.Backend.get_backend ().set_keymap (layout, variant, options);
+        Meta.Backend.get_backend ().lock_layout_group (settings.get_uint ("current"));
     }
 }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -250,6 +250,8 @@ namespace Gala {
             display.add_keybinding ("cycle-workspaces-next", keybinding_settings, Meta.KeyBindingFlags.NONE, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
             display.add_keybinding ("cycle-workspaces-previous", keybinding_settings, Meta.KeyBindingFlags.NONE, (Meta.KeyHandlerFunc) handle_cycle_workspaces);
             display.add_keybinding ("panel-main-menu", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_applications_menu);
+            display.add_keybinding ("switch-input-source", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_switch_input_source);
+            display.add_keybinding ("switch-input-source-backward", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_switch_input_source);
 
             display.add_keybinding ("screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
             display.add_keybinding ("window-screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
@@ -471,6 +473,12 @@ namespace Gala {
         private void handle_applications_menu (Meta.Display display, Meta.Window? window,
             Clutter.KeyEvent event, Meta.KeyBinding binding) {
             launch_action ("panel-main-menu-action");
+        }
+
+        [CCode (instance_pos = -1)]
+        private void handle_switch_input_source (Meta.Display display, Meta.Window? window,
+            Clutter.KeyEvent event, Meta.KeyBinding binding) {
+            KeyboardManager.handle_modifiers_accelerator_activated (display, binding.get_name ().has_suffix ("-backward"));
         }
 
         [CCode (instance_pos = -1)]


### PR DESCRIPTION
These keybinding were removed in https://code.launchpad.net/~ntnk/gala/modifiers-only-input-source-switch because Gnome Shell didn't have them at the time. But currently Gnome Shell supports both ways of switching keyboard layouts, so makes sense add it back.

This allows us to set shortcuts such as Super+Space to switch keyboard layouts.
