### PR TITLE
Implement PantheonShellX11 protocol

### DIFF
--- a/data/io.elementary.desktop.wm.shell
+++ b/data/io.elementary.desktop.wm.shell
@@ -1,11 +1,14 @@
 [io.elementary.wingpanel]
 launch-on-x=true
 args=io.elementary.wingpanel
+supports-id=false
 
 [io.elementary.desktop.agent-polkit]
 launch-on-x=true
 args=/usr/libexec/policykit-1-pantheon/io.elementary.desktop.agent-polkit
+supports-id=false
 
 [io.elementary.dock]
-launch-on-x=false
+launch-on-x=true
 args=io.elementary.dock
+supports-id=true

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: beat-box\n"
 "Report-Msgid-Bugs-To: https://github.com/elementary/gala/issues\n"
 "POT-Creation-Date: 2024-07-18 17:28+0000\n"
-"PO-Revision-Date: 2024-07-10 16:16+0000\n"
+"PO-Revision-Date: 2024-07-21 06:16+0000\n"
 "Last-Translator: Ihor Hordiichuk <igor_ck@outlook.com>\n"
 "Language-Team: Ukrainian <https://l10n.elementary.io/projects/desktop/gala/"
 "uk/>\n"
@@ -116,18 +116,14 @@ msgid "Improvements:"
 msgstr "Удосконалення:"
 
 #: data/gala.metainfo.xml.in:34
-#, fuzzy
-#| msgid "Fix screenshot keyboard shortcuts while in Multitasking View"
 msgid "Improve keyboard navigation in Multitasking View"
 msgstr ""
-"Виправлено комбінації клавіш під час створення знімків екрана у "
-"багатозадачному режимі"
+"Удосконалено навігацію за допомогою комбінацій клавіш у багатозадачному "
+"режимі"
 
 #: data/gala.metainfo.xml.in:35
-#, fuzzy
-#| msgid "Update panel color after dimming the wallpaper"
 msgid "Change panel color at the same time as wallpaper transition"
-msgstr "Оновлення кольору панелі після затемнення шпалер"
+msgstr "Зміна кольору панелі одночасно зі зміною шпалер"
 
 #: data/gala.metainfo.xml.in:36 data/gala.metainfo.xml.in:73
 #: data/gala.metainfo.xml.in:95 data/gala.metainfo.xml.in:110

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -345,15 +345,15 @@ namespace Gala {
             switch (anchor) {
                 case TOP:
                     break;
-    
+
                 case BOTTOM:
                     side = BOTTOM;
                     break;
-    
+
                 case LEFT:
                     side = LEFT;
                     break;
-    
+
                 case RIGHT:
                     side = RIGHT;
                     break;

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -336,5 +336,30 @@ namespace Gala {
                 return { 0, 0, (int) screen_width, (int) screen_height };
             }
         }
+
+        /**
+         * Returns Meta.Side that correspondes to Pantheon.Desktop.Anchor.
+         */
+        public static Meta.Side anchor_to_side (Pantheon.Desktop.Anchor anchor) {
+            Meta.Side side = TOP;
+            switch (anchor) {
+                case TOP:
+                    break;
+    
+                case BOTTOM:
+                    side = BOTTOM;
+                    break;
+    
+                case LEFT:
+                    side = LEFT;
+                    break;
+    
+                case RIGHT:
+                    side = RIGHT;
+                    break;
+            }
+
+            return side;
+        }
     }
 }

--- a/src/PantheonShell.vala
+++ b/src/PantheonShell.vala
@@ -243,25 +243,7 @@ namespace Gala {
             return;
         }
 
