### PR TITLE
WindowCloneContainer: Don't hold an extra reference to WindowClone

### DIFF
--- a/src/Widgets/WindowCloneContainer.vala
+++ b/src/Widgets/WindowCloneContainer.vala
@@ -51,7 +51,7 @@ namespace Gala {
          * The window that is currently selected via keyboard shortcuts. It is not
          * necessarily the same as the active window.
          */
-        private WindowClone? current_window = null;
+        private unowned WindowClone? current_window = null;
 
         public WindowCloneContainer (WindowManager wm, GestureTracker? gesture_tracker, float scale, bool overview_mode = false) {
             Object (wm: wm, gesture_tracker: gesture_tracker, monitor_scale: scale, overview_mode: overview_mode);


### PR DESCRIPTION
Fixes the issue when if you close window in the multitasking view (using the close button and without dragging it first) WindowClone will be freed only after reopening multitasking view. It's not a memory leak but still would be better to free objects early.