### PR TITLE
Fix crash

### DIFF
--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -181,5 +181,10 @@ namespace Gala {
          * @param direction The direction in which to switch
          */
         public abstract void switch_to_next_workspace (Meta.MotionDirection direction);
+
+        /*
+         * Same as Meta.MonitorManager.monitors_changed signal
+         */
+        public abstract signal void monitors_changed ();
     }
 }

--- a/src/Background/BackgroundCache.vala
+++ b/src/Background/BackgroundCache.vala
@@ -82,27 +82,5 @@ namespace Gala {
 
             return animation;
         }
-
-        public BackgroundSource get_background_source (Meta.Display display, string settings_schema) {
-            var background_source = background_sources[settings_schema];
-            if (background_source == null) {
-                background_source = new BackgroundSource (display, settings_schema);
-                background_source.use_count = 1;
-                background_sources[settings_schema] = background_source;
-            } else
-                background_source.use_count++;
-
-            return background_source;
-        }
-
-        public void release_background_source (string settings_schema) {
-            if (background_sources.has_key (settings_schema)) {
-                var source = background_sources[settings_schema];
-                if (--source.use_count == 0) {
-                    background_sources.unset (settings_schema);
-                    source.destroy ();
-                }
-            }
-        }
     }
 }

--- a/src/Background/BackgroundContainer.vala
+++ b/src/Background/BackgroundContainer.vala
@@ -20,15 +20,14 @@ namespace Gala {
         public signal void changed ();
         public signal void show_background_menu (int x, int y);
 
-        public Meta.Display display { get; construct; }
+        public WindowManager wm { get; construct; }
 
-        public BackgroundContainer (Meta.Display display) {
-            Object (display: display);
+        public BackgroundContainer (WindowManager wm) {
+            Object (wm: wm);
         }
 
         construct {
-            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
-            monitor_manager.monitors_changed.connect (update);
+            wm.monitors_changed.connect (update);
 
             reactive = true;
             button_release_event.connect ((event) => {
@@ -43,8 +42,7 @@ namespace Gala {
         }
 
         ~BackgroundContainer () {
-            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
-            monitor_manager.monitors_changed.disconnect (update);
+            wm.monitors_changed.disconnect (update);
         }
 
         private void update () {
@@ -54,8 +52,8 @@ namespace Gala {
 
             destroy_all_children ();
 
-            for (var i = 0; i < display.get_n_monitors (); i++) {
-                var background = new BackgroundManager (display, i);
+            for (var i = 0; i < wm.get_display ().get_n_monitors (); i++) {
+                var background = new BackgroundManager (wm, i);
 
                 add_child (background);
 

--- a/src/Background/BackgroundSource.vala
+++ b/src/Background/BackgroundSource.vala
@@ -46,8 +46,7 @@ namespace Gala {
             backgrounds = new Gee.HashMap<int,Background> ();
             hash_cache = new uint[OPTIONS.length];
 
-            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
-            monitor_manager.monitors_changed.connect (monitors_changed);
+            WindowManagerGala.instance.monitors_changed.connect (monitors_changed);
 
             // unfortunately the settings sometimes tend to fire random changes even though
             // nothing actually happened. The code below is used to prevent us from spamming
@@ -139,8 +138,7 @@ namespace Gala {
         }
 
         public void destroy () {
-            unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
-            monitor_manager.monitors_changed.disconnect (monitors_changed);
+            WindowManagerGala.instance.monitors_changed.disconnect (monitors_changed);
 
             foreach (var background in backgrounds.values) {
                 background.changed.disconnect (background_changed);

--- a/src/Widgets/MonitorClone.vala
+++ b/src/Widgets/MonitorClone.vala
@@ -41,7 +41,7 @@ namespace Gala {
         construct {
             reactive = true;
 
-            background = new BackgroundManager (display, monitor, false);
+            background = new BackgroundManager (wm, monitor, false);
 
             var scale = display.get_monitor_scale (monitor);
 

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -27,14 +27,14 @@ namespace Gala {
         private int last_width;
         private int last_height;
 
-        public FramedBackground (Meta.Display display) {
-            Object (display: display, monitor_index: display.get_primary_monitor (), control_position: false);
+        public FramedBackground (WindowManager wm) {
+            Object (wm: wm, monitor_index: wm.get_display ().get_primary_monitor (), control_position: false);
         }
 
         construct {
             pipeline = new Cogl.Pipeline (Clutter.get_default_backend ().get_cogl_context ());
-            var primary = display.get_primary_monitor ();
-            var monitor_geom = display.get_monitor_geometry (primary);
+            var primary = wm.get_display ().get_primary_monitor ();
+            var monitor_geom = wm.get_display ().get_monitor_geometry (primary);
 
             var effect = new ShadowEffect (40) {
                 css_class = "workspace"
@@ -175,7 +175,7 @@ namespace Gala {
             background_click_action.clicked.connect (() => {
                 selected (true);
             });
-            background = new FramedBackground (display);
+            background = new FramedBackground (wm);
             background.add_action (background_click_action);
 
             window_container = new WindowCloneContainer (wm, gesture_tracker, scale_factor);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -80,6 +80,8 @@ namespace Gala {
 
         public WindowTracker? window_tracker { get; private set; }
 
+        public static WindowManagerGala instance { get; private set; }
+
         /**
          * Allow to zoom in/out the entire desktop.
          */
@@ -119,6 +121,7 @@ namespace Gala {
         private bool animating_switch_workspace = false;
         private bool switch_workspace_with_gesture = false;
 
+        public signal void monitors_changed ();
         private signal void window_created (Meta.Window window);
 
         /**
@@ -146,6 +149,8 @@ namespace Gala {
         }
 
         public override void start () {
+            instance = this;
+
             show_stage ();
 
             Bus.watch_name (BusType.SESSION, DAEMON_DBUS_NAME, BusNameWatcherFlags.NONE, daemon_appeared, lost_daemon);
@@ -376,6 +381,7 @@ namespace Gala {
 
 
             display.window_created.connect ((window) => window_created (window));
+            monitor_manager.monitors_changed.connect (() => monitors_changed ());
 
             stage.show ();
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -80,8 +80,6 @@ namespace Gala {
 
         public WindowTracker? window_tracker { get; private set; }
 
-        public static WindowManagerGala instance { get; private set; }
-
         /**
          * Allow to zoom in/out the entire desktop.
          */
@@ -121,7 +119,6 @@ namespace Gala {
         private bool animating_switch_workspace = false;
         private bool switch_workspace_with_gesture = false;
 
-        public signal void monitors_changed ();
         private signal void window_created (Meta.Window window);
 
         /**
@@ -149,8 +146,6 @@ namespace Gala {
         }
 
         public override void start () {
-            instance = this;
-
             show_stage ();
 
             Bus.watch_name (BusType.SESSION, DAEMON_DBUS_NAME, BusNameWatcherFlags.NONE, daemon_appeared, lost_daemon);
@@ -243,7 +238,7 @@ namespace Gala {
             stage.remove_child (window_group);
             ui_group.add_child (window_group);
 
-            background_group = new BackgroundContainer (display);
+            background_group = new BackgroundContainer (this);
             ((BackgroundContainer)background_group).show_background_menu.connect (on_show_background_menu);
             window_group.add_child (background_group);
             window_group.set_child_below_sibling (background_group, null);


### PR DESCRIPTION
This should fix crash in described in https://github.com/elementary/gala/discussions/1764.

~~I decided to add `instance` field to `WindowManagerGala` to avoid passing it over object constructors down to `BackgroundSource`. I'll prepare similar branch for other objects later. Is this a good idea?~~

Moves handling of `BackgroundSource` to `BackgroundManager`, which allows passing `wm` into it.