### PR TITLE
Fix barriers

### DIFF
--- a/src/HotCorners/HotCorner.vala
+++ b/src/HotCorners/HotCorner.vala
@@ -48,27 +48,23 @@ public class Gala.HotCorner : Object {
     private Gala.Barrier? vertical_barrier = null;
     private Gala.Barrier? horizontal_barrier = null;
 
-    public HotCorner (Meta.Display display, float x, float y, float scale, string hot_corner_position) {
-        add_barriers (display, x, y, scale, hot_corner_position);
+    public HotCorner (Meta.Backend backend, float x, float y, float scale, string hot_corner_position) {
+        add_barriers (backend, x, y, scale, hot_corner_position);
     }
 
     public void destroy_barriers () {
-        if (vertical_barrier != null) {
-            vertical_barrier.destroy ();
-        }
-
-        if (horizontal_barrier != null) {
-            horizontal_barrier.destroy ();
-        }
+        vertical_barrier = null;
+        horizontal_barrier = null;
     }
 
-    private void add_barriers (Meta.Display display, float x, float y, float scale, string hot_corner_position) {
+    private void add_barriers (Meta.Backend backend, float x, float y, float scale, string hot_corner_position) {
         var vrect = get_barrier_rect (x, y, scale, hot_corner_position, Clutter.Orientation.VERTICAL);
         var hrect = get_barrier_rect (x, y, scale, hot_corner_position, Clutter.Orientation.HORIZONTAL);
         var vdir = get_barrier_direction (hot_corner_position, Clutter.Orientation.VERTICAL);
         var hdir = get_barrier_direction (hot_corner_position, Clutter.Orientation.HORIZONTAL);
 
         vertical_barrier = new Gala.Barrier (
+            backend,
             vrect.x, vrect.y, vrect.x + vrect.width, vrect.y + vrect.height, vdir,
             TRIGGER_PRESSURE_THRESHOLD,
             RELEASE_PRESSURE_THRESHOLD,
@@ -77,6 +73,7 @@ public class Gala.HotCorner : Object {
         );
 
         horizontal_barrier = new Gala.Barrier (
+            backend,
             hrect.x, hrect.y, hrect.x + hrect.width, hrect.y + hrect.height, hdir,
             TRIGGER_PRESSURE_THRESHOLD,
             RELEASE_PRESSURE_THRESHOLD,

--- a/src/HotCorners/HotCornerManager.vala
+++ b/src/HotCorners/HotCornerManager.vala
@@ -69,7 +69,7 @@ public class Gala.HotCornerManager : Object {
         }
 
         unowned Meta.Display display = wm.get_display ();
-        var hot_corner = new HotCorner (display, (int) x, (int) y, scale, hot_corner_position);
+        var hot_corner = new HotCorner (display.get_context ().get_backend (), (int) x, (int) y, scale, hot_corner_position);
 
         hot_corner.trigger.connect (() => {
             if (

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -171,7 +171,13 @@ public class Gala.HideTracker : Object {
     }
 
     private void toggle_display (bool should_hide) {
-        if (should_hide) {
+#if HAS_MUTTER45
+        hovered = panel.window.has_pointer ();
+#else
+        hovered = window_has_pointer ();
+#endif
+
+        if (should_hide && !hovered) {
             // Don't hide if we have transients, e.g. an open popover, dialog, etc.
             var has_transients = false;
             panel.window.foreach_transient (() => {
@@ -179,7 +185,7 @@ public class Gala.HideTracker : Object {
                 return false;
             });
 
-            if (hovered || has_transients) {
+            if (has_transients) {
                 return;
             }
 

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -181,10 +181,7 @@ public class Gala.PanelWindow : Object {
     }
 
     private void destroy_barrier () {
-        if (barrier != null) {
-            barrier.destroy ();
-            barrier = null;
-        }
+        barrier = null;
     }
 
     private void setup_barrier () {
@@ -214,6 +211,7 @@ public class Gala.PanelWindow : Object {
     private void setup_barrier_top (Meta.Rectangle monitor_geom, int offset) {
 #endif
         barrier = new Barrier (
+            wm.get_display ().get_context ().get_backend (),
             monitor_geom.x + offset,
             monitor_geom.y,
             monitor_geom.x + monitor_geom.width - offset,
@@ -234,6 +232,7 @@ public class Gala.PanelWindow : Object {
     private void setup_barrier_bottom (Meta.Rectangle monitor_geom, int offset) {
 #endif
         barrier = new Barrier (
+            wm.get_display ().get_context ().get_backend (),
             monitor_geom.x + offset,
             monitor_geom.y + monitor_geom.height,
             monitor_geom.x + monitor_geom.width - offset,


### PR DESCRIPTION
Barriers require the backend since a newer mutter version. Also switch to composition instead of inheritance to prevent this from happening again as well as catching errors if barriers aren't supported.