### PR TITLE
WindowManager: Keep docks static during workspace switch

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1966,7 +1966,6 @@ namespace Gala {
 
             var to_has_fullscreened = false;
             var from_has_fullscreened = false;
-            var docks = new List<Meta.WindowActor> ();
 
             // collect all windows and put them in the appropriate containers
             foreach (unowned Meta.WindowActor actor in display.get_window_actors ()) {
@@ -1985,24 +1984,27 @@ namespace Gala {
                 }
 
                 if (window.on_all_workspaces) {
-                    // only collect docks here that need to be displayed on both workspaces
-                    // all other windows will be collected below
-                    if (window.window_type == Meta.WindowType.DOCK) {
-                        docks.prepend (actor);
-                    } else if (window.window_type == Meta.WindowType.NOTIFICATION) {
-                        // notifications use their own group and are always on top
-                    } else {
-                        // windows that are on all workspaces will be faded out and back in
-                        windows.prepend (actor);
-                        parents.prepend (actor.get_parent ());
-
-                        clutter_actor_reparent (actor, static_windows);
-                        actor.set_translation (-clone_offset_x, -clone_offset_y, 0);
-                        actor.save_easing_state ();
-                        actor.set_easing_duration (300);
-                        actor.opacity = 0;
-                        actor.restore_easing_state ();
+                    // notifications use their own group and are always on top
+                    if (window.window_type == NOTIFICATION) {
+                        continue;
                     }
+
+                    windows.prepend (actor);
+                    parents.prepend (actor.get_parent ());
+
+                    clutter_actor_reparent (actor, static_windows);
+                    actor.set_translation (-clone_offset_x, -clone_offset_y, 0);
+
+                    // Don't fade docks they just stay where they are
+                    if (window.window_type == DOCK) {
+                        continue;
+                    }
+
+                    // windows that are on all workspaces will be faded out and back in
+                    actor.save_easing_state ();
+                    actor.set_easing_duration (300);
+                    actor.opacity = 0;
+                    actor.restore_easing_state ();
 
                     continue;
                 }
@@ -2025,30 +2027,6 @@ namespace Gala {
                     if (window.fullscreen)
                         to_has_fullscreened = true;
 
-                }
-            }
-
-            // make sure we don't add docks when there are fullscreened
-            // windows on one of the groups. Simply raising seems not to
-            // work, mutter probably reverts the order internally to match
-            // the display stack
-            foreach (var window in docks) {
-                if (workspace_to != null && !to_has_fullscreened) {
-                    var clone = new SafeWindowClone (window.get_meta_window ()) {
-                        x = window.x - clone_offset_x,
-                        y = window.y - clone_offset_y
-                    };
-
-                    in_group.add_child (clone);
-                    tmp_actors.prepend (clone);
-                }
-
-                if (!from_has_fullscreened) {
-                    windows.prepend (window);
-                    parents.prepend (window.get_parent ());
-                    window.set_translation (-clone_offset_x, -clone_offset_y, 0.0f);
-
-                    clutter_actor_reparent (window, out_group);
                 }
             }
 


### PR DESCRIPTION
Works both on X (also with plank) and on wayland with #1887.

Fixes #275 