### PR TITLE
Keep track of dimmed windows

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -822,6 +822,7 @@ namespace Gala {
                     foreach (var data in dim_data) {
                         if (data.child == window) {
                             data_to_remove = data;
+                            break;
                         }
                     }
                     if (data_to_remove != null) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -817,6 +817,16 @@ namespace Gala {
                     }
                 } else if (transient_actor.get_effect ("dim-parent") != null) {
                     transient_actor.remove_effect_by_name ("dim-parent");
+
+                    DimData? data_to_remove = null;
+                    foreach (var data in dim_data) {
+                        if (data.child == window) {
+                            data_to_remove = data;
+                        }
+                    }
+                    if (data_to_remove != null) {
+                        dim_data.remove (data_to_remove);
+                    }
                 }
 
                 return;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -800,7 +800,7 @@ namespace Gala {
             unowned Meta.WindowActor parent_actor;
         }
 
-        private List<DimData?> dim_data = new List<DimData?>();
+        private List<DimData?> dim_data = new List<DimData?> ();
         private void dim_parent_window (Meta.Window window, bool dim) {
             unowned var transient = window.get_transient_for ();
             if (transient != null && transient != window) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -820,9 +820,9 @@ namespace Gala {
             }
 
             // fall back to dim_data (see https://github.com/elementary/gala/issues/1331)
-            if (window in dim_table && dim_table[window].get_effect ("dim-parent") != null) {
-                dim_table[window].remove_effect_by_name ("dim-parent");
-                dim_table.remove (window);
+            var transient_actor = dim_table.take (window);
+            if (transient_actor != null) {
+                transient_actor.remove_effect_by_name ("dim-parent");
                 debug ("Removed dim using dim_data");
             }
         }


### PR DESCRIPTION
Fixes #1331

That's an ugly solution but I guess it's the only working one. For some reason when double commander destroys its dialogs they no longer have transient window, because of that the undim failed.