### PR TITLE
WM: Init things that depend on GTK later

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -294,6 +294,8 @@ namespace Gala {
 
             zoom = new Zoom (this);
 
+            // Most things inside this "later" depend on GTK. We get segfaults if we try to do GTK stuff before the window manager
+            // is initialized, so we hold this stuff off until we're ready to draw
             laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
                 string[] args = {};
                 unowned string[] _args = args;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -294,68 +294,78 @@ namespace Gala {
 
             zoom = new Zoom (this);
 
-            accent_color_manager = new AccentColorManager ();
+            laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
+                string[] args = {};
+                unowned string[] _args = args;
+                Gtk.init (ref _args);
 
-            // initialize plugins and add default components if no plugin overrides them
-            var plugin_manager = PluginManager.get_default ();
-            plugin_manager.initialize (this);
-            plugin_manager.regions_changed.connect (update_input_area);
+                accent_color_manager = new AccentColorManager ();
 
-            if (plugin_manager.workspace_view_provider == null
-                || (workspace_view = (plugin_manager.get_plugin (plugin_manager.workspace_view_provider) as ActivatableComponent)) == null) {
-                workspace_view = new MultitaskingView (this);
-                ui_group.add_child ((Clutter.Actor) workspace_view);
-            }
+                // initialize plugins and add default components if no plugin overrides them
+                var plugin_manager = PluginManager.get_default ();
+                plugin_manager.initialize (this);
+                plugin_manager.regions_changed.connect (update_input_area);
 
-            Meta.KeyBinding.set_custom_handler ("show-desktop", () => {
-                if (workspace_view.is_opened ())
-                    workspace_view.close ();
-                else
-                    workspace_view.open ();
-            });
-
-            if (plugin_manager.window_switcher_provider == null) {
-                winswitcher = new WindowSwitcher (this);
-                ui_group.add_child (winswitcher);
-
-                Meta.KeyBinding.set_custom_handler ("switch-applications", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-                Meta.KeyBinding.set_custom_handler ("switch-applications-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-                Meta.KeyBinding.set_custom_handler ("switch-windows", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-                Meta.KeyBinding.set_custom_handler ("switch-windows-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-                Meta.KeyBinding.set_custom_handler ("switch-group", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-                Meta.KeyBinding.set_custom_handler ("switch-group-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
-            }
-
-            if (plugin_manager.window_overview_provider == null
-                || (window_overview = (plugin_manager.get_plugin (plugin_manager.window_overview_provider) as ActivatableComponent)) == null) {
-                window_overview = new WindowOverview (this);
-                ui_group.add_child ((Clutter.Actor) window_overview);
-            }
-
-            notification_group = new Clutter.Actor ();
-            ui_group.add_child (notification_group);
-
-            pointer_locator = new PointerLocator (this);
-            ui_group.add_child (pointer_locator);
-            ui_group.add_child (new DwellClickTimer (this));
-
-            ui_group.add_child (screen_shield);
-
-            display.add_keybinding ("expose-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
-                if (window_overview.is_opened ()) {
-                    window_overview.close ();
-                } else {
-                    window_overview.open ();
+                if (plugin_manager.workspace_view_provider == null
+                    || (workspace_view = (plugin_manager.get_plugin (plugin_manager.workspace_view_provider) as ActivatableComponent)) == null) {
+                    workspace_view = new MultitaskingView (this);
+                    ui_group.add_child ((Clutter.Actor) workspace_view);
                 }
-            });
-            display.add_keybinding ("expose-all-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
-                if (window_overview.is_opened ()) {
-                    window_overview.close ();
-                } else {
-                    var hints = new HashTable<string,Variant> (str_hash, str_equal);
-                    hints.@set ("all-windows", true);
-                    window_overview.open (hints);
+
+                Meta.KeyBinding.set_custom_handler ("show-desktop", () => {
+                    if (workspace_view.is_opened ())
+                        workspace_view.close ();
+                    else
+                        workspace_view.open ();
+                });
+
+                if (plugin_manager.window_switcher_provider == null) {
+                    winswitcher = new WindowSwitcher (this);
+                    ui_group.add_child (winswitcher);
+
+                    Meta.KeyBinding.set_custom_handler ("switch-applications", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
+                    Meta.KeyBinding.set_custom_handler ("switch-applications-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
+                    Meta.KeyBinding.set_custom_handler ("switch-windows", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
+                    Meta.KeyBinding.set_custom_handler ("switch-windows-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
+                    Meta.KeyBinding.set_custom_handler ("switch-group", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
+                    Meta.KeyBinding.set_custom_handler ("switch-group-backward", (Meta.KeyHandlerFunc) winswitcher.handle_switch_windows);
                 }
+
+                if (plugin_manager.window_overview_provider == null
+                    || (window_overview = (plugin_manager.get_plugin (plugin_manager.window_overview_provider) as ActivatableComponent)) == null) {
+                    window_overview = new WindowOverview (this);
+                    ui_group.add_child ((Clutter.Actor) window_overview);
+                }
+
+                notification_group = new Clutter.Actor ();
+                ui_group.add_child (notification_group);
+
+                pointer_locator = new PointerLocator (this);
+                ui_group.add_child (pointer_locator);
+                ui_group.add_child (new DwellClickTimer (this));
+
+                ui_group.add_child (screen_shield);
+
+                display.add_keybinding ("expose-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
+                    if (window_overview.is_opened ()) {
+                        window_overview.close ();
+                    } else {
+                        window_overview.open ();
+                    }
+                });
+                display.add_keybinding ("expose-all-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
+                    if (window_overview.is_opened ()) {
+                        window_overview.close ();
+                    } else {
+                        var hints = new HashTable<string,Variant> (str_hash, str_equal);
+                        hints.@set ("all-windows", true);
+                        window_overview.open (hints);
+                    }
+                });
+
+                plugin_manager.load_waiting_plugins ();
+
+                return false;
             });
 
             update_input_area ();
@@ -382,7 +392,6 @@ namespace Gala {
                 Systemd.Daemon.notify (true, "READY=1");
 #endif
                 display.get_context ().notify_ready ();
-                plugin_manager.load_waiting_plugins ();
                 return GLib.Source.REMOVE;
             });
 


### PR DESCRIPTION
Review with whitespace changes hidden.

In Mutter 44, Gala crashes on startup due to trying to initialize GTK before Gala is fully initialized. This is the same issue we have trying to start Gala in Wayland mode, but we will have it in Mutter 44 in X11 mode too.

If we manually initialize GTK and all of our GTK dependant things in a "later", we can delay the initialization of GTK until a point where the compositor is ready to accept connections from GTK.

This fixes the crashing issue with Mutter 44 in X11 mode. It may unblock Wayland too, but I haven't tested yet.

I've been testing this for a bit and haven't noticed any regressions yet, but it'll need some testing, especially around the functionality that has been moved into this block.