### PR TITLE
maskcorners: Scale corner masks per-monitor

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -248,6 +248,14 @@ namespace Gala {
         }
 
         /**
+         * Multiplies an integer by a floating scaling factor, and then
+         * returns the result rounded to the nearest integer
+         */
+         public static int scale_to_int (int value, float scale_factor) {
+            return (int) (Math.round ((float)value * scale_factor));
+        }
+
+        /**
          * Get the number of toplevel windows on a workspace excluding those that are
          * on all workspaces
          *

--- a/plugins/maskcorners/Main.vala
+++ b/plugins/maskcorners/Main.vala
@@ -21,7 +21,7 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
 
     private Gala.WindowManager? wm = null;
     private GLib.Settings settings;
-    private int corner_radius = DEFAULT_CORNER_RADIUS;
+    private int[] corner_radii;
     private List<Clutter.Actor>[] cornermasks;
     private Meta.Display display;
 
@@ -45,11 +45,13 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
             return;
         }
 
-        var scale = Utils.get_ui_scaling_factor ();
-
         int n_monitors = display.get_n_monitors ();
+        corner_radii = new int[n_monitors];
         cornermasks = new List<Clutter.Actor>[n_monitors];
-        corner_radius = DEFAULT_CORNER_RADIUS * scale;
+
+        for (int m = 0; m < n_monitors; m++) {
+            corner_radii[m] = Utils.scale_to_int (DEFAULT_CORNER_RADIUS, display.get_monitor_scale (m));
+        }
 
         if (settings.get_boolean ("only-on-primary")) {
             add_cornermasks (display.get_primary_monitor ());
@@ -103,13 +105,13 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
         var monitor_geometry = display.get_monitor_geometry (monitor_no);
 
         var canvas = new Clutter.Canvas ();
-        canvas.set_size (corner_radius, corner_radius);
-        canvas.draw.connect (draw_cornermask);
+        canvas.set_size (corner_radii[monitor_no], corner_radii[monitor_no]);
+        canvas.draw.connect ((context) => draw_cornermask (context, monitor_no));
         canvas.invalidate ();
 
         var actor = new Clutter.Actor ();
         actor.set_content (canvas);
-        actor.set_size (corner_radius, corner_radius);
+        actor.set_size (corner_radii[monitor_no], corner_radii[monitor_no]);
         actor.set_position (monitor_geometry.x, monitor_geometry.y);
         actor.set_pivot_point ((float) 0.5, (float) 0.5);
 
@@ -137,13 +139,13 @@ public class Gala.Plugins.MaskCorners.Main : Gala.Plugin {
         }
     }
 
-    private bool draw_cornermask (Cairo.Context context) {
-        var buffer = new Drawing.BufferSurface (corner_radius, corner_radius);
+    private bool draw_cornermask (Cairo.Context context, int monitor_no) requires (corner_radii.length > monitor_no) {
+        var buffer = new Drawing.BufferSurface (corner_radii[monitor_no], corner_radii[monitor_no]);
         var buffer_context = buffer.context;
 
-        buffer_context.arc (corner_radius, corner_radius, corner_radius, Math.PI, 1.5 * Math.PI);
+        buffer_context.arc (corner_radii[monitor_no], corner_radii[monitor_no], corner_radii[monitor_no], Math.PI, 1.5 * Math.PI);
         buffer_context.line_to (0, 0);
-        buffer_context.line_to (0, corner_radius);
+        buffer_context.line_to (0, corner_radii[monitor_no]);
         buffer_context.set_source_rgb (0, 0, 0);
         buffer_context.fill ();
 


### PR DESCRIPTION
Reduces the diff of #1570 by allowing a per-monitor, non-integer scale factor for the corner masks.