### PR TITLE
wayland: Add make_modal protocol method

### DIFF
--- a/protocol/pantheon-desktop-shell-v1.xml
+++ b/protocol/pantheon-desktop-shell-v1.xml
@@ -115,6 +115,8 @@
       <description summary="requests to make a surface system modal">
         This will block all user input outside the surface and most system shortcuts.
       </description>
+
+      <arg name="dim" type="uint" summary="1 to dim, 0 to not dim"/>
     </request>
   </interface>
 </protocol>

--- a/protocol/pantheon-desktop-shell-v1.xml
+++ b/protocol/pantheon-desktop-shell-v1.xml
@@ -111,5 +111,10 @@
         Tell the shell to keep the surface above on all workspaces
       </description>
     </request>
+    <request name="make_modal">
+      <description summary="requests to make a surface system modal">
+        This will block all user input outside the surface and most system shortcuts.
+      </description>
+    </request>
   </interface>
 </protocol>

--- a/protocol/pantheon-desktop-shell.vapi
+++ b/protocol/pantheon-desktop-shell.vapi
@@ -56,6 +56,7 @@ namespace Pantheon.Desktop {
         public static Wl.Interface iface;
         public Destroy destroy;
         public SetKeepAbove set_keep_above;
+        public MakeModal make_modal;
     }
 
     [CCode (has_target = false, has_typedef = false)]
@@ -74,6 +75,8 @@ namespace Pantheon.Desktop {
     public delegate void SetHideMode (Wl.Client client, Wl.Resource resource, [CCode (type = "uint32_t")] HideMode hide_mode);
     [CCode (has_target = false, has_typedef = false)]
     public delegate void SetKeepAbove (Wl.Client client, Wl.Resource resource);
+    [CCode (has_target = false, has_typedef = false)]
+    public delegate void MakeModal (Wl.Client client, Wl.Resource resource);
     [CCode (has_target = false, has_typedef = false)]
     public delegate void Destroy (Wl.Client client, Wl.Resource resource);
 }

--- a/protocol/pantheon-desktop-shell.vapi
+++ b/protocol/pantheon-desktop-shell.vapi
@@ -76,7 +76,7 @@ namespace Pantheon.Desktop {
     [CCode (has_target = false, has_typedef = false)]
     public delegate void SetKeepAbove (Wl.Client client, Wl.Resource resource);
     [CCode (has_target = false, has_typedef = false)]
-    public delegate void MakeModal (Wl.Client client, Wl.Resource resource);
+    public delegate void MakeModal (Wl.Client client, Wl.Resource resource, uint dim);
     [CCode (has_target = false, has_typedef = false)]
     public delegate void Destroy (Wl.Client client, Wl.Resource resource);
 }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -336,5 +336,15 @@ namespace Gala {
                 return { 0, 0, (int) screen_width, (int) screen_height };
             }
         }
+
+        public static void clutter_actor_reparent (Clutter.Actor actor, Clutter.Actor new_parent) {
+            if (actor == new_parent)
+                return;
+
+            actor.ref ();
+            actor.get_parent ().remove_child (actor);
+            new_parent.add_child (actor);
+            actor.unref ();
+        }
     }
 }

--- a/src/PantheonShell.vala
+++ b/src/PantheonShell.vala
@@ -328,7 +328,7 @@ namespace Gala {
         window.make_above ();
     }
 
