### PR TITLE
DesktopIntegration: Switch to correct workspace when focusing window

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -105,7 +105,7 @@ public class Gala.DesktopIntegration : GLib.Object {
         foreach (unowned var app in apps) {
             foreach (weak Meta.Window window in app.get_windows ()) {
                 if (window.get_id () == uid) {
-                    window.activate (wm.get_display ().get_current_time ());
+                    window.get_workspace ().activate_with_focus (window, wm.get_display ().get_current_time ());
                 }
             }
         }


### PR DESCRIPTION
Fixes #1937 