### PR TITLE
Gtk.init only in X11 session

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -303,6 +303,10 @@ namespace Gala {
             // Most things inside this "later" depend on GTK. We get segfaults if we try to do GTK stuff before the window manager
             // is initialized, so we hold this stuff off until we're ready to draw
             laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
+                string[] args = {};
+                unowned string[] _args = args;
+                Gtk.init (ref _args);
+
                 accent_color_manager = new AccentColorManager ();
 
                 // initialize plugins and add default components if no plugin overrides them

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -303,9 +303,12 @@ namespace Gala {
             // Most things inside this "later" depend on GTK. We get segfaults if we try to do GTK stuff before the window manager
             // is initialized, so we hold this stuff off until we're ready to draw
             laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
-                string[] args = {};
-                unowned string[] _args = args;
-                Gtk.init (ref _args);
+                unowned string XDG_SESSION_TYPE = Environment.get_variable ("XDG_SESSION_TYPE");
+                if (XDG_SESSION_TYPE == "x11") {
+                    string[] args = {};
+                    unowned string[] _args = args;
+                    Gtk.init (ref _args);
+                }
 
                 accent_color_manager = new AccentColorManager ();
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -303,8 +303,8 @@ namespace Gala {
             // Most things inside this "later" depend on GTK. We get segfaults if we try to do GTK stuff before the window manager
             // is initialized, so we hold this stuff off until we're ready to draw
             laters.add (Meta.LaterType.BEFORE_REDRAW, () => {
-                unowned string XDG_SESSION_TYPE = Environment.get_variable ("XDG_SESSION_TYPE");
-                if (XDG_SESSION_TYPE == "x11") {
+                unowned string xdg_session_type = Environment.get_variable ("XDG_SESSION_TYPE");
+                if (xdg_session_type == "x11") {
                     string[] args = {};
                     unowned string[] _args = args;
                     Gtk.init (ref _args);


### PR DESCRIPTION
The change introduced in #1762 causes a X11 session to crash on Fedora 38. After reverting the change, the session doesn't crash.

On Fedora 38 a Wayland session crashes both with and without the change introduced in #1762.

To fix the issue, GTK should be initialized only in a X11 session.