### PR TITLE
Add window spread for an app

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -19,10 +19,10 @@ namespace Gala {
     [DBus (name="org.pantheon.gala")]
     public class DBus {
         private static DBus? instance;
-        private static WindowManager wm;
+        private static WindowManagerGala wm;
 
         [DBus (visible = false)]
-        public static void init (WindowManager _wm) {
+        public static void init (WindowManagerGala _wm) {
             wm = _wm;
 
             Bus.own_name (BusType.SESSION, "org.pantheon.gala", BusNameOwnerFlags.NONE,
@@ -65,19 +65,14 @@ namespace Gala {
                 () => {},
                 () => critical ("Could not acquire name") );
 
-            unowned WindowManagerGala? gala_wm = wm as WindowManagerGala;
-            if (gala_wm != null) {
-                var screensaver_manager = gala_wm.screensaver;
-
-                Bus.own_name (BusType.SESSION, "org.gnome.ScreenSaver", BusNameOwnerFlags.REPLACE,
-                    (connection) => {
-                        try {
-                            connection.register_object ("/org/gnome/ScreenSaver", screensaver_manager);
-                        } catch (Error e) { warning (e.message); }
-                    },
-                    () => {},
-                    () => critical ("Could not acquire ScreenSaver bus") );
-            }
+            Bus.own_name (BusType.SESSION, "org.gnome.ScreenSaver", BusNameOwnerFlags.REPLACE,
+                (connection) => {
+                    try {
+                        connection.register_object ("/org/gnome/ScreenSaver", wm.screensaver);
+                    } catch (Error e) { warning (e.message); }
+                },
+                () => {},
+                () => critical ("Could not acquire ScreenSaver bus") );
         }
 
         private DBus () {

--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -101,6 +101,10 @@ public class Gala.DesktopIntegration : GLib.Object {
     }
 
     public void show_windows_for (string app_id) throws IOError, DBusError {
+        if (wm.window_overview == null) {
+            throw new IOError.FAILED ("Window overview not provided by window manager");
+        }
+
         App app;
         if ((app = AppSystem.get_default ().lookup_app (app_id)) == null) {
             throw new IOError.NOT_FOUND ("App not found");
@@ -111,9 +115,13 @@ public class Gala.DesktopIntegration : GLib.Object {
             window_ids += window.get_id ();
         }
 
-        var hash_table = new HashTable<string, Variant> (str_hash, str_equal);
-        hash_table["windows"] = window_ids;
+        var hints = new HashTable<string, Variant> (str_hash, str_equal);
+        hints["windows"] = window_ids;
 
-        wm.show_window_spread (hash_table);
+        if (wm.window_overview.is_opened ()) {
+            wm.window_overview.close ();
+        }
+
+        wm.window_overview.open (hints);
     }
 }

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -16,7 +16,6 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
 
     // the workspaces which we expose right now
     private List<Meta.Workspace> workspaces;
-    private List<Meta.Window> minimized_windows;
 
     public WindowOverview (WindowManager wm) {
         Object (wm : wm);
@@ -92,19 +91,12 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
 
                 if (window.window_type != Meta.WindowType.NORMAL &&
                     window.window_type != Meta.WindowType.DIALOG ||
-                    window.is_attached_dialog ()
+                    window.is_attached_dialog () ||
+                    (window_ids != null && !(window.get_id () in window_ids))
                 ) {
                     unowned var actor = (Meta.WindowActor) window.get_compositor_private ();
                     actor.hide ();
 
-                    continue;
-                }
-
-                if (window_ids != null && !(window.get_id () in window_ids)) {
-                    if (!window.minimized) {
-                        window.minimize ();
-                        minimized_windows.append (window);
-                    }
                     continue;
                 }
 
@@ -286,10 +278,6 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
 
         foreach (unowned var child in get_children ()) {
             ((WindowCloneContainer) child).close ();
-        }
-
-        foreach (var window in minimized_windows) {
-            window.unminimize ();
         }
 
         Clutter.Threads.Timeout.add (MultitaskingView.ANIMATION_DURATION, () => {

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -80,7 +80,6 @@ public class Gala.WindowOverview : Clutter.Actor, ActivatableComponent {
             window_ids = (uint64[]) hints["windows"];
         }
 
-        minimized_windows = new List<Meta.Window> ();
         var windows = new List<Meta.Window> ();
         foreach (var workspace in workspaces) {
             foreach (unowned var window in workspace.list_windows ()) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -72,7 +72,8 @@ namespace Gala {
         private Meta.PluginInfo info;
 
         private WindowSwitcher? window_switcher = null;
-        private ActivatableComponent? window_overview = null;
+
+        public ActivatableComponent? window_overview { get; private set; }
 
         public ScreenSaverManager? screensaver { get; private set; }
 
@@ -2426,14 +2427,6 @@ namespace Gala {
             actor.get_parent ().remove_child (actor);
             new_parent.add_child (actor);
             actor.unref ();
-        }
-
-        public void show_window_spread (HashTable<string,Variant>? hints = null) {
-            if (window_overview.is_opened ()) {
-                window_overview.close ();
-            }
-
-            window_overview.open (hints);
         }
     }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -72,7 +72,7 @@ namespace Gala {
         private Meta.PluginInfo info;
 
         private WindowSwitcher? window_switcher = null;
-        private ActivatableComponent? window_overview = null;
+        public ActivatableComponent? window_overview = null;
 
         public ScreenSaverManager? screensaver { get; private set; }
 
@@ -2426,6 +2426,14 @@ namespace Gala {
             actor.get_parent ().remove_child (actor);
             new_parent.add_child (actor);
             actor.unref ();
+        }
+
+        public void show_window_spread (HashTable<string,Variant>? hints = null) {
+            if (window_overview.is_opened ()) {
+                window_overview.close ();
+            }
+
+            window_overview.open (hints);
         }
     }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -72,7 +72,7 @@ namespace Gala {
         private Meta.PluginInfo info;
 
         private WindowSwitcher? window_switcher = null;
-        public ActivatableComponent? window_overview = null;
+        private ActivatableComponent? window_overview = null;
 
         public ScreenSaverManager? screensaver { get; private set; }
 


### PR DESCRIPTION
This is going to be used by dock when more than one window is open for an app and the app icon is clicked on.

Uses the WindowOverview but with only the windows that belong to the specific app. Once the dock is properly integrated it will stay as well and don't go away.

Also opinions in general on this? An alternative would be something more classical like the alt tab switcher but with window previews over the dock icon but I like this a bit more and it is as far as I understood it what's meant in #1377.

Mostly fixes #1377 (probably together with #1817, alternatively that can be absorbed here with this handling deciding between focus for one or spread for two or more but I think a window list in the context menu would still be useful in the dock)
