### PR TITLE
Increase `window-clone` shadow size

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -7,7 +7,6 @@
 public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     private int button_size;
     private int container_margin;
-    private const int SHADOW_SIZE = 100;
     private const uint FADE_OUT_TIMEOUT = 200;
     private const float MINIMUM_SCALE = 0.1f;
     private const float MAXIMUM_SCALE = 1.0f;
@@ -88,7 +87,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
         container = new Clutter.Actor ();
         container.reactive = true;
         container.set_scale (0.35f, 0.35f);
-        container.add_effect (new ShadowEffect (SHADOW_SIZE) { css_class = "window-clone" });
+        container.add_effect (new ShadowEffect (55) { css_class = "window-clone" });
         container.add_child (clone);
         container.add_action (move_action);
 

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -241,7 +241,7 @@ public class Gala.WindowClone : Clutter.Actor {
 
         if (window.fullscreen || window.maximized_horizontally && window.maximized_vertically) {
             if (shadow_effect == null) {
-                shadow_effect = new ShadowEffect (40) { css_class = "window-clone" };
+                shadow_effect = new ShadowEffect (55) { css_class = "window-clone" };
                 shadow_opacity = 0;
                 clone.add_effect_with_name ("shadow", shadow_effect);
             }


### PR DESCRIPTION
Fixes clipped shadows in multitasking view:
![Screenshot from 2023-10-26 14 04 21](https://github.com/elementary/gala/assets/80143868/3ec6cafc-1ff4-4af8-bbe8-3e15e3b7dc5e)
