### PR TITLE
DesktopIntegration: Emit windows changed on workspace changed

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -24,6 +24,7 @@ public class Gala.DesktopIntegration : GLib.Object {
     public DesktopIntegration (WindowManagerGala wm) {
         this.wm = wm;
         wm.window_tracker.windows_changed.connect (() => windows_changed ());
+        wm.get_display ().get_workspace_manager ().active_workspace_changed.connect (() => windows_changed ());
     }
 
     public RunningApplication[] get_running_applications () throws GLib.DBusError, GLib.IOError {


### PR DESCRIPTION
The indicators of the dock change appearance (currently they show/hide or with elementary/dock#270 they change appearance) depending on whether windows are on the current workspace or another so we have to update it when the workspace changes.