### PR TITLE
WindowSwitcher: Fix accent color

### DIFF
--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -70,10 +70,10 @@ public class Gala.WindowSwitcherIcon : Clutter.Actor {
             // draw rect
             var rgba = InternalUtils.get_theme_accent_color ();
             ctx.set_source_rgba (
-                (uint8) (rgba.red * 255),
-                (uint8) (rgba.green * 255),
-                (uint8) (rgba.blue * 255),
-                (uint8) (rgba.alpha * 255)
+                rgba.red,
+                rgba.green,
+                rgba.blue,
+                rgba.alpha
             );
             var rect_radius = InternalUtils.scale_to_int (WRAPPER_BORDER_RADIUS, scale_factor);
             Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, rect_radius);


### PR DESCRIPTION
Fixes #1834 

`Clutter.Color` uses `uint` whereas `ctx.set_source_rgba` uses `double`

This is a remnant from #1825