### PR TITLE
Fix stacking order after workspace switch

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2058,8 +2058,8 @@ namespace Gala {
                         continue;
                     }
 
-                    windows.prepend (actor);
-                    parents.prepend (actor.get_parent ());
+                    windows.append (actor);
+                    parents.append (actor.get_parent ());
 
                     clutter_actor_reparent (actor, static_windows);
                     actor.set_translation (-clone_offset_x, -clone_offset_y, 0);


### PR DESCRIPTION
Starts addressing #2080 

On main a 100% way to reproduce #2080 is having a maximized window so that the dock is hidden then trying to switch workspace so that a nudge plays and then trying to show the dock again. That is fixed by this PR. However there are more ways to reproduce #2080 so it's not entirely fixed.

#2080 will be fixed by #2094 however this can/should still be merged because the current behavior is just wrong