### PR TITLE
Sort windows by stacking order before workspace switch

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2056,7 +2056,6 @@ namespace Gala {
                 }
             }
 
-
             main_container.clip_to_allocation = true;
             main_container.x = move_primary_only ? monitor_geom.x : 0.0f;
             main_container.y = move_primary_only ? monitor_geom.y : 0.0f;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1990,12 +1990,16 @@ namespace Gala {
             var from_has_fullscreened = false;
 
             // collect all windows and put them in the appropriate containers
-            foreach (unowned Meta.WindowActor actor in display.get_window_actors ()) {
+            var slist = new GLib.SList<Meta.Window> ();
+            display.list_all_windows ().@foreach ((win) => {
+                slist.append (win);
+            });
+            foreach (unowned var window in display.sort_windows_by_stacking (slist)) {
+                unowned var actor = (Meta.WindowActor) window.get_compositor_private ();
+
                 if (actor.is_destroyed ()) {
                     continue;
                 }
-
-                unowned var window = actor.get_meta_window ();
 
                 if (!window.showing_on_its_workspace () ||
                     move_primary_only && !window.is_on_primary_monitor () ||
@@ -2051,6 +2055,7 @@ namespace Gala {
 
                 }
             }
+
 
             main_container.clip_to_allocation = true;
             main_container.x = move_primary_only ? monitor_geom.x : 0.0f;


### PR DESCRIPTION
Fixes an issue when maximized windows could've had an incorrect stacking order on workspace switch