### PR TITLE
Fix rounded background

### DIFF
--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -89,6 +89,7 @@ public class Gala.BackgroundManager : Meta.BackgroundGroup {
         var background = new_content.background.get_data<unowned Background> ("delegate");
 
         if (background.is_loaded) {
+            new_content.rounded_clip_radius = Utils.scale_to_int (6, wm.get_display ().get_monitor_scale (monitor_index));
             swap_background_actor (animate);
             return;
         }
@@ -99,6 +100,7 @@ public class Gala.BackgroundManager : Meta.BackgroundGroup {
             background.set_data<ulong> ("background-loaded-handler", 0);
 
             swap_background_actor (animate);
+            new_content.rounded_clip_radius = Utils.scale_to_int (6, wm.get_display ().get_monitor_scale (monitor_index));
         });
         background.set_data<ulong> ("background-loaded-handler", handler);
     }
@@ -119,8 +121,6 @@ public class Gala.BackgroundManager : Meta.BackgroundGroup {
         content.background = background.background;
 
         var monitor = display.get_monitor_geometry (monitor_index);
-
-        content.rounded_clip_radius = Utils.scale_to_int (6, display.get_monitor_scale (monitor_index));
 
         if (background_source.should_dim) {
             content.vignette = true;


### PR DESCRIPTION
Fixes #1841
Closes #1843 

Ok I did some digging so here is what I found and what I think is happening:
When clip bounds aren't set the full texture size is used as clip bounds. But when the texture isn't loaded yet the size is seen as 0 so clip bounds are set to 0 and the whole texture is clipped away because clip bounds aren't updated when the texture is loaded.

Anyways regardless of whether that's actually what's happening this PR fixes the issue for me without reintroducing #1815 :)