### PR TITLE
Fix building with gcc 14

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -388,7 +388,9 @@ namespace Gala {
                 return;
             }
 
-            AtkBridge.adaptor_init (0, {});
+            string[] args = {};
+            unowned string[] _args = args;
+            AtkBridge.adaptor_init (ref _args);
         }
 
         private void update_ui_group_size () {

--- a/vapi/atk-bridge-2.0.vapi
+++ b/vapi/atk-bridge-2.0.vapi
@@ -1,6 +1,6 @@
-[CCode (lower_case_cprefix = "atk_bridge_")]
+[CCode (cheader_filename = "atk-bridge.h", lower_case_cprefix = "atk_bridge_")]
 namespace AtkBridge {
-	public static int adaptor_init (int argc, char[] argv);
+    public static int adaptor_init ([CCode (array_length_pos = 0.9)] ref unowned string[] argv);
     public static void adaptor_cleanup ();
     public static void set_event_context (GLib.MainContext cnx);
 }


### PR DESCRIPTION
Fixes #2042

Confirmed build success on:

- elementary OS 8 Early Access (gcc 13.2.0)
- Fedora 40 Workstation (gcc 14.2.1)

Confirmed Gala runs as expected on:

- elementary OS 8 Early Access