### PR TITLE
Dialogs: Fix Mutter bindings around dialog creation

### DIFF
--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -130,8 +130,6 @@ namespace Gala {
             construct { parent = value; }
         }
 
-        public static Gee.Set<CloseDialog> open_dialogs = new Gee.HashSet<CloseDialog> ();
-
         // this function isn't exported in glib.vapi
         [CCode (cname = "g_locale_from_utf8")]
         extern static string locale_from_utf8 (
@@ -144,10 +142,6 @@ namespace Gala {
 
         public CloseDialog (Meta.Window window) {
             Object (window: window);
-        }
-
-        ~CloseDialog () {
-            open_dialogs.remove (this);
         }
 
         construct {
@@ -163,8 +157,6 @@ namespace Gala {
             body = _("You may choose to wait a short while for the application to continue, or force it to quit entirely.");
             accept_label = _("Force Quit");
             deny_label = _("Wait");
-
-            open_dialogs.add (this);
         }
 
         public override void show () {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2332,15 +2332,8 @@ namespace Gala {
             dialog.show ();
         }
 
-        public override unowned Meta.CloseDialog create_close_dialog (Meta.Window window) {
-            var new_dialog = CloseDialog.open_dialogs.first_match ((d) => d.window == window);
-
-            if (new_dialog == null) {
-                new_dialog = new CloseDialog (window);
-            }
-
-            unowned var dialog = new_dialog;
-            return dialog;
+        public override Meta.CloseDialog? create_close_dialog (Meta.Window window) {
+            return new CloseDialog (window);
         }
 
         public override unowned Meta.PluginInfo? plugin_info () {

--- a/vapi/Meta-14.metadata
+++ b/vapi/Meta-14.metadata
@@ -168,6 +168,9 @@ unsigned_long_hash.v type="ulong?"
 warning parent="Meta.Util" cheader_filename="meta/util.h"
 create_context parent="Meta.Context" name="new" symbol_type="constructor" cheader_filename="meta/meta-context.h"
 
+Plugin.create_close_dialog unowned=false nullable
+Plugin.create_inhibit_shortcuts_dialog unowned=false
+
 BackgroundActor sealed
 BackgroundContent sealed
 BackgroundImage sealed

--- a/vapi/libmutter.vapi
+++ b/vapi/libmutter.vapi
@@ -690,9 +690,9 @@ namespace Meta {
 		[NoWrapper]
 		public virtual void confirm_display_change ();
 		[NoWrapper]
-		public virtual unowned Meta.CloseDialog create_close_dialog (Meta.Window window);
+		public virtual Meta.CloseDialog? create_close_dialog (Meta.Window window);
 		[NoWrapper]
-		public virtual unowned Meta.InhibitShortcutsDialog create_inhibit_shortcuts_dialog (Meta.Window window);
+		public virtual Meta.InhibitShortcutsDialog create_inhibit_shortcuts_dialog (Meta.Window window);
 		[NoWrapper]
 		public virtual void destroy (Meta.WindowActor actor);
 		public void destroy_completed (Meta.WindowActor actor);

--- a/vapi/meson.build
+++ b/vapi/meson.build
@@ -328,6 +328,7 @@ if mutter46_dep.found()
 			'--pkg=gio-2.0',
 			'--pkg=cairo',
 			'--pkg=graphene-gobject-1.0',
+			'--pkg=x11',
 			vapigen_args,
 			files('Cogl-14-custom.vala')
 		],
@@ -345,6 +346,7 @@ if mutter46_dep.found()
 			'--pkg=pangocairo',
 			'--pkg=gio-2.0',
 			'--pkg=glib-2.0',
+			'--pkg=x11',
 			vapigen_args
 		],
 		depends: [mtk_target, cogl_target],
@@ -364,6 +366,7 @@ if mutter46_dep.found()
 			'--pkg=gio-2.0',
 			'--pkg=json-glib-1.0',
 			'--pkg=pangocairo',
+			'--pkg=x11',
 			vapigen_args,
 			files('Clutter-14-custom.vala')
 		],

--- a/vapi/mutter-cogl-14.deps
+++ b/vapi/mutter-cogl-14.deps
@@ -2,3 +2,4 @@ pango
 glib-2.0
 gio-2.0
 mutter-mtk-14
+x11


### PR DESCRIPTION
The dialog creation methods have to return a full reference.

Also we can assume that the dialog de-duplication work will already be done.