### PR TITLE
WindowSwitcher: Merge icon and indicator

### DIFF
--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -38,6 +38,8 @@ namespace Gala {
 
                 _current_icon = value;
                 _current_icon.selected = true;
+
+                update_caption_text ();
             }
         }
 
@@ -190,7 +192,6 @@ namespace Gala {
                 }
 
                 open_switcher ();
-                update_caption_text ();
             }
 
             var binding_name = binding.get_name ();
@@ -387,7 +388,6 @@ namespace Gala {
             }
 
             current_icon = (WindowSwitcherIcon) actor;
-            update_caption_text ();
         }
 
         private void update_caption_text () {
@@ -420,7 +420,6 @@ namespace Gala {
 
             if (current_icon != selected) {
                 current_icon = selected;
-                update_caption_text ();
             }
 
             return true;

--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -34,7 +34,7 @@ public class Gala.WindowSwitcherIcon : Clutter.Actor {
     public WindowSwitcherIcon (Meta.Window window, int icon_size) {
         Object (window: window);
 
-        icon = new WindowIcon (window, icon_size, 1);
+        icon = new WindowIcon (window, icon_size);
         icon.add_constraint (new Clutter.AlignConstraint (this, Clutter.AlignAxis.BOTH, 0.5f));
         add_child (icon);
 

--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -1,0 +1,86 @@
+public class Gala.WindowSwitcherIcon : Clutter.Actor {
+    private const int WRAPPER_BORDER_RADIUS = 3;
+
+    public Meta.Window window { get; construct; }
+
+    private WindowIcon icon;
+    private Clutter.Canvas canvas;
+
+    private bool _selected = false;
+    public bool selected {
+        get {
+            return _selected;
+        }
+        set {
+            _selected = value;
+            canvas.invalidate ();
+        }
+    }
+
+    private float _scale_factor = 1.0f;
+    public float scale_factor {
+        get {
+            return _scale_factor;
+        }
+        set {
+            _scale_factor = value;
+            canvas.scale_factor = _scale_factor;
+
+            update_size ();
+            canvas.invalidate ();
+        }
+    }
+
+    public WindowSwitcherIcon (Meta.Window window, int icon_size) {
+        Object (window: window);
+
+        icon = new WindowIcon (window, icon_size, 1);
+        icon.add_constraint (new Clutter.AlignConstraint (this, Clutter.AlignAxis.BOTH, 0.5f));
+        add_child (icon);
+
+        canvas = new Clutter.Canvas ();
+        canvas.draw.connect (draw_background);
+        set_content (canvas);
+
+        update_size ();
+    }
+
+    private void update_size () {
+        var indicator_size = InternalUtils.scale_to_int (
+            (WindowSwitcher.ICON_SIZE + WindowSwitcher.WRAPPER_PADDING * 2),
+            scale_factor
+        );
+        set_size (indicator_size, indicator_size);
+        canvas.set_size (indicator_size, indicator_size);
+    }
+
+    private bool draw_background (Cairo.Context ctx, int width, int height) {
+        ctx.save ();
+        ctx.set_operator (Cairo.Operator.CLEAR);
+        ctx.paint ();
+        ctx.clip ();
+        ctx.reset_clip ();
+
+        if (selected) {
+            var rgba = InternalUtils.get_theme_accent_color ();
+            Clutter.Color accent_color = {
+                (uint8) (rgba.red * 255),
+                (uint8) (rgba.green * 255),
+                (uint8) (rgba.blue * 255),
+                (uint8) (rgba.alpha * 255)
+            };
+    
+            var rect_radius = InternalUtils.scale_to_int (WRAPPER_BORDER_RADIUS, scale_factor);
+    
+            // draw rect
+            Clutter.cairo_set_source_color (ctx, accent_color);
+            Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, rect_radius);
+            ctx.set_operator (Cairo.Operator.SOURCE);
+            ctx.fill ();
+    
+            ctx.restore ();
+        }
+
+        return true;
+    }
+}

--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2023 elementary, Inc. <https://elementary.io>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 public class Gala.WindowSwitcherIcon : Clutter.Actor {
     private const int WRAPPER_BORDER_RADIUS = 3;
 

--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -69,15 +69,15 @@ public class Gala.WindowSwitcherIcon : Clutter.Actor {
                 (uint8) (rgba.blue * 255),
                 (uint8) (rgba.alpha * 255)
             };
-    
+
             var rect_radius = InternalUtils.scale_to_int (WRAPPER_BORDER_RADIUS, scale_factor);
-    
+
             // draw rect
             Clutter.cairo_set_source_color (ctx, accent_color);
             Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, rect_radius);
             ctx.set_operator (Cairo.Operator.SOURCE);
             ctx.fill ();
-    
+
             ctx.restore ();
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,7 +52,7 @@ gala_bin_sources = files(
     'Widgets/WindowIconActor.vala',
     'Widgets/WindowOverview.vala',
     'Widgets/WindowSwitcher/WindowSwitcher.vala',
-        'Widgets/WindowSwitcher/WindowSwitcherIcon.vala',
+    'Widgets/WindowSwitcher/WindowSwitcherIcon.vala',
     'Widgets/WorkspaceClone.vala',
     'Widgets/WorkspaceInsertThumb.vala',
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,7 +51,8 @@ gala_bin_sources = files(
     'Widgets/WindowCloneContainer.vala',
     'Widgets/WindowIconActor.vala',
     'Widgets/WindowOverview.vala',
-    'Widgets/WindowSwitcher.vala',
+    'Widgets/WindowSwitcher/WindowSwitcher.vala',
+        'Widgets/WindowSwitcher/WindowSwitcherIcon.vala',
     'Widgets/WorkspaceClone.vala',
     'Widgets/WorkspaceInsertThumb.vala',
 )


### PR DESCRIPTION
Preparation for https://github.com/elementary/gala/issues/1547

Fixes FIXME in the code:
```
// For some reason, on Odin, the height of the caption loses
// its padding after the first time the switcher displays. As a
// workaround, I store the initial value here once we have it
// and use that correct value on subsequent attempts.
```

and

```
// FIXME there are some troubles with layouting, in some cases we
//       are here too early, in which case all the children are at
//       (0|0), so we can easily check for that and come back later
```