### PR TITLE
KeyboardManager: Set keyboard layout on startup

### DIFF
--- a/src/KeyboardManager.vala
+++ b/src/KeyboardManager.vala
@@ -35,7 +35,8 @@ public class Gala.KeyboardManager : Object {
     construct {
         settings.changed.connect (set_keyboard_layout);
 
-        set_keyboard_layout (settings, "sources"); // Update layouts
+        set_keyboard_layout (settings, "sources"); // Update the list of layouts
+        set_keyboard_layout (settings, "current"); // Set current layout
     }
 
     private KeyboardManager (Meta.Display display) {


### PR DESCRIPTION
In `master` on startup keyboard indicator may show current keyboard layout as Russian but the real selected layout is English. This PR sets current a keyboard layout on startup preventing the bug.