### PR TITLE
ci: Update mutter version for noble

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
         version: [stable, unstable, development-target]
         include:
           - version: stable
-            mutter_pkg: libmutter-10-dev
+            mutter_pkg: libmutter-14-dev
           - version: unstable
-            mutter_pkg: libmutter-10-dev
+            mutter_pkg: libmutter-14-dev
           - version: development-target
             mutter_pkg: libmutter-14-dev
     container:


### PR DESCRIPTION
The stable and unstable images are no longer jammy but noble