### PR TITLE
DragDropAction: Fix memory leak

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -26,7 +26,7 @@ namespace Gala {
 
     public class DragDropAction : Clutter.Action {
         // DO NOT keep a reference otherwise we get a ref cycle
-        private static Gee.HashMap<string, Gee.LinkedList<unowned Actor>>? sources = null;
+        private static Gee.HashMap<string,Gee.LinkedList<unowned Actor>>? sources = null;
         private static Gee.HashMap<string,Gee.LinkedList<unowned Actor>>? destinations = null;
 
         /**

--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -414,9 +414,7 @@ namespace Gala {
                 return;
 
             foreach (var actor in actors) {
-                warning ("FOREACH ACTOR");
                 foreach (var action in actor.get_actions ()) {
-                    warning ("FOREACH ACTION");
                     var drag_action = action as DragDropAction;
                     if (drag_action != null && drag_action.dragging) {
                         drag_action.cancel ();

--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -156,6 +156,8 @@ namespace Gala {
                 var dest_list = destinations[drag_id];
                 dest_list.remove (actor);
             }
+
+            actor.destroy.disconnect (release_actor);
         }
 
         private void connect_actor (Actor actor) {
@@ -179,6 +181,8 @@ namespace Gala {
 
                 dest_list.add (actor);
             }
+
+            actor.destroy.connect (release_actor);
         }
 
         private void emit_crossed (Actor destination, bool is_hovered) {
@@ -410,7 +414,9 @@ namespace Gala {
                 return;
 
             foreach (var actor in actors) {
+                warning ("FOREACH ACTOR");
                 foreach (var action in actor.get_actions ()) {
+                    warning ("FOREACH ACTION");
                     var drag_action = action as DragDropAction;
                     if (drag_action != null && drag_action.dragging) {
                         drag_action.cancel ();

--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -25,8 +25,9 @@ namespace Gala {
     }
 
     public class DragDropAction : Clutter.Action {
-        private static Gee.HashMap<string,Gee.LinkedList<Actor>>? sources = null;
-        private static Gee.HashMap<string,Gee.LinkedList<Actor>>? destinations = null;
+        // DO NOT keep a reference otherwise we get a ref cycle
+        private static Gee.HashMap<string, Gee.LinkedList<unowned Actor>>? sources = null;
+        private static Gee.HashMap<string,Gee.LinkedList<unowned Actor>>? destinations = null;
 
         /**
          * A drag has been started. You have to connect to this signal and
@@ -120,10 +121,10 @@ namespace Gala {
             Object (drag_type : type, drag_id : id);
 
             if (sources == null)
-                sources = new Gee.HashMap<string,Gee.LinkedList<Actor>> ();
+                sources = new Gee.HashMap<string,Gee.LinkedList<unowned Actor>> ();
 
             if (destinations == null)
-                destinations = new Gee.HashMap<string,Gee.LinkedList<Actor>> ();
+                destinations = new Gee.HashMap<string,Gee.LinkedList<unowned Actor>> ();
 
         }
 
@@ -162,7 +163,7 @@ namespace Gala {
 
                 var source_list = sources.@get (drag_id);
                 if (source_list == null) {
-                    source_list = new Gee.LinkedList<Actor> ();
+                    source_list = new Gee.LinkedList<unowned Actor> ();
                     sources.@set (drag_id, source_list);
                 }
 
@@ -172,7 +173,7 @@ namespace Gala {
             if (DragDropActionType.DESTINATION in drag_type) {
                 var dest_list = destinations[drag_id];
                 if (dest_list == null) {
-                    dest_list = new Gee.LinkedList<Actor> ();
+                    dest_list = new Gee.LinkedList<unowned Actor> ();
                     destinations[drag_id] = dest_list;
                 }
 


### PR DESCRIPTION
We've had a ref cycle here leading to pretty big memory consumption if many workspaces were opened and closed again, since all the backgrounds were kept around.