### PR TITLE
IconGroup: Correctly set highlight opacity on start

### DIFF
--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -48,13 +48,20 @@ namespace Gala {
                 return _active;
             }
             set {
-                if (_active == value)
+                if (_active == value) {
                     return;
-
-                if (get_transition ("backdrop-opacity") != null)
-                    remove_transition ("backdrop-opacity");
+                }
 
                 _active = value;
+
+                if (get_stage () == null) {
+                    backdrop_opacity = 40;
+                    return;
+                }
+
+                if (get_transition ("backdrop-opacity") != null) {
+                    remove_transition ("backdrop-opacity");
+                }
 
                 var transition = new Clutter.PropertyTransition ("backdrop-opacity") {
                     duration = 300,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/80143868/231107313-0dadce1f-8096-4f25-b9b2-95415ffbc85d.png)

After:
![image](https://user-images.githubusercontent.com/80143868/231107450-99c3b849-9232-4146-9c15-8c496bad8217.png)
