### PR TITLE
InternalUtils: Remove pixel_align method, and just round

### DIFF
--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -195,7 +195,7 @@ public class Gala.GestureTracker : Object {
         float value = ((target_value - initial_value) * (float) percentage) + initial_value;
 
         if (rounded) {
-            value = (float) InternalUtils.pixel_align (value);
+            value = Math.roundf (value);
         }
 
         return value;

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -298,14 +298,6 @@ namespace Gala {
         }
 
         /**
-         * Round the value to match physical pixels.
-         */
-        public static int pixel_align (float value) {
-            var scale_factor = InternalUtils.get_ui_scaling_factor ();
-            return (int) Math.round (value * scale_factor) / scale_factor;
-        }
-
-        /**
          * Multiplies an integer by a floating scaling factor, and then
          * returns the result rounded to the nearest integer
          */

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -775,8 +775,8 @@ public class Gala.WindowClone : Clutter.Actor {
         var y = window_height - (size * 0.75f);
 
         if (aligned) {
-            x = InternalUtils.pixel_align (x);
-            y = InternalUtils.pixel_align (y);
+            x = (int) Math.round (x);
+            y = (int) Math.round (y);
         }
 
         window_icon.set_size (size, size);
@@ -785,8 +785,8 @@ public class Gala.WindowClone : Clutter.Actor {
 
     private void set_window_title_position (float window_width, float window_height) {
         var scale_factor = InternalUtils.get_ui_scaling_factor ();
-        var x = InternalUtils.pixel_align ((window_width - window_title.width) / 2);
-        var y = InternalUtils.pixel_align (window_height - (WINDOW_ICON_SIZE * scale_factor) * 0.75f - (window_title.height / 2) - (18 * scale_factor));
+        var x = (int)Math.round ((window_width - window_title.width) / 2);
+        var y = (int)Math.round (window_height - (WINDOW_ICON_SIZE * scale_factor) * 0.75f - (window_title.height / 2) - (18 * scale_factor));
         window_title.set_position (x, y);
     }
 


### PR DESCRIPTION
To get to the nearest physical pixel and fit on the grid, we just need to round to the nearest integer, we don't need to know the scale factor.