### PR TITLE
ci: Specify the mutter package to use

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         version: [stable, unstable, development-target]
+        include:
+          - version: stable
+            mutter_pkg: libmutter-10-dev
+          - version: unstable
+            mutter_pkg: libmutter-10-dev
+          - version: development-target
+            mutter_pkg: libmutter-13-dev
     container:
       image: ghcr.io/elementary/docker:${{ matrix.version }}
 
@@ -24,7 +31,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libbamf3-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libmutter-*-dev libplank-dev libxml2-utils libgexiv2-dev meson valac valadoc
+        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libbamf3-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev ${{ matrix.mutter_pkg }} libplank-dev libxml2-utils libgexiv2-dev meson valac valadoc
     - name: Build
       env:
         DESTDIR: out


### PR DESCRIPTION
This allows us to specify the mutter version instead of using globs (useful as some Ubuntu version have two mutter version in the repository while transitioning to the next version)