### PR TITLE
WindowSwitcher: draw our own borders

### DIFF
--- a/data/gala.css
+++ b/data/gala.css
@@ -18,17 +18,6 @@
  *  Authored by: Tom Beckmann
  */
 
-.gala-notification {
-    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.5);
-    background-color: rgb(2434, 2434, 2434);
-    border: 1px solid rgba(0, 0, 0, 0.3);
-    border-radius: 4px;
-}
-
-.gala-notification .title, .gala-notification .label {
-    color: #333;
-}
-
 .decoration {
     border-radius: 4px 4px 0 0;
     box-shadow:
@@ -55,9 +44,8 @@
 }
 
 .window-switcher.decoration {
-    border-radius: 6px;
+    border-radius: 9px;
     box-shadow:
-        0 0 0 1px alpha(#000, 0.2),
         0 8px 10px 1px alpha(#000, 0.14),
         0 3px 14px 2px alpha(#000, 0.12),
         0 5px 5px -3px alpha(#000, 0.4);

--- a/lib/Drawing/Color.vala
+++ b/lib/Drawing/Color.vala
@@ -13,6 +13,10 @@ namespace Gala.Drawing {
     public class Color : GLib.Object {
         public const Gdk.RGBA LIGHT_BACKGROUND = { (250f / 255f), (250f / 255f), (250f / 255f), 1};
         public const Gdk.RGBA DARK_BACKGROUND = { (51 / 255f), (51 / 255f), (51 / 255f), 1};
+        public const Gdk.RGBA LIGHT_BORDER = { 0, 0, 0, 0.2};
+        public const Gdk.RGBA DARK_BORDER = { 0, 0, 0, 0.75};
+        public const Gdk.RGBA LIGHT_HIGHLIGHT = { 255, 255, 255, 1};
+        public const Gdk.RGBA DARK_HIGHLIGHT = { 255, 255, 255, 0.05};
         public const Gdk.RGBA TOOLTIP_BACKGROUND = { 0, 0, 0, 1};
         public const Gdk.RGBA TOOLTIP_TEXT_COLOR = { 1, 1, 1, 1};
 

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -142,10 +142,16 @@ public class Gala.WindowSwitcher : CanvasActor {
     }
 
     protected override void draw (Cairo.Context ctx, int width, int height) {
+        var background_color = Drawing.Color.LIGHT_BACKGROUND;
+        var border_color = Drawing.Color.LIGHT_BORDER;
         var caption_color = "#2e2e31";
+        var highlight_color = Drawing.Color.LIGHT_HIGHLIGHT;
 
         if (style_manager.prefers_color_scheme == Drawing.StyleManager.ColorScheme.DARK) {
+            background_color = Drawing.Color.DARK_BACKGROUND;
+            border_color = Drawing.Color.DARK_BORDER;
             caption_color = "#fafafa";
+            highlight_color = Drawing.Color.DARK_HIGHLIGHT;
         }
 
         caption.color = Clutter.Color.from_string (caption_color);
@@ -156,20 +162,38 @@ public class Gala.WindowSwitcher : CanvasActor {
         ctx.clip ();
         ctx.reset_clip ();
 
-        var background_color = Drawing.Color.LIGHT_BACKGROUND;
-        if (style_manager.prefers_color_scheme == Drawing.StyleManager.ColorScheme.DARK) {
-            background_color = Drawing.Color.DARK_BACKGROUND;
-        }
-
         ctx.set_operator (Cairo.Operator.SOURCE);
+
+        Drawing.Utilities.cairo_rounded_rectangle (ctx, 0.5, 0.5, width - 1, height - 1, InternalUtils.scale_to_int (9, scaling_factor));
+
         ctx.set_source_rgba (
             background_color.red,
             background_color.green,
             background_color.blue,
             background_color.alpha
         );
-        Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, InternalUtils.scale_to_int (6, scaling_factor));
-        ctx.fill ();
+        ctx.fill_preserve ();
+
+        ctx.set_line_width (1);
+        ctx.set_source_rgba (
+            border_color.red,
+            border_color.green,
+            border_color.blue,
+            border_color.alpha
+        );
+        ctx.stroke ();
+        ctx.restore ();
+
+        Drawing.Utilities.cairo_rounded_rectangle (ctx, 1.5, 1.5, width - 3, height - 3, InternalUtils.scale_to_int (8, scaling_factor));
+
+        ctx.set_line_width (1);
+        ctx.set_source_rgba (
+            highlight_color.red,
+            highlight_color.green,
+            highlight_color.blue,
+            highlight_color.alpha
+        );
+        ctx.stroke ();
         ctx.restore ();
     }
 

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -194,7 +194,7 @@ public class Gala.WindowSwitcher : CanvasActor {
 
         // Offset by 0.5 so cairo draws a stroke on real pixels
         Drawing.Utilities.cairo_rounded_rectangle (
-            ctx, stroke_width  + 0.5, stroke_width + 0.5,
+            ctx, stroke_width + 0.5, stroke_width + 0.5,
             width - stroke_width * 2 - 1,
             height - stroke_width * 2 - 1,
             InternalUtils.scale_to_int (8, scaling_factor)

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -154,6 +154,8 @@ public class Gala.WindowSwitcher : CanvasActor {
             highlight_color = Drawing.Color.DARK_HIGHLIGHT;
         }
 
+        var stroke_width = scaling_factor;
+
         caption.color = Clutter.Color.from_string (caption_color);
 
         ctx.save ();
@@ -164,7 +166,13 @@ public class Gala.WindowSwitcher : CanvasActor {
 
         ctx.set_operator (Cairo.Operator.SOURCE);
 
-        Drawing.Utilities.cairo_rounded_rectangle (ctx, 0.5, 0.5, width - 1, height - 1, InternalUtils.scale_to_int (9, scaling_factor));
+        // Offset by 0.5 so cairo draws a stroke on real pixels
+        Drawing.Utilities.cairo_rounded_rectangle (
+            ctx, 0.5, 0.5,
+            width - stroke_width,
+            height - stroke_width,
+            InternalUtils.scale_to_int (9, scaling_factor)
+        );
 
         ctx.set_source_rgba (
             background_color.red,
@@ -174,7 +182,7 @@ public class Gala.WindowSwitcher : CanvasActor {
         );
         ctx.fill_preserve ();
 
-        ctx.set_line_width (1);
+        ctx.set_line_width (stroke_width);
         ctx.set_source_rgba (
             border_color.red,
             border_color.green,
@@ -184,9 +192,15 @@ public class Gala.WindowSwitcher : CanvasActor {
         ctx.stroke ();
         ctx.restore ();
 
-        Drawing.Utilities.cairo_rounded_rectangle (ctx, 1.5, 1.5, width - 3, height - 3, InternalUtils.scale_to_int (8, scaling_factor));
+        // Offset by 0.5 so cairo draws a stroke on real pixels
+        Drawing.Utilities.cairo_rounded_rectangle (
+            ctx, stroke_width  + 0.5, stroke_width + 0.5,
+            width - stroke_width * 2 - 1,
+            height - stroke_width * 2 - 1,
+            InternalUtils.scale_to_int (8, scaling_factor)
+        );
 
-        ctx.set_line_width (1);
+        ctx.set_line_width (stroke_width);
         ctx.set_source_rgba (
             highlight_color.red,
             highlight_color.green,


### PR DESCRIPTION
We need to remove GTK style context for Wayland, but it's being used for both shadows and borders here. Draw our own border here so we can handle drawing our own shadow in a future branch without worrying about the border too

![Screenshot from 2024-05-27 13 52 44](https://github.com/elementary/gala/assets/7277719/c069a79a-f685-4215-b7cf-969bd415cacf)

Remove some dead css while we're here