-        Meta.Side side = TOP;
-        switch (anchor) {
-            case TOP:
-                break;
-
-            case BOTTOM:
-                side = BOTTOM;
-                break;
-
-            case LEFT:
-                side = LEFT;
-                break;
-
-            case RIGHT:
-                side = RIGHT;
-                break;
-        }
-
-        ShellClientsManager.get_instance ().set_anchor (window, side);
+        ShellClientsManager.get_instance ().set_anchor (window, InternalUtils.anchor_to_side (anchor));
     }
 
     internal static void focus_panel (Wl.Client client, Wl.Resource resource) {

--- a/src/PantheonShellX11.vala
+++ b/src/PantheonShellX11.vala
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
+ */
+
+[DBus (name = "io.elementary.gala.PantheonShellX11")]
+public class Gala.PantheonShellX11 : GLib.Object {
+    private static PantheonShellX11 instance;
+    private static Meta.Display display;
+
+    [DBus (visible = false)]
+    public static void init (Meta.Display display) {
+        PantheonShellX11.display = display;
+
+        Bus.own_name (
+            BusType.SESSION,
+            "io.elementary.gala.PantheonShellX11",
+            BusNameOwnerFlags.NONE,
+            (connection) => {
+                if (instance == null) {
+                    instance = new PantheonShellX11 ();
+                }
+
+                try {
+                    connection.register_object ("/io/elementary/gala/PantheonShellX11", instance);
+                } catch (Error e) {
+                    warning (e.message);
+                }
+            },
+            () => {},
+            () => warning ("Could not acquire name")
+        );
+    }
+
+    public void set_anchor (string id, Pantheon.Desktop.Anchor anchor) throws GLib.Error {
+        foreach (unowned var window in display.list_all_windows ()) {
+            if (window.title == id) {
+                ShellClientsManager.get_instance ().set_anchor (window, InternalUtils.anchor_to_side (anchor));
+            }
+        }
+    }
+
+    public void set_size (string id, int width, int height) throws GLib.Error {
+        foreach (unowned var window in display.list_all_windows ()) {
+            if (window.title == id) {
+                ShellClientsManager.get_instance ().set_size (window, width, height);
+            }
+        }
+    }
+
+    public void set_hide_mode (string id, Pantheon.Desktop.HideMode hide_mode) throws GLib.Error {
+        foreach (unowned var window in display.list_all_windows ()) {
+            if (window.title == id) {
+                ShellClientsManager.get_instance ().set_hide_mode (window, hide_mode);
+            }
+        }
+    }
+
+    public void make_centered (string id) throws GLib.Error {
+        foreach (unowned var window in display.list_all_windows ()) {
+            if (window.title == id) {
+                ShellClientsManager.get_instance ().make_centered (window);
+            }
+        }
+    }
+}

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -78,7 +78,9 @@ public class Gala.ManagedClient : Object {
         }
     }
 
