### PR TITLE
MonitorLabel: clean up styles, gtk4 prep

### DIFF
--- a/daemon/MonitorLabel.vala
+++ b/daemon/MonitorLabel.vala
@@ -42,13 +42,11 @@
             (int) (info.y / scale_factor) + SPACING
         );
 
-
-        get_style_context ().add_class ("monitor-label");
-
         var provider = new Gtk.CssProvider ();
         try {
             provider.load_from_data (COLORED_STYLE_CSS.printf (title, info.background_color, info.text_color));
             get_style_context ().add_class (title);
+            get_style_context ().add_class ("monitor-label");
 
             Gtk.StyleContext.add_provider_for_screen (
                 Gdk.Screen.get_default (),

--- a/daemon/MonitorLabel.vala
+++ b/daemon/MonitorLabel.vala
@@ -6,8 +6,10 @@
  public class Gala.Daemon.MonitorLabel : Hdy.Window {
     private const int SPACING = 12;
     private const string COLORED_STYLE_CSS = """
-        @define-color BG_COLOR %s;
-        @define-color TEXT_COLOR %s;
+    .%s {
+        background-color: alpha(%s, 0.8);
+        color: %s;
+    }
     """;
 
     public MonitorLabelInfo info { get; construct; }
@@ -17,9 +19,7 @@
     }
 
     construct {
-        child = new Gtk.Label (info.label) {
-            margin = 12
-        };
+        child = new Gtk.Label (info.label);
 
         title = "LABEL-%i".printf (info.monitor);
 
@@ -42,12 +42,19 @@
             (int) (info.y / scale_factor) + SPACING
         );
 
+
+        get_style_context ().add_class ("monitor-label");
+
         var provider = new Gtk.CssProvider ();
         try {
-            provider.load_from_data (COLORED_STYLE_CSS.printf (info.background_color, info.text_color));
+            provider.load_from_data (COLORED_STYLE_CSS.printf (title, info.background_color, info.text_color));
+            get_style_context ().add_class (title);
 
-            get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            get_style_context ().add_class ("colored");
+            Gtk.StyleContext.add_provider_for_screen (
+                Gdk.Screen.get_default (),
+                provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            );
         } catch (Error e) {
             warning ("Failed to load CSS: %s", e.message);
         }

--- a/data/gala-daemon.css
+++ b/data/gala-daemon.css
@@ -7,17 +7,12 @@ daemon-window {
     background-color: transparent;
 }
 
-/* For better dark style support */
-@define-color BG_COLOR_ALPHA alpha(@BG_COLOR, 0.75);
-
-.colored {
-    background-color: @BG_COLOR_ALPHA;
-    color: @TEXT_COLOR;
-    text-shadow: 0 1px 1px alpha(white, 0.1);
-    -gtk-icon-shadow: 0 1px 1px alpha(white, 0.1);
-    -gtk-icon-palette: warning white;
+.monitor-label {
+    border-radius: 9px;
+    font-weight: 600;
 }
 
-window.colored {
-    background-color: alpha (@BG_COLOR, 0.8);
+.monitor-label label {
+    margin: 1em;
+    text-shadow: 0 1px 1px alpha(white, 0.1);
 }


### PR DESCRIPTION
* In latest Gtk4 the only non-deprecated way to add styles from a string is to the whole display, so prepare for that
* Set label margin in CSS
* Remove some unused styles that were for the display plug