### PR TITLE
ci: Use any available mutter version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libbamf3-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libmutter-10-dev libplank-dev libxml2-utils libgexiv2-dev meson valac valadoc
+        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libbamf3-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libmutter-*-dev libplank-dev libxml2-utils libgexiv2-dev meson valac valadoc
     - name: Build
       env:
         DESTDIR: out


### PR DESCRIPTION
Avoid specifying the mutter version per container.