### PR TITLE
CI: Remove plank dep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libbamf3-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev ${{ matrix.mutter_pkg }} libplank-dev libxml2-utils libsqlite3-dev meson valac valadoc
+        apt install -y gettext gnome-settings-daemon-dev gsettings-desktop-schemas-dev libcanberra-dev libcanberra-gtk3-dev libclutter-1.0-dev libgee-0.8-dev libglib2.0-dev libgnome-desktop-3-dev libgranite-dev libgtk-3-dev ${{ matrix.mutter_pkg }} libxml2-utils libsqlite3-dev meson valac valadoc
     - name: Build
       env:
         DESTDIR: out

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -13,8 +13,6 @@ basic_command = [
     '--package-version', '0.0.0',
     '--driver', vala.version(),
     mutter_packages_command,
-    '--pkg', 'libbamf3',
-    '--pkg', 'plank',
     '--pkg', 'gnome-desktop-3.0',
     '--pkg', 'gtk+-3.0',
     '--pkg', 'gee-0.8',


### PR DESCRIPTION
CI currently fails for development target because of some libplank dependency mismatch. But since we don't depend on plank anymore anyways remove it from CI and while we're here documentation.