### PR TITLE
WorkspaceInsertThumb: Support floating point scale factors

### DIFF
--- a/src/Widgets/IconGroupContainer.vala
+++ b/src/Widgets/IconGroupContainer.vala
@@ -27,8 +27,32 @@ namespace Gala {
 
         public signal void request_reposition (bool animate);
 
-        public IconGroupContainer () {
+        private float _scale_factor = 1.0f;
+        public float scale_factor {
+            get {
+                return _scale_factor;
+            }
+            set {
+                if (value != _scale_factor) {
+                    _scale_factor = value;
+                    reallocate ();
+                }
+            }
+        }
+
+        public IconGroupContainer (float scale) {
+            Object (scale_factor: scale);
+
             layout_manager = new Clutter.BoxLayout ();
+        }
+
+        private void reallocate () {
+            foreach (var child in get_children ()) {
+                unowned WorkspaceInsertThumb thumb = child as WorkspaceInsertThumb;
+                if (thumb != null) {
+                    thumb.scale_factor = scale_factor;
+                }
+            }
         }
 
         public void add_group (IconGroup group) {

--- a/src/Widgets/IconGroupContainer.vala
+++ b/src/Widgets/IconGroupContainer.vala
@@ -27,11 +27,7 @@ namespace Gala {
 
         public signal void request_reposition (bool animate);
 
-        public Meta.Display display { get; construct; }
-
-        public IconGroupContainer (Meta.Display display) {
-            Object (display: display);
-
+        public IconGroupContainer () {
             layout_manager = new Clutter.BoxLayout ();
         }
 

--- a/src/Widgets/IconGroupContainer.vala
+++ b/src/Widgets/IconGroupContainer.vala
@@ -40,7 +40,8 @@ namespace Gala {
 
             insert_child_at_index (group, index * 2);
 
-            var thumb = new WorkspaceInsertThumb (index);
+            var scale = InternalUtils.get_ui_scaling_factor ();
+            var thumb = new WorkspaceInsertThumb (index, scale);
             thumb.notify["expanded"].connect_after (expanded_changed);
             insert_child_at_index (thumb, index * 2);
 
@@ -63,8 +64,8 @@ namespace Gala {
          * it and it's previous WorkspaceInsertThumb. This would make
          * the container immediately reallocate and fill the empty space
          * with right-most IconGroups.
-         * 
-         * We don't want that until the IconGroup 
+         *
+         * We don't want that until the IconGroup
          * leaves the expanded WorkspaceInsertThumb.
          */
         public void remove_group_in_place (IconGroup group) {

--- a/src/Widgets/IconGroupContainer.vala
+++ b/src/Widgets/IconGroupContainer.vala
@@ -60,8 +60,7 @@ namespace Gala {
 
             insert_child_at_index (group, index * 2);
 
-            var scale = InternalUtils.get_ui_scaling_factor ();
-            var thumb = new WorkspaceInsertThumb (index, scale);
+            var thumb = new WorkspaceInsertThumb (index, scale_factor);
             thumb.notify["expanded"].connect_after (expanded_changed);
             insert_child_at_index (thumb, index * 2);
 
@@ -128,9 +127,8 @@ namespace Gala {
          * end states into account
          */
         public float calculate_total_width () {
-            var scale = InternalUtils.get_ui_scaling_factor ();
-            var spacing = SPACING * scale;
-            var group_width = GROUP_WIDTH * scale;
+            var spacing = InternalUtils.scale_to_int (SPACING, scale_factor);
+            var group_width = InternalUtils.scale_to_int (GROUP_WIDTH, scale_factor);
 
             var width = 0.0f;
             foreach (var child in get_children ()) {

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -71,7 +71,7 @@ namespace Gala {
             workspaces = new Clutter.Actor ();
             workspaces.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
 
-            icon_groups = new IconGroupContainer (display);
+            icon_groups = new IconGroupContainer ();
 
             dock_clones = new Clutter.Actor ();
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -71,7 +71,7 @@ namespace Gala {
             workspaces = new Clutter.Actor ();
             workspaces.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
 
-            icon_groups = new IconGroupContainer ();
+            icon_groups = new IconGroupContainer (display.get_monitor_scale (display.get_primary_monitor ()));
 
             dock_clones = new Clutter.Actor ();
 
@@ -157,6 +157,8 @@ namespace Gala {
             }
 
             var primary_geometry = display.get_monitor_geometry (primary);
+            var scale = display.get_monitor_scale (primary);
+            icon_groups.scale_factor = scale;
 
             set_position (primary_geometry.x, primary_geometry.y);
             set_size (primary_geometry.width, primary_geometry.height);

--- a/src/Widgets/WorkspaceInsertThumb.vala
+++ b/src/Widgets/WorkspaceInsertThumb.vala
@@ -28,6 +28,7 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     public WorkspaceInsertThumb (int workspace_index, float scale) {
         Object (workspace_index: workspace_index, scale_factor: scale);
 
+        reallocate ();
         opacity = 0;
         set_pivot_point (0.5f, 0.5f);
         reactive = true;

--- a/src/Widgets/WorkspaceInsertThumb.vala
+++ b/src/Widgets/WorkspaceInsertThumb.vala
@@ -10,16 +10,24 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     public int workspace_index { get; construct set; }
     public bool expanded { get; set; default = false; }
     public int delay { get; set; default = EXPAND_DELAY; }
-    public float scale_factor { get; construct set; }
+    private float _scale_factor = 1.0f;
+    public float scale_factor {
+        get {
+            return _scale_factor;
+        }
+        set {
+            if (value != _scale_factor) {
+                _scale_factor = value;
+                reallocate ();
+            }
+        }
+    }
 
     private uint expand_timeout = 0;
 
     public WorkspaceInsertThumb (int workspace_index, float scale) {
         Object (workspace_index: workspace_index, scale_factor: scale);
 
-        width = InternalUtils.scale_to_int (IconGroupContainer.SPACING, scale);
-        height = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH, scale);
-        y = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH - IconGroupContainer.SPACING, scale) / 2;
         opacity = 0;
         set_pivot_point (0.5f, 0.5f);
         reactive = true;
@@ -44,6 +52,12 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
         });
 
         add_action (drop);
+    }
+
+    private void reallocate () {
+        width = InternalUtils.scale_to_int (IconGroupContainer.SPACING, scale_factor);
+        height = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH, scale_factor);
+        y = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH - IconGroupContainer.SPACING, scale_factor) / 2;
     }
 
     public void set_window_thumb (Meta.Window window) {

--- a/src/Widgets/WorkspaceInsertThumb.vala
+++ b/src/Widgets/WorkspaceInsertThumb.vala
@@ -77,7 +77,7 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
         } else {
             add_pulse_animation ();
             opacity = 200;
-            width = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH + IconGroupContainer.SPACING, scale_factor) * 2;
+            width = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH + IconGroupContainer.SPACING * 2, scale_factor);
             expanded = true;
         }
 

--- a/src/Widgets/WorkspaceInsertThumb.vala
+++ b/src/Widgets/WorkspaceInsertThumb.vala
@@ -10,16 +10,16 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     public int workspace_index { get; construct set; }
     public bool expanded { get; set; default = false; }
     public int delay { get; set; default = EXPAND_DELAY; }
+    public float scale_factor { get; construct set; }
 
     private uint expand_timeout = 0;
 
-    public WorkspaceInsertThumb (int workspace_index) {
-        Object (workspace_index: workspace_index);
+    public WorkspaceInsertThumb (int workspace_index, float scale) {
+        Object (workspace_index: workspace_index, scale_factor: scale);
 
-        var scale = InternalUtils.get_ui_scaling_factor ();
-        width = IconGroupContainer.SPACING * scale;
-        height = IconGroupContainer.GROUP_WIDTH * scale;
-        y = (IconGroupContainer.GROUP_WIDTH * scale - IconGroupContainer.SPACING * scale) / 2;
+        width = InternalUtils.scale_to_int (IconGroupContainer.SPACING, scale);
+        height = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH, scale);
+        y = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH - IconGroupContainer.SPACING, scale) / 2;
         opacity = 0;
         set_pivot_point (0.5f, 0.5f);
         reactive = true;
@@ -49,8 +49,7 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     public void set_window_thumb (Meta.Window window) {
         destroy_all_children ();
 
-        var scale = InternalUtils.get_ui_scaling_factor ();
-        var icon = new WindowIcon (window, IconGroupContainer.GROUP_WIDTH, scale) {
+        var icon = new WindowIcon (window, IconGroupContainer.GROUP_WIDTH, (int)Math.round (scale_factor)) {
             x = IconGroupContainer.SPACING,
             x_align = Clutter.ActorAlign.CENTER
         };
@@ -70,16 +69,15 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
         set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
         set_easing_duration (200);
 
-        var scale = InternalUtils.get_ui_scaling_factor ();
         if (!expand) {
             remove_transition ("pulse");
             opacity = 0;
-            width = IconGroupContainer.SPACING * scale;
+            width = InternalUtils.scale_to_int (IconGroupContainer.SPACING, scale_factor);
             expanded = false;
         } else {
             add_pulse_animation ();
             opacity = 200;
-            width = IconGroupContainer.GROUP_WIDTH * scale + IconGroupContainer.SPACING * 2;
+            width = InternalUtils.scale_to_int (IconGroupContainer.GROUP_WIDTH + IconGroupContainer.SPACING, scale_factor) * 2;
             expanded = true;
         }
 


### PR DESCRIPTION
Updates `IconGroupContainer` and `WorkspaceInsertThumb` to have a settable scale factor, meaning that the parent widget that manages these can set the scale factor on the instances of these widgets. This means they can in theory be used on multiple monitors with differing scale factors in future.

But for now, the LoDPI/HiDPI support still works, and this reduces the diff of #1570 