### PR TITLE
Dialogs: Use the provided object in finish

### DIFF
--- a/src/Dialogs.vala
+++ b/src/Dialogs.vala
@@ -99,7 +99,7 @@ namespace Gala {
                 uint ret;
 
                 try {
-                    portal.access_dialog.end (res, out ret);
+                    ((AccessPortal) obj).access_dialog.end (res, out ret);
                 } catch (Error e) {
                     warning (e.message);
                     ret = 2;


### PR DESCRIPTION
Allows to make sure that the object will be the same as the one the function started and will actually not be null.