### PR TITLE
ScreenshotManager: Support non-integer scaling factors

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -79,8 +79,10 @@ namespace Gala {
         public async void screenshot (bool include_cursor, bool flash, string filename, out bool success, out string filename_used) throws DBusError, IOError {
             debug ("Taking screenshot");
 
+            unowned var display = wm.get_display ();
+
             int width, height;
-            wm.get_display ().get_size (out width, out height);
+            display.get_size (out width, out height);
 
             var image = take_screenshot (0, 0, width, height, include_cursor);
             unconceal_text ();
@@ -89,7 +91,8 @@ namespace Gala {
                 flash_area (0, 0, width, height);
             }
 
-            success = yield save_image (image, filename, out filename_used);
+            var scale = display.get_monitor_scale (display.get_primary_monitor ());
+            success = yield save_image (image, filename, scale, out filename_used);
 
             if (success) {
                 play_shutter_sound ();
@@ -112,7 +115,11 @@ namespace Gala {
                 flash_area (x, y, width, height);
             }
 
-            success = yield save_image (image, filename, out filename_used);
+            Meta.Rectangle rect = { x, y, width, height };
+            unowned var display = wm.get_display ();
+            var scale = display.get_monitor_scale (display.get_monitor_index_for_rect (rect));
+
+            success = yield save_image (image, filename, scale, out filename_used);
 
             if (success) {
                 play_shutter_sound ();
@@ -154,7 +161,10 @@ namespace Gala {
                 flash_area (rect.x, rect.y, rect.width, rect.height);
             }
 
-            success = yield save_image (image, filename, out filename_used);
+            unowned var display = wm.get_display ();
+            var scale = display.get_monitor_scale (display.get_monitor_index_for_rect (rect));
+
+            success = yield save_image (image, filename, scale, out filename_used);
 
             if (success) {
                 play_shutter_sound ();
@@ -266,13 +276,13 @@ namespace Gala {
             return Environment.get_home_dir ();
         }
 
-        private static async bool save_image (Cairo.ImageSurface image, string filename, out string used_filename) {
+        private static async bool save_image (Cairo.ImageSurface image, string filename, float scale, out string used_filename) {
             return (filename != "")
-                ? yield save_image_to_file (image, filename, out used_filename)
+                ? yield save_image_to_file (image, filename, scale, out used_filename)
                 : save_image_to_clipboard (image, filename, out used_filename);
         }
 
-        private static async bool save_image_to_file (Cairo.ImageSurface image, string filename, out string used_filename) {
+        private static async bool save_image_to_file (Cairo.ImageSurface image, string filename, float scale, out string used_filename) {
             used_filename = filename;
 
             // We only alter non absolute filename because absolute
@@ -282,10 +292,9 @@ namespace Gala {
                     used_filename = used_filename.concat (EXTENSION);
                 }
 
-                var scale_factor = InternalUtils.get_ui_scaling_factor ();
-                if (scale_factor > 1) {
+                if (scale > 1) {
                     var scale_pos = -EXTENSION.length;
-                    used_filename = used_filename.splice (scale_pos, scale_pos, "@%ix".printf (scale_factor));
+                    used_filename = used_filename.splice (scale_pos, scale_pos, "@%.1gx".printf (scale));
                 }
 
                 var path = find_target_path ();


### PR DESCRIPTION
Only affects the naming of saved screenshot files, but in theory allows this to support non-integer and per monitor scaling factors.