### PR TITLE
DragDropAction: pass correct coordinates to `drag_begin`

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -291,7 +291,7 @@ namespace Gala {
                     if (!dragging && clicked) {
                         var drag_threshold = Clutter.Settings.get_default ().dnd_drag_threshold;
                         if (Math.fabsf (last_x - x) > drag_threshold || Math.fabsf (last_y - y) > drag_threshold) {
-                            handle = drag_begin (x, y);
+                            handle = drag_begin (last_x, last_y);
                             if (handle == null) {
                                 ungrab_actor ();
                                 critical ("No handle has been returned by the started signal, aborting drag.");

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -669,8 +669,10 @@ public class Gala.WindowClone : Clutter.Actor {
         window_icon.save_easing_state ();
         window_icon.set_easing_duration (duration);
         window_icon.set_easing_mode (Clutter.AnimationMode.EASE_IN_OUT_CUBIC);
-        window_icon.set_position (click_x - (abs_x + prev_parent_x) - window_icon.width / 2,
-            click_y - (abs_y + prev_parent_y) - window_icon.height / 2);
+        window_icon.set_position (
+            click_x - (abs_x + prev_parent_x) - window_icon.width / 2,
+            click_y - (abs_y + prev_parent_y) - window_icon.height / 2
+        );
         window_icon.restore_easing_state ();
 
         close_button.opacity = 0;


### PR DESCRIPTION
Fixes an issue where window icon can get detached from cursor if one is moving it too fast