### PR TITLE
ShellClients: Fix crash when positioning window while unmanaging

### DIFF
--- a/src/ShellClients/CenteredWindow.vala
+++ b/src/ShellClients/CenteredWindow.vala
@@ -9,6 +9,8 @@ public class Gala.CenteredWindow : Object {
     public WindowManager wm { get; construct; }
     public Meta.Window window { get; construct; }
 
+    private uint idle_move_id = 0;
+
     public CenteredWindow (WindowManager wm, Meta.Window window) {
         Object (wm: wm, window: window);
     }
@@ -23,6 +25,8 @@ public class Gala.CenteredWindow : Object {
         position_window ();
 
         window.shown.connect (() => window.focus (wm.get_display ().get_current_time ()));
+
+        window.unmanaging.connect (() => Source.remove (idle_move_id));
     }
 
     private void position_window () {
@@ -33,8 +37,15 @@ public class Gala.CenteredWindow : Object {
         var x = monitor_geom.x + (monitor_geom.width - window_rect.width) / 2;
         var y = monitor_geom.y + (monitor_geom.height - window_rect.height) / 2;
 
-        Idle.add (() => {
+
+        if (idle_move_id != 0) {
+            Source.remove (idle_move_id);
+        }
+
+        idle_move_id = Idle.add (() => {
             window.move_frame (false, x, y);
+
+            idle_move_id = 0;
             return Source.REMOVE;
         });
     }

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -37,7 +37,9 @@ public class Gala.PanelWindow : Object {
     construct {
         window.size_changed.connect (position_window);
 
-        window.unmanaged.connect (() => {
+        window.unmanaging.connect (() => {
+            Source.remove (idle_move_id);
+
             destroy_barrier ();
 
             if (window_struts.remove (window)) {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -153,7 +153,7 @@ public class Gala.ShellClientsManager : Object {
         windows[window] = new PanelWindow (wm, window, side);
 
         // connect_after so we make sure the PanelWindow can destroy its barriers and struts
-        window.unmanaged.connect_after (() => windows.remove (window));
+        window.unmanaging.connect_after (() => windows.remove (window));
     }
 
     /**
@@ -187,6 +187,8 @@ public class Gala.ShellClientsManager : Object {
         }
 
         centered_windows[window] = new CenteredWindow (wm, window);
+
+        window.unmanaging.connect_after (() => centered_windows.remove (window));
     }
 
     public bool is_positioned_window (Meta.Window window) {


### PR DESCRIPTION
Should hopefully fix #1961 for real this time

Also fixes a memory leak where we were keeping centeredwindows around even after they were unmanaged