### PR TITLE
WorkspaceManager: count windows on primary monitor only

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -31,6 +31,7 @@
         <ul>
           <li>Changing the wallpaper or going to sleep respects the "Reduce Motion" option</li>
           <li>Use appropriate drag-and-drop pointers when moving windows</li>
+          <li>Improve dynamic workspaces behaviour with multiple monitors</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -261,16 +261,20 @@ namespace Gala {
          *
          * @param workspace The workspace on which to count the windows
          */
-        public static uint get_n_windows (Meta.Workspace workspace) {
+        public static uint get_n_windows (Meta.Workspace workspace, bool on_primary = false) {
             var n = 0;
-            foreach (weak Meta.Window window in workspace.list_windows ()) {
-                if (window.on_all_workspaces)
+            foreach (unowned var window in workspace.list_windows ()) {
+                if (window.on_all_workspaces) {
                     continue;
+                }
+
                 if (
-                    window.window_type == Meta.WindowType.NORMAL ||
-                    window.window_type == Meta.WindowType.DIALOG ||
-                    window.window_type == Meta.WindowType.MODAL_DIALOG)
+                    (window.window_type == Meta.WindowType.NORMAL
+                    || window.window_type == Meta.WindowType.DIALOG
+                    || window.window_type == Meta.WindowType.MODAL_DIALOG)
+                    && (!on_primary || (on_primary && window.is_on_primary_monitor ()))) {
                     n ++;
+                }
             }
 
             return n;

--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -156,7 +156,7 @@ namespace Gala {
             // or we are in modal-mode
             if ((!is_active_workspace || wm.is_modal ())
                 && remove_freeze_count < 1
-                && Utils.get_n_windows (workspace) == 0
+                && Utils.get_n_windows (workspace, true) == 0
                 && workspace != last_workspace) {
                 remove_workspace (workspace);
             }
@@ -164,7 +164,7 @@ namespace Gala {
             // if window is the second last and empty, make it the last workspace
             if (is_active_workspace
                 && remove_freeze_count < 1
-                && Utils.get_n_windows (workspace) == 0
+                && Utils.get_n_windows (workspace, true) == 0
                 && workspace.index () == last_workspace_index - 1) {
                 remove_workspace (last_workspace);
             }


### PR DESCRIPTION
In `master` `WorkspaceManager` doesn't delete empty workspaces despite window located on second monitor.