### PR TITLE
DragDropAction: Release hovered reference when finishing the action

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -86,7 +86,7 @@ namespace Gala {
          */
         public string drag_id { get; construct; }
 
-        public Actor handle { get; private set; }
+        public Actor? handle { get; private set; }
         /**
          * Indicates whether a drag action is currently active
          */
@@ -241,6 +241,7 @@ namespace Gala {
                     } else if (dragging) {
                         if (hovered != null) {
                             finish ();
+                            hovered = null;
                         } else {
                             cancel ();
                         }
@@ -460,6 +461,7 @@ namespace Gala {
             }
 
             dragging = false;
+            handle = null;
         }
 
         private bool is_valid_touch_event (Clutter.Event event) {


### PR DESCRIPTION
Make sure that we are not holding a reference to the object after handling the dnd action.