### PR TITLE
wayland: Don't hide under systemd

### DIFF
--- a/data/gala-wayland.desktop
+++ b/data/gala-wayland.desktop
@@ -11,5 +11,4 @@ X-GNOME-WMName=Gala
 X-GnomeWMSettingsLibrary=metacity
 X-GNOME-Autostart-Phase=DisplayServer
 X-GNOME-Autostart-Notify=true
-X-GNOME-HiddenUnderSystemd=true
 X-Ubuntu-Gettext-Domain=gala


### PR DESCRIPTION
Works around the broken session start for now. The proper fix would probably be to get the systemd units working (for some reason the X one works? or is gala launched by something else there?) but I don't know how :(