### PR TITLE
WM: Add laters via compositor

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -196,7 +196,8 @@ namespace Gala {
             var color = background_settings.get_string ("primary-color");
             stage.background_color = Clutter.Color.from_string (color);
 
-            Meta.Util.later_add (Meta.LaterType.BEFORE_REDRAW, () => {
+            unowned var laters = display.get_compositor ().get_laters ();
+            laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
                 WorkspaceManager.init (this);
                 return false;
             });


### PR DESCRIPTION
`Meta.Util.later_add` is removed in newer versions of Mutter. We can do this to prepare for Mutter 44 and reduce the diff of #1570 