### PR TITLE
InternalUtils: Fix window placement

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -172,9 +172,8 @@ namespace Gala {
             }
 
             // Assign each window to the closest available slot
-            var tmplist = windows.copy ();
-            while (tmplist.length () > 0) {
-                unowned List<unowned TilableWindow?> link = tmplist.nth (0);
+            while (windows.length () > 0) {
+                unowned List<TilableWindow?> link = windows.nth (0);
                 var window = link.data;
                 var rect = window.rect;
 
@@ -207,9 +206,9 @@ namespace Gala {
                     continue;
 
                 if (taken_slots[slot_candidate] != null)
-                    tmplist.prepend (taken_slots[slot_candidate]);
+                    windows.prepend (taken_slots[slot_candidate]);
 
-                tmplist.remove_link (link);
+                windows.remove_link (link);
                 taken_slots[slot_candidate] = window;
             }
 

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -143,6 +143,9 @@ namespace Gala {
             unowned WindowClone id;
         }
 
+        /**
+         * Careful: List<TilableWindow?> windows will be modified in place and shouldn't be used afterwards.
+         */
 #if HAS_MUTTER45
         public static List<TilableWindow?> calculate_grid_placement (Mtk.Rectangle area, List<TilableWindow?> windows) {
 #else


### PR DESCRIPTION
Copying the list would sometimes lead to absolutly crazy numbers for width and height of some TilableWindow rects. I'm lacking the background knowledge as to why this just started happening now or what was actually going on but in my  testing this seems to fix it. Also it seems as if the algorithm is more stable now and windows don't just randomly change place but maybe I'm just imagining things at this point lol :)

Thanks @bobby285271 for your investigations otherwise I would've been looking into wayland stuff for far too long :)

Fixes #1911