-    internal static void make_modal (Wl.Client client, Wl.Resource resource) {
+    internal static void make_modal (Wl.Client client, Wl.Resource resource, uint dim) {
         unowned ExtendedBehaviorSurface? eb_surface = resource.get_user_data<ExtendedBehaviorSurface> ();
         if (eb_surface.wayland_surface == null) {
             warning ("Window tried to make modal but wayland surface is null.");
@@ -342,7 +342,7 @@ namespace Gala {
             return;
         }
 
-        ShellClientsManager.get_instance ().make_modal (window);
+        ShellClientsManager.get_instance ().make_modal (window, dim == 1);
     }
 
     internal static void destroy_panel_surface (Wl.Client client, Wl.Resource resource) {

--- a/src/PantheonShell.vala
+++ b/src/PantheonShell.vala
@@ -67,9 +67,11 @@ namespace Gala {
         wayland_pantheon_extended_behavior_interface = {
             destroy_extended_behavior_surface,
             set_keep_above,
+            make_modal,
         };
 
         PanelSurface.quark = GLib.Quark.from_string ("-gala-wayland-panel-surface-data");
+        ExtendedBehaviorSurface.quark = GLib.Quark.from_string ("-gala-wayland-extended-behavior-surface-data");
 
         shell_global = Wl.Global.create (wl_disp, ref Pantheon.Desktop.ShellInterface.iface, 1, (client, version, id) => {
             unowned var resource = client.create_resource (ref Pantheon.Desktop.ShellInterface.iface, (int) version, id);
@@ -324,6 +326,23 @@ namespace Gala {
         }
 
         window.make_above ();
+    }
+
+    internal static void make_modal (Wl.Client client, Wl.Resource resource) {
+        unowned ExtendedBehaviorSurface? eb_surface = resource.get_user_data<ExtendedBehaviorSurface> ();
+        if (eb_surface.wayland_surface == null) {
+            warning ("Window tried to make modal but wayland surface is null.");
+            return;
+        }
+
+        Meta.Window? window;
+        eb_surface.wayland_surface.get ("window", out window, null);
+        if (window == null) {
+            warning ("Window tried to make modal but wayland surface had no associated window.");
+            return;
+        }
+
+        ShellClientsManager.get_instance ().make_modal (window);
     }
 
     internal static void destroy_panel_surface (Wl.Client client, Wl.Resource resource) {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -8,7 +8,7 @@
 public class Gala.ShellClientsManager : Object {
     private static ShellClientsManager instance;
 
-    public static void init (WindowManager wm) {
+    public static void init (WindowManagerGala wm) {
         if (instance != null) {
             return;
         }
@@ -20,14 +20,14 @@ public class Gala.ShellClientsManager : Object {
         return instance;
     }
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
 
     private NotificationsClient notifications_client;
     private ManagedClient[] protocol_clients = {};
 
     private GLib.HashTable<Meta.Window, PanelWindow> windows = new GLib.HashTable<Meta.Window, PanelWindow> (null, null);
 
-    private ShellClientsManager (WindowManager wm) {
+    private ShellClientsManager (WindowManagerGala wm) {
         Object (wm: wm);
     }
 
@@ -142,5 +142,9 @@ public class Gala.ShellClientsManager : Object {
         }
 
         windows[window].set_hide_mode (hide_mode);
+    }
+
+    public void make_modal (Meta.Window window) {
+        wm.modal_actor.make_modal (window);
     }
 }

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -144,7 +144,8 @@ public class Gala.ShellClientsManager : Object {
         windows[window].set_hide_mode (hide_mode);
     }
 
-    public void make_modal (Meta.Window window) {
+    public void make_modal (Meta.Window window, bool dim) {
         wm.modal_actor.make_modal (window);
+        wm.modal_actor.dim = dim;
     }
 }

--- a/src/Widgets/ModalActor.vala
+++ b/src/Widgets/ModalActor.vala
@@ -14,6 +14,16 @@
  public class Gala.ModalActor : Clutter.Actor {
     public Meta.Display display { get; construct; }
 
+    public bool dim {
+        set {
+            if (value) {
+                background_color = { 0, 0, 0, 200 };
+            } else {
+                background_color = { 0, 0, 0, 0 };
+            }
+        }
+    }
+
     private int modal_dialogs = 0;
 
     public ModalActor (Meta.Display display) {
@@ -59,6 +69,10 @@
 
     private void check_visible () {
         visible = modal_dialogs > 0;
+
+        if (visible) {
+            get_parent ().set_child_above_sibling (this, null);
+        }
     }
 
     public bool is_modal () {

--- a/src/Widgets/ModalActor.vala
+++ b/src/Widgets/ModalActor.vala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+/**
+ * This class allows to make windows system modal i.e. dim
+ * the desktop behind them and only allow interaction with them.
+ * Not to be confused with WindowManager.push_modal which only
+ * works for our own Clutter.Actors.
+ */
+ public class Gala.ModalActor : Clutter.Actor {
+    public Meta.Display display { get; construct; }
+
+    private int modal_dialogs = 0;
+
+    public ModalActor (Meta.Display display) {
+        Object (display: display);
+    }
+
+    construct {
+        background_color = { 0, 0, 0, 200 };
+        x = 0;
+        y = 0;
+        visible = false;
+        reactive = true;
+
+        unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+        monitor_manager.monitors_changed.connect (update_size);
+
+        update_size ();
+    }
+
+    private void update_size () {
+        int width, height;
+        display.get_size (out width, out height);
+
+        set_size (width, height);
+    }
+
+    public void make_modal (Meta.Window window) {
+        modal_dialogs++;
+        window.unmanaged.connect (unmake_modal);
+
+        var actor = (Meta.WindowActor) window.get_compositor_private ();
+        InternalUtils.clutter_actor_reparent (actor, this);
+
+        check_visible ();
+    }
+
+    public void unmake_modal (Meta.Window window) {
+        modal_dialogs--;
+        window.unmanaged.disconnect (unmake_modal);
+
+        check_visible ();
+    }
+
+    private void check_visible () {
+        visible = modal_dialogs > 0;
+    }
+
+    public bool is_modal () {
+        return modal_dialogs > 0;
+    }
+}

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -49,6 +49,8 @@ namespace Gala {
          */
          public Gala.ActivatableComponent workspace_view { get; protected set; }
 
+        public ModalActor modal_actor { get; private set; }
+
         /**
          * {@inheritDoc}
          */
@@ -240,6 +242,9 @@ namespace Gala {
 #endif
             stage.remove_child (feedback_group);
             ui_group.add_child (feedback_group);
+
+            modal_actor = new ModalActor (display);
+            ui_group.insert_child_above (modal_actor, null);
 
             FilterManager.init (this);
 
@@ -2293,6 +2298,10 @@ namespace Gala {
         }
 
         public override bool keybinding_filter (Meta.KeyBinding binding) {
+            if (modal_actor.is_modal ()) {
+                return true;
+            }
+
             if (!is_modal ())
                 return false;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,6 +49,7 @@ gala_bin_sources = files(
     'Widgets/DwellClickTimer.vala',
     'Widgets/IconGroup.vala',
     'Widgets/IconGroupContainer.vala',
+    'Widgets/ModalActor.vala',
     'Widgets/MonitorClone.vala',
     'Widgets/MultitaskingView.vala',
     'Widgets/PixelPicker.vala',


### PR DESCRIPTION
Takes a bunch of stuff from #1879 and makes it a wayland protocol method. 

This will open up a bunch of useful possibilities like making end session, polkit, etc. dialogs modal with a dimmed background or like using GTK for the window switcher in an external process (that's also why dimming is optional).