### PR TITLE
WindowClone: Allow force kill with control modifier

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -74,7 +74,7 @@ namespace Gala {
          *
          * @param button The button which was pressed
          */
-        public signal void actor_clicked (uint32 button);
+        public signal void actor_clicked (uint32 button, bool control_modifier);
 
         /**
          * The type of the action
@@ -229,7 +229,7 @@ namespace Gala {
 
                         // release has happened within bounds of actor
                         if (clicked && x < ex && x + actor.width > ex && y < ey && y + actor.height > ey) {
-                            actor_clicked (event.get_button ());
+                            actor_clicked (event.get_button (), event.has_control_modifier ());
                         }
 
                         if (clicked) {

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -117,7 +117,7 @@ public class Gala.WindowClone : Clutter.Actor {
         if (overview_mode) {
             var click_action = new Clutter.ClickAction ();
             click_action.clicked.connect ((action, actor) => {
-                actor_clicked (action.get_button ());
+                actor_clicked (action.get_button (), CONTROL_MASK in action.get_state ());
             });
 
             add_action (click_action);
@@ -612,13 +612,17 @@ public class Gala.WindowClone : Clutter.Actor {
         destroy ();
     }
 
-    private void actor_clicked (uint32 button) {
+    private void actor_clicked (uint32 button, bool control_modifier) {
         switch (button) {
             case Clutter.Button.PRIMARY:
                 selected ();
                 break;
             case Clutter.Button.MIDDLE:
-                close_window (wm.get_display ().get_current_time ());
+                if (control_modifier) {
+                    window.kill ();
+                } else {
+                    close_window (wm.get_display ().get_current_time ());
+                }
                 break;
         }
     }


### PR DESCRIPTION
Allows to force kill an app corresponding to a window if middle clicked in the overview while the control key is held down, which would be pretty cool to have IMHO :)

I know there's is the not responding dialog but sometimes that takes a while to pop up or it doesn't because you want to kill something that is in theory responding (e.g. things with a daemon like appcenter), so this is much more convenient.

It's not a lot of effort to support and although this is probably only useful for more technical users and also pretty hidden, I still think it could be pretty cool :sweat_smile: 