### PR TITLE
WindowSwitcher: set accessible properties

### DIFF
--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -69,6 +69,9 @@ public class Gala.WindowSwitcher : CanvasActor {
 #endif
         };
 
+        container.get_accessible ().set_name (_("Window switcher"));
+        get_accessible ().accessible_role = LIST;
+
         caption = new Clutter.Text () {
             font_name = CAPTION_FONT_NAME,
             ellipsize = END,
@@ -355,6 +358,7 @@ public class Gala.WindowSwitcher : CanvasActor {
 
     private void add_icon (WindowSwitcherIcon icon) {
         container.add_child (icon);
+        icon.get_accessible ().accessible_parent = container.get_accessible ();
 
         icon.motion_event.connect (() => {
             if (current_icon != icon && !handling_gesture) {

--- a/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcherIcon.vala
@@ -40,6 +40,9 @@ public class Gala.WindowSwitcherIcon : CanvasActor {
         icon.add_constraint (new Clutter.AlignConstraint (this, Clutter.AlignAxis.BOTH, 0.5f));
         add_child (icon);
 
+        get_accessible ().accessible_name = window.title;
+        get_accessible ().accessible_role = LIST_ITEM;
+
         reactive = true;
 
         this.scale_factor = scale_factor;
@@ -76,5 +79,7 @@ public class Gala.WindowSwitcherIcon : CanvasActor {
 
             ctx.restore ();
         }
+
+        get_accessible ().notify_state_change (Atk.StateType.SELECTED, selected);
     }
 }


### PR DESCRIPTION
Fixes #1301 

Not familiar enough with Clutter to know why this isn't working, but theoretically should add accessible labels, role, and state