### PR TITLE
Barrier: fix build with mutter 46

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           - version: unstable
             mutter_pkg: libmutter-10-dev
           - version: development-target
-            mutter_pkg: libmutter-13-dev
+            mutter_pkg: libmutter-14-dev
     container:
       image: ghcr.io/elementary/docker:${{ matrix.version }}
 

--- a/src/HotCorners/Barrier.vala
+++ b/src/HotCorners/Barrier.vala
@@ -9,6 +9,10 @@
 public class Gala.Barrier : Meta.Barrier {
     public signal void trigger ();
 
+#if HAS_MUTTER46
+    public Meta.Display display { owned get; construct; }
+#endif
+
     public bool triggered { get; set; default = false; }
 
     public int trigger_pressure_threshold { get; construct; }

--- a/src/HotCorners/Barrier.vala
+++ b/src/HotCorners/Barrier.vala
@@ -9,10 +9,6 @@
 public class Gala.Barrier : Meta.Barrier {
     public signal void trigger ();
 
-#if HAS_MUTTER46
-    public Meta.Display display { owned get; construct; }
-#endif
-
     public bool triggered { get; set; default = false; }
 
     public int trigger_pressure_threshold { get; construct; }
@@ -30,7 +26,6 @@ public class Gala.Barrier : Meta.Barrier {
      * the barrier to trigger again. Set to int.MAX to disallow retrigger.
      */
     public Barrier (
-        Meta.Display display,
         int x1,
         int y1,
         int x2,
@@ -42,7 +37,6 @@ public class Gala.Barrier : Meta.Barrier {
         int retrigger_delay
     ) {
         Object (
-            display: display,
             x1: x1,
             y1: y1,
             x2: x2,

--- a/src/HotCorners/HotCorner.vala
+++ b/src/HotCorners/HotCorner.vala
@@ -69,7 +69,7 @@ public class Gala.HotCorner : Object {
         var hdir = get_barrier_direction (hot_corner_position, Clutter.Orientation.HORIZONTAL);
 
         vertical_barrier = new Gala.Barrier (
-            display, vrect.x, vrect.y, vrect.x + vrect.width, vrect.y + vrect.height, vdir,
+            vrect.x, vrect.y, vrect.x + vrect.width, vrect.y + vrect.height, vdir,
             TRIGGER_PRESSURE_THRESHOLD,
             RELEASE_PRESSURE_THRESHOLD,
             RETRIGGER_PRESSURE_THRESHOLD,
@@ -77,7 +77,7 @@ public class Gala.HotCorner : Object {
         );
 
         horizontal_barrier = new Gala.Barrier (
-            display, hrect.x, hrect.y, hrect.x + hrect.width, hrect.y + hrect.height, hdir,
+            hrect.x, hrect.y, hrect.x + hrect.width, hrect.y + hrect.height, hdir,
             TRIGGER_PRESSURE_THRESHOLD,
             RELEASE_PRESSURE_THRESHOLD,
             RETRIGGER_PRESSURE_THRESHOLD,


### PR DESCRIPTION
Meta.Display is removed from barrier in 46 (and it was deprecated before), so remove it here