### PR TITLE
ShellClients: Fix memory leak and crash

### DIFF
--- a/src/ShellClients/CenteredWindow.vala
+++ b/src/ShellClients/CenteredWindow.vala
@@ -26,7 +26,11 @@ public class Gala.CenteredWindow : Object {
 
         window.shown.connect (() => window.focus (wm.get_display ().get_current_time ()));
 
-        window.unmanaging.connect (() => Source.remove (idle_move_id));
+        window.unmanaging.connect (() => {
+            if (idle_move_id != 0) {
+                Source.remove (idle_move_id);
+            }
+        });
     }
 
     private void position_window () {
@@ -36,7 +40,6 @@ public class Gala.CenteredWindow : Object {
 
         var x = monitor_geom.x + (monitor_geom.width - window_rect.width) / 2;
         var y = monitor_geom.y + (monitor_geom.height - window_rect.height) / 2;
-
 
         if (idle_move_id != 0) {
             Source.remove (idle_move_id);

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -12,7 +12,7 @@ public class Gala.HideTracker : Object {
     public signal void show ();
 
     public Meta.Display display { get; construct; }
-    public PanelWindow panel { get; construct; }
+    public unowned PanelWindow panel { get; construct; }
     public Pantheon.Desktop.HideMode hide_mode { get; set; default = NEVER; }
 
     private bool hovered = false;

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -9,7 +9,7 @@ public class Gala.PanelClone : Object {
     private const int ANIMATION_DURATION = 250;
 
     public WindowManager wm { get; construct; }
-    public PanelWindow panel { get; construct; }
+    public unowned PanelWindow panel { get; construct; }
 
     public Pantheon.Desktop.HideMode hide_mode {
         get {

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -38,7 +38,9 @@ public class Gala.PanelWindow : Object {
         window.size_changed.connect (position_window);
 
         window.unmanaging.connect (() => {
-            Source.remove (idle_move_id);
+            if (idle_move_id != 0) {
+                Source.remove (idle_move_id);
+            }
 
             destroy_barrier ();
 


### PR DESCRIPTION
If a shellclient window became unmanaged the corresponding panelwindow wasn't actually destroyed due to a ref cycle. This could cause a crash when a client was killed and then launched again and then something about the monitors (e.g. scale) changed. Also it was a memory leak.