### PR TITLE
Background: Use GLib.File instead of dealing with Paths

### DIFF
--- a/src/Background/Animation.vala
+++ b/src/Background/Animation.vala
@@ -17,20 +17,20 @@
 
 namespace Gala {
     public class Animation : Object {
-        public string filename { get; construct; }
-        public string[] key_frame_files { get; private set; default = {}; }
+        public GLib.File file { get; construct; }
+        public GLib.GenericArray<GLib.File> key_frame_files { get; private set; default = new GLib.GenericArray<GLib.File> (); }
         public double transition_progress { get; private set; default = 0.0; }
         public double transition_duration { get; private set; default = 0.0; }
         public bool loaded { get; private set; default = false; }
 
         private Gnome.BGSlideShow? show = null;
 
-        public Animation (string filename) {
-            Object (filename: filename);
+        public Animation (GLib.File file) {
+            Object (file: file);
         }
 
         public async void load () {
-            show = new Gnome.BGSlideShow (filename);
+            show = new Gnome.BGSlideShow (file.get_path ());
 
             show.load_async (null, (obj, res) => {
                 loaded = true;
@@ -42,7 +42,7 @@ namespace Gala {
         }
 
         public void update (Meta.Rectangle monitor) {
-            string[] key_frame_files = {};
+            var new_key_frame_files = new GLib.GenericArray<GLib.File> ();
 
             if (show == null)
                 return;
@@ -52,19 +52,21 @@ namespace Gala {
 
             double progress, duration;
             bool is_fixed;
-            string file1, file2;
+            unowned string? file1, file2;
             show.get_current_slide (monitor.width, monitor.height, out progress, out duration, out is_fixed, out file1, out file2);
 
             transition_duration = duration;
             transition_progress = progress;
 
-            if (file1 != null)
-                key_frame_files += file1;
+            if (file1 != null) {
+                new_key_frame_files.add (GLib.File.new_for_path (file1));
+            }
 
-            if (file2 != null)
-                key_frame_files += file2;
+            if (file2 != null) {
+                new_key_frame_files.add (GLib.File.new_for_path (file2));
+            }
 
-            this.key_frame_files = key_frame_files;
+            this.key_frame_files = new_key_frame_files;
         }
     }
 }

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -87,26 +87,26 @@ namespace Gala {
         }
 
         public Background get_background (int monitor_index) {
-            string? filename = null;
+            GLib.File? file = null;
 
             var style = settings.get_enum ("picture-options");
             if (style != GDesktop.BackgroundStyle.NONE) {
                 var uri = settings.get_string ("picture-uri");
                 if (Uri.parse_scheme (uri) != null)
-                    filename = File.new_for_uri (uri).get_path ();
+                    file = File.new_for_uri (uri);
                 else
-                    filename = uri;
+                    file = File.new_for_path (uri);
             }
 
             // Animated backgrounds are (potentially) per-monitor, since
             // they can have variants that depend on the aspect ratio and
             // size of the monitor; for other backgrounds we can use the
             // same background object for all monitors.
-            if (filename == null || !filename.has_suffix (".xml"))
+            if (file == null || !file.get_basename ().has_suffix (".xml"))
                 monitor_index = 0;
 
             if (!backgrounds.has_key (monitor_index)) {
-                var background = new Background (display, monitor_index, filename, this, (GDesktop.BackgroundStyle) style);
+                var background = new Background (display, monitor_index, file, this, (GDesktop.BackgroundStyle) style);
                 background.changed.connect (background_changed);
                 backgrounds[monitor_index] = background;
             }

--- a/vapi/gnome-desktop-3.0.vapi
+++ b/vapi/gnome-desktop-3.0.vapi
@@ -98,7 +98,7 @@ namespace Gnome {
 	public class BGSlideShow : GLib.Object {
 		[CCode (has_construct_function = false)]
 		public BGSlideShow (string filename);
-		public void get_current_slide (int width, int height, out double progress, out double duration, out bool is_fixed, out unowned string file1, out unowned string file2);
+		public void get_current_slide (int width, int height, out double progress, out double duration, out bool is_fixed, out unowned string? file1, out unowned string? file2);
 		public bool get_has_multiple_sizes ();
 		public int get_num_slides ();
 		public bool get_slide (int frame_number, int width, int height, out double progress, out double duration, out bool is_fixed, out unowned string file1, out unowned string file2);


### PR DESCRIPTION
Simplify the code and avoids to deal with File paths directly.