### PR TITLE
WindowManager: Allow making modal without a grab

### DIFF
--- a/daemon/MenuDaemon.vala
+++ b/daemon/MenuDaemon.vala
@@ -16,6 +16,8 @@ public class Gala.Daemon.MenuDaemon : GLib.Object {
     private const string DAEMON_DBUS_NAME = "org.pantheon.gala.daemon";
     private const string DAEMON_DBUS_OBJECT_PATH = "/org/pantheon/gala/daemon";
 
+    public signal void pop_modal ();
+
     private WMDBus? wm_proxy = null;
 
     private WindowMenu? window_menu;
@@ -101,5 +103,7 @@ public class Gala.Daemon.MenuDaemon : GLib.Object {
                 return Gdk.EVENT_PROPAGATE;
             });
         }
+
+        window.destroy.connect (() => pop_modal ());
     }
 }

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -135,7 +135,7 @@ namespace Gala {
          * @return a {@link ModalProxy} which is needed to end the modal mode again and provides some
          *         some basic control on the behavior of the window manager while it is in modal mode.
          */
-        public abstract ModalProxy push_modal (Clutter.Actor actor);
+        public abstract ModalProxy push_modal (Clutter.Actor? actor);
 
         /**
          * May exit the modal mode again, unless another component has called {@link push_modal}

--- a/src/DaemonManager.vala
+++ b/src/DaemonManager.vala
@@ -12,17 +12,19 @@ public class Gala.DaemonManager : GLib.Object {
 
     [DBus (name = "org.pantheon.gala.daemon")]
     public interface Daemon: GLib.Object {
+        public signal void pop_modal ();
         public abstract async void show_window_menu (WindowFlags flags, int width, int height, int x, int y) throws Error;
         public abstract async void show_desktop_menu (int display_width, int display_height, int x, int y) throws Error;
     }
 
-    public Meta.Display display { get; construct; }
+    public WindowManager wm { get; construct; }
 
     private Meta.WaylandClient daemon_client;
     private Daemon? daemon_proxy = null;
+    private ModalProxy? modal_proxy = null;
 
-    public DaemonManager (Meta.Display display) {
-        Object (display: display);
+    public DaemonManager (WindowManager wm) {
+        Object (wm: wm);
     }
 
     construct {
@@ -31,7 +33,7 @@ public class Gala.DaemonManager : GLib.Object {
         if (Meta.Util.is_wayland_compositor ()) {
             start_wayland.begin ();
 
-            display.window_created.connect ((window) => {
+            wm.get_display ().window_created.connect ((window) => {
                 if (daemon_client.owns_window (window)) {
                     window.shown.connect (handle_daemon_window);
                 }
@@ -45,12 +47,12 @@ public class Gala.DaemonManager : GLib.Object {
         var subprocess_launcher = new GLib.SubprocessLauncher (NONE);
         try {
 #if HAS_MUTTER44
-            daemon_client = new Meta.WaylandClient (display.get_context (), subprocess_launcher);
+            daemon_client = new Meta.WaylandClient (wm.get_display ().get_context (), subprocess_launcher);
 #else
             daemon_client = new Meta.WaylandClient (subprocess_launcher);
 #endif
             string[] args = {"gala-daemon"};
-            var subprocess = daemon_client.spawnv (display, args);
+            var subprocess = daemon_client.spawnv (wm.get_display (), args);
 
             yield subprocess.wait_async ();
 
@@ -94,6 +96,12 @@ public class Gala.DaemonManager : GLib.Object {
             Bus.get_proxy.begin<Daemon> (BusType.SESSION, DAEMON_DBUS_NAME, DAEMON_DBUS_OBJECT_PATH, 0, null, (obj, res) => {
                 try {
                     daemon_proxy = Bus.get_proxy.end (res);
+                    daemon_proxy.pop_modal.connect (() => {
+                        if (modal_proxy != null) {
+                            wm.pop_modal (modal_proxy);
+                            modal_proxy = null;
+                        }
+                    });
                 } catch (Error e) {
                     warning ("Failed to get Menu proxy: %s", e.message);
                 }
@@ -107,10 +115,13 @@ public class Gala.DaemonManager : GLib.Object {
         }
 
         int width, height;
-        display.get_size (out width, out height);
+        wm.get_display ().get_size (out width, out height);
 
         try {
             yield daemon_proxy.show_desktop_menu (width, height, x, y);
+            if (modal_proxy == null) {
+                modal_proxy = wm.push_modal (null);
+            }
         } catch (Error e) {
             warning ("Error invoking MenuManager: %s", e.message);
         }
@@ -122,10 +133,13 @@ public class Gala.DaemonManager : GLib.Object {
         }
 
         int width, height;
-        display.get_size (out width, out height);
+        wm.get_display ().get_size (out width, out height);
 
         try {
             yield daemon_proxy.show_window_menu (flags, width, height, x, y);
+            if (modal_proxy == null) {
+                modal_proxy = wm.push_modal (null);
+            }
         } catch (Error e) {
             warning ("Error invoking MenuManager: %s", e.message);
         }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -138,7 +138,7 @@ namespace Gala {
         }
 
         public override void start () {
-            daemon_manager = new DaemonManager (get_display ());
+            daemon_manager = new DaemonManager (this);
 
             show_stage ();
 
@@ -784,7 +784,7 @@ namespace Gala {
         /**
          * {@inheritDoc}
          */
-        public ModalProxy push_modal (Clutter.Actor actor) {
+        public ModalProxy push_modal (Clutter.Actor? actor) {
             var proxy = new ModalProxy ();
 
             modal_stack.offer_head (proxy);
@@ -796,7 +796,10 @@ namespace Gala {
             unowned Meta.Display display = get_display ();
 
             update_input_area ();
-            proxy.grab = stage.grab (actor);
+
+            if (actor != null) {
+                proxy.grab = stage.grab (actor);
+            }
 
             if (modal_stack.size == 1) {
                 display.disable_unredirect ();
@@ -814,7 +817,9 @@ namespace Gala {
                 return;
             }
 
-            proxy.grab.dismiss ();
+            if (proxy.grab != null) {
+                proxy.grab.dismiss ();
+            }
 
             if (is_modal ())
                 return;


### PR DESCRIPTION
- This allows making the WindowManager modal without a stage grab
- Useful if you just want to block keybindings
- Fixes being able to switch workspaces while a window menu is active which was brought up by @lenemter in #1844 
- It's an API break (I think?) but I'm not sure anybody except for us currently uses gala api?
- Will also be useful if we want to introduce a shell modal hint for windows