### PR TITLE
MultiTaskingView: Fix notifications sliding in and out

### DIFF
--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -799,6 +799,10 @@ namespace Gala {
                     continue;
                 }
 
+                if (window.get_data (NOTIFICATION_DATA_KEY)) {
+                    continue;
+                }
+
                 if (display.get_monitor_in_fullscreen (monitor)) {
                     continue;
                 }


### PR DESCRIPTION
Currently if you open the multitaskingview while a notification is open they are being animated in and out like a normal dock although they should just stay where they normally are. 