### PR TITLE
Get MonitorManager from context

### DIFF
--- a/plugins/maskcorners/Main.vala
+++ b/plugins/maskcorners/Main.vala
@@ -62,7 +62,7 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
             display.in_fullscreen_changed.connect (fullscreen_changed);
         }
 
-        unowned Meta.MonitorManager monitor_manager = Meta.MonitorManager.@get ();
+        unowned Meta.MonitorManager monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
         monitor_manager.monitors_changed.connect (resetup_cornermasks);
 
         display.gl_video_memory_purged.connect (resetup_cornermasks);
@@ -71,7 +71,7 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
     private void destroy_cornermasks () {
         display.gl_video_memory_purged.disconnect (resetup_cornermasks);
 
-        unowned Meta.MonitorManager monitor_manager = Meta.MonitorManager.@get ();
+        unowned Meta.MonitorManager monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
         monitor_manager.monitors_changed.disconnect (resetup_cornermasks);
         display.in_fullscreen_changed.disconnect (fullscreen_changed);
 

--- a/src/Background/BackgroundContainer.vala
+++ b/src/Background/BackgroundContainer.vala
@@ -27,7 +27,8 @@ namespace Gala {
         }
 
         construct {
-            Meta.MonitorManager.@get ().monitors_changed.connect (update);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (update);
 
             reactive = true;
             button_release_event.connect ((event) => {
@@ -40,7 +41,8 @@ namespace Gala {
         }
 
         ~BackgroundContainer () {
-            Meta.MonitorManager.@get ().monitors_changed.disconnect (update);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.disconnect (update);
         }
 
         private void update () {

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -45,7 +45,8 @@ namespace Gala {
             backgrounds = new Gee.HashMap<int,Background> ();
             hash_cache = new uint[OPTIONS.length];
 
-            Meta.MonitorManager.@get ().monitors_changed.connect (monitors_changed);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (monitors_changed);
 
             // unfortunately the settings sometimes tend to fire random changes even though
             // nothing actually happened. The code below is used to prevent us from spamming
@@ -120,7 +121,8 @@ namespace Gala {
         }
 
         public void destroy () {
-            Meta.MonitorManager.@get ().monitors_changed.disconnect (monitors_changed);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.disconnect (monitors_changed);
 
             foreach (var background in backgrounds.values) {
                 background.changed.disconnect (background_changed);

--- a/src/HotCorners/HotCornerManager.vala
+++ b/src/HotCorners/HotCornerManager.vala
@@ -29,7 +29,8 @@ public class Gala.HotCornerManager : Object {
 
         hot_corners = new GLib.GenericArray<HotCorner> ();
         behavior_settings.changed.connect (configure);
-        Meta.MonitorManager.@get ().monitors_changed.connect (configure);
+        unowned var monitor_manager = wm.get_display ().get_context ().get_backend ().get_monitor_manager ();
+        monitor_manager.monitors_changed.connect (configure);
     }
 
     public void configure () {

--- a/src/NotificationStack.vala
+++ b/src/NotificationStack.vala
@@ -42,7 +42,8 @@ public class Gala.NotificationStack : Object {
     construct {
         notifications = new Gee.ArrayList<unowned Meta.WindowActor> ();
 
-        Meta.MonitorManager.@get ().monitors_changed_internal.connect (update_stack_allocation);
+        unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+        monitor_manager.monitors_changed_internal.connect (update_stack_allocation);
         display.workareas_changed.connect (update_stack_allocation);
         update_stack_allocation ();
     }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -93,7 +93,8 @@ namespace Gala {
 
             window_containers_monitors = new List<MonitorClone> ();
             update_monitors ();
-            Meta.MonitorManager.@get ().monitors_changed.connect (update_monitors);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (update_monitors);
 
             Meta.Prefs.add_listener ((pref) => {
                 if (pref == Meta.Preference.WORKSPACES_ONLY_ON_PRIMARY) {

--- a/src/Widgets/PointerLocator.vala
+++ b/src/Widgets/PointerLocator.vala
@@ -55,7 +55,8 @@ namespace Gala {
             pivot.init (0.5f, 0.5f);
             pivot_point = pivot;
 
-            Meta.MonitorManager.@get ().monitors_changed.connect (update_surface);
+            unowned var monitor_manager = wm.get_display ().get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (update_surface);
         }
 
         private void update_surface () {

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -74,7 +74,8 @@ namespace Gala {
                 create_components ();
             });
 
-            Meta.MonitorManager.@get ().monitors_changed.connect (() => {
+            unowned var monitor_manager = wm.get_display ().get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (() => {
                 var cur_scale = InternalUtils.get_ui_scaling_factor ();
                 if (cur_scale != scaling_factor) {
                     scaling_factor = cur_scale;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -286,7 +286,8 @@ namespace Gala {
             var shadow_settings = new GLib.Settings (Config.SCHEMA + ".shadows");
             shadow_settings.changed.connect (InternalUtils.reload_shadow);
 
-            Meta.MonitorManager.@get ().monitors_changed.connect (on_monitors_changed);
+            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+            monitor_manager.monitors_changed.connect (on_monitors_changed);
 
             hot_corner_manager = new HotCornerManager (this, behavior_settings);
             hot_corner_manager.on_configured.connect (update_input_area);
@@ -359,7 +360,7 @@ namespace Gala {
             update_input_area ();
 
             // while a workspace is being switched mutter doesn't map windows
-            // TODO: currently only notifications are handled here, other windows should be too 
+            // TODO: currently only notifications are handled here, other windows should be too
             display.window_created.connect ((window) => {
                 if (!animating_switch_workspace) {
                     return;


### PR DESCRIPTION
Shrinks the diff of #1570 by getting the `MonitorManager` in a way that is also compatible with Mutter 44