### PR TITLE
Fix double icon when crossing icon group

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -704,7 +704,7 @@ public class Gala.WindowClone : Clutter.Actor {
             if (hovered) {
                 icon_group.add_window (window, false, true);
             } else {
-                icon_group.remove_window (window);
+                icon_group.remove_window (window, false);
             }
         }
     }


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/80143868/235619957-44799cfc-8054-40e6-9f8a-ee1ceafaef9f.png)
