### PR TITLE
Fix multiple crashes

### DIFF
--- a/src/Widgets/WindowCloneContainer.vala
+++ b/src/Widgets/WindowCloneContainer.vala
@@ -277,6 +277,10 @@ namespace Gala {
 
                     var window_rect = ((WindowClone) child).slot;
 
+                    if (window_rect == null) {
+                        continue;
+                    }
+
                     if (direction == LEFT) {
                         if (window_rect.x > current_rect.x) {
                             continue;

--- a/src/Widgets/WindowCloneContainer.vala
+++ b/src/Widgets/WindowCloneContainer.vala
@@ -51,7 +51,7 @@ namespace Gala {
          * The window that is currently selected via keyboard shortcuts. It is not
          * necessarily the same as the active window.
          */
-        private WindowClone? current_window = null;
+        private unowned WindowClone? current_window = null;
 
         public WindowCloneContainer (WindowManager wm, GestureTracker? gesture_tracker, float scale, bool overview_mode = false) {
             Object (wm: wm, gesture_tracker: gesture_tracker, monitor_scale: scale, overview_mode: overview_mode);


### PR DESCRIPTION
Fixes two crashes that regularly appeared when opening multitasking view.

1. the slot of a windowclone can be null as noted in documentation. Without checking it we could crash when opening two windows on the same workspace, move one to another workspace without ever opening multitaskingview. If you then open multitasking view it would crash since it runs a few handlers trying to select another window since in the view of the multitasking view one was "removed" and in the process it will try to access fields on the slot that is null because it's the first time we open so they haven't taken a slot yet. 

2. current_window could be unrefed twice if it was set to null in open which could cause the actor to be destroyed since current_window held the only ref on it. This in turn would cause the destroyed handler to run which would try to select another window as current and if that fails set the current_window to null again unrefing it a second time even though it was already disposing.


These are two independent crashes and I made them two commits so I'd say this can be rebase merged.