-    private void make_dock_x11 (Meta.Window window) requires (!Meta.Util.is_wayland_compositor ()) {
+    private void make_dock_x11 (Meta.Window window) requires (
+        !Meta.Util.is_wayland_compositor () && supports_id && window.title == id
+    ) {
         unowned var x11_display = display.get_x11_display ();
 
 #if HAS_MUTTER46

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -18,7 +18,7 @@ public class Gala.ManagedClient : Object {
     public bool supports_id { get; construct; }
 
     public Meta.WaylandClient? wayland_client { get; private set; }
-    
+
     private Subprocess? subprocess;
     // id is used to identify X11 client
     private string? id;

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -20,6 +20,7 @@ public class Gala.ManagedClient : Object {
     public Meta.WaylandClient? wayland_client { get; private set; }
 
     private Subprocess? subprocess;
+    // id is used to identify X11 client
     private string? id;
 
     public ManagedClient (Meta.Display display, string[] args, bool supports_id) {

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -143,8 +143,6 @@ public class Gala.ManagedClient : Object {
                 _args += id;
             }
 
-            debug ("Launching client with id: %s", id);
-
             subprocess = new Subprocess.newv (_args, NONE);
             yield subprocess.wait_async ();
 

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -19,7 +19,7 @@ public class Gala.ManagedClient : Object {
 
     private Meta.WaylandClient? wayland_client;
     private Subprocess? subprocess;
-    // id is used to identify X11 client
+    // id is used to identify X11 clients
     private string? id;
 
     // currently used to avoid overlapping

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -23,7 +23,7 @@ public class Gala.ManagedClient : Object {
     // id is used to identify X11 client
     private string? id;
 
-    // currently used to avoid overlaping
+    // currently used to avoid overlapping
     private static Gee.HashSet<string> ids;
 
     public ManagedClient (Meta.Display display, string[] args, bool supports_id) {

--- a/src/ShellClients/NotificationsClient.vala
+++ b/src/ShellClients/NotificationsClient.vala
@@ -21,7 +21,7 @@ public class Gala.NotificationsClient : Object {
             window.set_data (NOTIFICATION_DATA_KEY, true);
             window.make_above ();
 #if HAS_MUTTER46
-            client.wayland_client.make_dock (window);
+            client.make_dock (window);
 #endif
         });
     }

--- a/src/ShellClients/NotificationsClient.vala
+++ b/src/ShellClients/NotificationsClient.vala
@@ -16,7 +16,7 @@ public class Gala.NotificationsClient : Object {
 
     construct {
         client = new ManagedClient (display, { "io.elementary.notifications" }, false);
-        
+
         client.window_created.connect ((window) => {
             window.set_data (NOTIFICATION_DATA_KEY, true);
             window.make_above ();

--- a/src/ShellClients/NotificationsClient.vala
+++ b/src/ShellClients/NotificationsClient.vala
@@ -15,8 +15,8 @@ public class Gala.NotificationsClient : Object {
     }
 
     construct {
-        client = new ManagedClient (display, { "io.elementary.notifications" });
-
+        client = new ManagedClient (display, { "io.elementary.notifications" }, false);
+        
         client.window_created.connect ((window) => {
             window.set_data (NOTIFICATION_DATA_KEY, true);
             window.make_above ();

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -100,40 +100,12 @@ public class Gala.ShellClientsManager : Object {
     }
 
     private void make_dock (Meta.Window window) {
-        if (Meta.Util.is_wayland_compositor ()) {
-            make_dock_wayland (window);
-        } else {
-            make_dock_x11 (window);
-        }
-    }
-
-    private void make_dock_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
         foreach (var client in protocol_clients) {
-            if (client.wayland_client.owns_window (window)) {
-                client.wayland_client.make_dock (window);
+            if (client.owns_window (window)) {
+                client.make_dock (window);
                 break;
             }
         }
-    }
-
-    private void make_dock_x11 (Meta.Window window) requires (!Meta.Util.is_wayland_compositor ()) {
-        unowned var display = wm.get_display ();
-        unowned var x11_display = display.get_x11_display ();
-
-#if HAS_MUTTER46
-        var x_window = x11_display.lookup_xwindow (window);
-#else
-        var x_window = window.get_xwindow ();
-#endif
-        // gtk3's gdk_x11_window_set_type_hint() is used as a reference
-        unowned var xdisplay = x11_display.get_xdisplay ();
-        var atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE", false);
-        var dock_atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE_DOCK", false);
-
-        // (X.Atom) 4 is XA_ATOM
-        // 32 is format
-        // 0 means replace
-        xdisplay.change_property (x_window, atom, (X.Atom) 4, 32, 0, (uchar[]) dock_atom, 1);
     }
 
     public void set_anchor (Meta.Window window, Meta.Side side) {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -91,7 +91,8 @@ public class Gala.ShellClientsManager : Object {
 
             try {
                 var args = key_file.get_string_list (group, "args");
-                protocol_clients += new ManagedClient (wm.get_display (), args);
+                var supports_id = key_file.get_boolean (group, "supports-id");
+                protocol_clients += new ManagedClient (wm.get_display (), args, supports_id);
             } catch (Error e) {
                 warning ("Failed to load launch args for client %s: %s", group, e.message);
             }
@@ -99,12 +100,40 @@ public class Gala.ShellClientsManager : Object {
     }
 
     private void make_dock (Meta.Window window) {
+        if (Meta.Util.is_wayland_compositor ()) {
+            make_dock_wayland (window);
+        } else {
+            make_dock_x11 (window);
+        }
+    }
+
+    private void make_dock_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
         foreach (var client in protocol_clients) {
             if (client.wayland_client.owns_window (window)) {
                 client.wayland_client.make_dock (window);
                 break;
             }
         }
+    }
+
+    private void make_dock_x11 (Meta.Window window) requires (!Meta.Util.is_wayland_compositor ()) {
+        unowned var display = wm.get_display ();
+        unowned var x11_display = display.get_x11_display ();
+
+#if HAS_MUTTER46
+        var x_window = x11_display.lookup_xwindow (window);
+#else
+        var x_window = window.get_xwindow ();
+#endif
+        // gtk3's gdk_x11_window_set_type_hint() is used as a reference
+        unowned var xdisplay = x11_display.get_xdisplay ();
+        var atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE", false);
+        var FORMAT = 32;
+        var PROP_MODE_REPLACE = 0;
+        var dock_atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE_DOCK", false);
+
+        // (X.Atom) 4 is XA_ATOM
+        xdisplay.change_property (x_window, atom, (X.Atom) 4, FORMAT, PROP_MODE_REPLACE, (uchar[]) dock_atom, 1);
     }
 
     public void set_anchor (Meta.Window window, Meta.Side side) {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -128,12 +128,12 @@ public class Gala.ShellClientsManager : Object {
         // gtk3's gdk_x11_window_set_type_hint() is used as a reference
         unowned var xdisplay = x11_display.get_xdisplay ();
         var atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE", false);
-        var FORMAT = 32;
-        var PROP_MODE_REPLACE = 0;
         var dock_atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE_DOCK", false);
 
         // (X.Atom) 4 is XA_ATOM
-        xdisplay.change_property (x_window, atom, (X.Atom) 4, FORMAT, PROP_MODE_REPLACE, (uchar[]) dock_atom, 1);
+        // 32 is format
+        // 0 means replace
+        xdisplay.change_property (x_window, atom, (X.Atom) 4, 32, 0, (uchar[]) dock_atom, 1);
     }
 
     public void set_anchor (Meta.Window window, Meta.Side side) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -167,6 +167,10 @@ namespace Gala {
             DBusAccelerator.init (this);
             MediaFeedback.init ();
 
+            if (!Meta.Util.is_wayland_compositor ()) {
+                PantheonShellX11.init (display);
+            }
+
             WindowListener.init (display);
             KeyboardManager.init (display);
             window_tracker = new WindowTracker ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,7 @@ gala_bin_sources = files(
     'MediaFeedback.vala',
     'NotificationStack.vala',
     'PantheonShell.vala',
+    'PantheonShellX11.vala',
     'PluginManager.vala',
     'ScreenSaverManager.vala',
     'ScreenshotManager.vala',


### PR DESCRIPTION
Closes #1965 

Makes Gtk4 Dock (and other Gtk4 ports in the future) usable in X11 session.

This is achieved using 3 "hacks":

1. Adds `supports-id` as an attribute in shell list. If it's true, then window is launched with a unique id by passing it as `--id <id here>`. Then Gala can identify new windows by checking the window titles.
2. Implements `PantheonShellX11` protocol for positioning windows on X11. It requires an id from the first step. Other than that it's a simplified copy of our Wayland protocol.
3. Since mutter can't change window_type on X11, Gala does it manually via `X.Display`.

You can use https://github.com/elementary/dock/pull/260 to test it with the dock.

Unblocks https://github.com/elementary/notifications/pull/157