### PR TITLE
Canvas: discard bitmap on invalidate

### DIFF
--- a/lib/Drawing/Canvas.vala
+++ b/lib/Drawing/Canvas.vala
@@ -69,7 +69,9 @@ public class Gala.Drawing.Canvas : GLib.Object, Clutter.Content {
     }
 
     public void invalidate () {
-        if (width <= 0 || height <= 0) {
+    bitmap = null;
+
+    if (width <= 0 || height <= 0) {
             return;
         }
 


### PR DESCRIPTION
Currently the bitmap isn't being cleared and the old content is showing even after invalidate is called.

Fixes https://github.com/elementary/gala/issues/1934