### PR TITLE
Remove `expose-windows` shortcut

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -7,11 +7,10 @@
     <value nick="minimize-current" value="3" />
     <value nick="open-launcher" value="4" />
     <value nick="custom-command" value="5" />
-    <value nick="window-overview" value="6" />
-    <value nick="window-overview-all" value="7" />
-    <value nick="switch-to-workspace-previous" value="8" />
-    <value nick="switch-to-workspace-next" value="9" />
-    <value nick="switch-to-workspace-last" value="10" />
+    <value nick="window-overview-all" value="6" />
+    <value nick="switch-to-workspace-previous" value="7" />
+    <value nick="switch-to-workspace-next" value="8" />
+    <value nick="switch-to-workspace-last" value="9" />
   </enum>
   <enum id="GalaWindowOverviewType">
     <value nick='grid' value='0'/>
@@ -148,7 +147,7 @@
       <summary>Zoom out</summary>
     </key>
     <key type="as" name="expose-windows">
-      <default><![CDATA[['<Super>w']]]></default>
+      <default><![CDATA[['']]]></default>
       <summary>Shortcut to open the window overview</summary>
       <description></description>
     </key>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -148,7 +148,7 @@
     </key>
     <key type="as" name="expose-windows">
       <default><![CDATA[['']]]></default>
-      <summary>Shortcut to open the window overview</summary>
+      <summary>DEPRECATED: This key is deprecated and ignored</summary>
       <description></description>
     </key>
     <key type="as" name="expose-all-windows">

--- a/lib/ActivatableComponent.vala
+++ b/lib/ActivatableComponent.vala
@@ -27,8 +27,7 @@ namespace Gala {
          * The component was requested to be opened.
          *
          * @param hints The hashmap may contain special parameters that are useful
-         *              to the component. Currently, the only one implemented is the
-         *              'all-windows' hint to the windowoverview.
+         *              to the component.
          */
         public abstract void open (HashTable<string,Variant>? hints = null);
 

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -67,19 +67,12 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
 
     /**
      * {@inheritDoc}
-     * You may specify 'all-windows' in hints to expose all windows
      */
     public void open (HashTable<string,Variant>? hints = null) {
-        var all_windows = hints != null && "all-windows" in hints;
-
         workspaces = new List<Meta.Workspace> ();
         unowned var manager = wm.get_display ().get_workspace_manager ();
-        if (all_windows) {
-            foreach (unowned var workspace in manager.get_workspaces ()) {
-                workspaces.append (workspace);
-            }
-        } else {
-            workspaces.append (manager.get_active_workspace ());
+        foreach (unowned var workspace in manager.get_workspaces ()) {
+            workspaces.append (workspace);
         }
 
         var windows = new List<Meta.Window> ();
@@ -172,7 +165,6 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
         }
 
         switch (binding.get_name ()) {
-            case "expose-windows":
             case "expose-all-windows":
             case "zoom-in":
             case "zoom-out":

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -357,20 +357,11 @@ namespace Gala {
 
                 ui_group.add_child (screen_shield);
 
-                display.add_keybinding ("expose-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
-                    if (window_overview.is_opened ()) {
-                        window_overview.close ();
-                    } else {
-                        window_overview.open ();
-                    }
-                });
                 display.add_keybinding ("expose-all-windows", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, () => {
                     if (window_overview.is_opened ()) {
                         window_overview.close ();
                     } else {
-                        var hints = new HashTable<string,Variant> (str_hash, str_equal);
-                        hints.@set ("all-windows", true);
-                        window_overview.open (hints);
+                        window_overview.open ();
                     }
                 });
 
@@ -982,24 +973,26 @@ namespace Gala {
                     }
                     break;
                 case ActionType.WINDOW_OVERVIEW:
-                    if (window_overview == null)
+                    if (window_overview == null) {
                         break;
-
-                    if (window_overview.is_opened ())
+                    }
+                
+                    if (window_overview.is_opened ()) {
                         window_overview.close ();
-                    else
+                    } else {
                         window_overview.open ();
+                    }
+                    critical ("Window overview is deprecated");
                     break;
                 case ActionType.WINDOW_OVERVIEW_ALL:
-                    if (window_overview == null)
+                    if (window_overview == null) {
                         break;
+                    }
 
-                    if (window_overview.is_opened ())
+                    if (window_overview.is_opened ()) {
                         window_overview.close ();
-                    else {
-                        var hints = new HashTable<string,Variant> (str_hash, str_equal);
-                        hints.@set ("all-windows", true);
-                        window_overview.open (hints);
+                    } else {
+                        window_overview.open ();
                     }
                     break;
                 case ActionType.SWITCH_TO_WORKSPACE_LAST:

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -976,7 +976,7 @@ namespace Gala {
                     if (window_overview == null) {
                         break;
                     }
-                
+
                     if (window_overview.is_opened ()) {
                         window_overview.close ();
                     } else {


### PR DESCRIPTION
The first step towards https://github.com/elementary/gala/issues/485
Removes window spread for one workspace. AFAIK it does the exact same thing as the multitasking view, so it can be removed.

Do not merge until #1777