### PR TITLE
Background: Remove `background_sources` HashMap

### DIFF
--- a/src/Background/Background.vala
+++ b/src/Background/Background.vala
@@ -99,13 +99,13 @@ namespace Gala {
 
             Idle.add (() => {
                 loaded ();
-                return false;
+                return Source.REMOVE;
             });
         }
 
         private void load_pattern () {
             string color_string;
-            var settings = background_source.settings;
+            var settings = background_source.gnome_background_settings;
 
             color_string = settings.get_string ("primary-color");
             var color = Clutter.Color.from_string (color_string);
@@ -209,7 +209,7 @@ namespace Gala {
             update_animation_timeout_id = Timeout.add (interval, () => {
                 update_animation_timeout_id = 0;
                 update_animation ();
-                return false;
+                return Source.REMOVE;
             });
         }
 

--- a/src/Background/BackgroundCache.vala
+++ b/src/Background/BackgroundCache.vala
@@ -20,8 +20,9 @@ namespace Gala {
         private static BackgroundCache? instance = null;
 
         public static unowned BackgroundCache get_default () {
-            if (instance == null)
+            if (instance == null) {
                 instance = new BackgroundCache ();
+            }
 
             return instance;
         }
@@ -29,17 +30,11 @@ namespace Gala {
         public signal void file_changed (string filename);
 
         private Gee.HashMap<string,FileMonitor> file_monitors;
-        private Gee.HashMap<string,BackgroundSource> background_sources;
-
+        private BackgroundSource? background_source;
         private Animation animation;
-
-        public BackgroundCache () {
-            Object ();
-        }
 
         construct {
             file_monitors = new Gee.HashMap<string,FileMonitor> ();
-            background_sources = new Gee.HashMap<string,BackgroundSource> ();
         }
 
         public void monitor_file (string filename) {
@@ -63,45 +58,39 @@ namespace Gala {
             if (animation != null && animation.filename == filename) {
                 Idle.add (() => {
                     get_animation.callback ();
-                    return false;
+                    return Source.REMOVE;
                 });
                 yield;
 
                 return animation;
             }
 
-            var animation = new Animation (filename);
+            animation = new Animation (filename);
 
             yield animation.load ();
 
             Idle.add (() => {
                 get_animation.callback ();
-                return false;
+                return Source.REMOVE;
             });
             yield;
 
             return animation;
         }
 
-        public BackgroundSource get_background_source (Meta.Display display, string settings_schema) {
-            var background_source = background_sources[settings_schema];
+        public unowned BackgroundSource get_background_source (Meta.Display display) {
             if (background_source == null) {
-                background_source = new BackgroundSource (display, settings_schema);
+                background_source = new BackgroundSource (display);
                 background_source.use_count = 1;
-                background_sources[settings_schema] = background_source;
             } else
                 background_source.use_count++;
 
             return background_source;
         }
 
-        public void release_background_source (string settings_schema) {
-            if (background_sources.has_key (settings_schema)) {
-                var source = background_sources[settings_schema];
-                if (--source.use_count == 0) {
-                    background_sources.unset (settings_schema);
-                    source.destroy ();
-                }
+        public void release_background_source () {
+            if (--background_source.use_count == 0) {
+                background_source.destroy ();
             }
         }
     }

--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -17,7 +17,6 @@
 
 namespace Gala {
     public class BackgroundManager : Meta.BackgroundGroup {
-        private const string GNOME_BACKGROUND_SCHEMA = "org.gnome.desktop.background";
         private const string GALA_BACKGROUND_SCHEMA = "io.elementary.desktop.background";
         private const string DIM_WALLPAPER_KEY = "dim-wallpaper-in-dark-style";
         private const double DIM_OPACITY = 0.55;
@@ -46,14 +45,14 @@ namespace Gala {
         }
 
         construct {
-            background_source = BackgroundCache.get_default ().get_background_source (display, GNOME_BACKGROUND_SCHEMA);
+            background_source = BackgroundCache.get_default ().get_background_source (display);
             background_actor = create_background_actor ();
 
             destroy.connect (on_destroy);
         }
 
         private void on_destroy () {
-            BackgroundCache.get_default ().release_background_source (GNOME_BACKGROUND_SCHEMA);
+            BackgroundCache.get_default ().release_background_source ();
             background_source = null;
 
             if (new_background_actor != null) {


### PR DESCRIPTION
This HashMap always contains only one item, so we can safely remove it.