### PR TITLE
Utils: Remove bell

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -302,19 +302,6 @@ namespace Gala {
             return container;
         }
 
-        /**
-        * Ring the system bell, will most likely emit a <beep> error sound or, if the
-        * audible bell is disabled, flash the display
-        *
-        * @param display The display to flash, if necessary
-        */
-        public static void bell (Meta.Display display) {
-            if (Meta.Prefs.bell_is_audible ())
-                Gdk.beep ();
-            else
-                display.get_compositor ().flash_display (display);
-        }
-
         public static int get_ui_scaling_factor () {
             return Meta.Backend.get_backend ().get_settings ().get_ui_scaling_factor ();
         }

--- a/src/Widgets/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher.vala
@@ -242,7 +242,7 @@ namespace Gala {
             var display = wm.get_display ();
 
             if (container.get_n_children () == 0) {
-                Utils.bell (display);
+                Clutter.get_default_backend ().get_default_seat ().bell_notify ();
                 return;
             }
 
@@ -380,7 +380,7 @@ namespace Gala {
             var current = cur_icon;
 
             if (container.get_n_children () == 1) {
-                Utils.bell (display);
+                Clutter.get_default_backend ().get_default_seat ().bell_notify ();
                 return;
             }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -723,13 +723,13 @@ namespace Gala {
 
             // don't allow empty workspaces to be created by moving, if we have dynamic workspaces
             if (Meta.Prefs.get_dynamic_workspaces () && Utils.get_n_windows (active) == 1 && next.index () == manager.n_workspaces - 1) {
-                Utils.bell (display);
+                Clutter.get_default_backend ().get_default_seat ().bell_notify ();
                 return;
             }
 
             // don't allow moving into non-existing workspaces
             if (active == next) {
-                Utils.bell (display);
+                Clutter.get_default_backend ().get_default_seat ().bell_notify ();
                 return;
             }
 


### PR DESCRIPTION
The `bell_notify` function in Clutter handles reading the preference for audio or screen flash notifications, so we don't need this complexity.