### PR TITLE
Fix autohide

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -38,6 +38,7 @@
         <issue url="https://github.com/elementary/gala/issues/1898">wayland: opening windows when overview is opened breaks a lot</issue>
         <issue url="https://github.com/elementary/gala/issues/2053">Window renders black</issue>
         <issue url="https://github.com/elementary/gala/issues/2067">Terminal and System Settings have generic icon in multitasking view on Wayland</issue>
+        <issue url="https://github.com/elementary/gala/issues/2083">Autohide is too sensitive</issue>
         <issue url="https://github.com/elementary/dock/issues/78">Touch support - getting the dock to display when hidden</issue>
       </issues>
     </release>

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -175,7 +175,7 @@ public class Gala.HideTracker : Object {
     }
 
     private void toggle_display (bool should_hide) {
-        unowned var window_actor = (Meta.WindowActor ) panel.window.get_compositor_private ();
+        unowned var window_actor = (Meta.WindowActor) panel.window.get_compositor_private ();
 
 #if HAS_MUTTER45
         hovered = panel.window.has_pointer () && window_actor.visible;

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -175,10 +175,12 @@ public class Gala.HideTracker : Object {
     }
 
     private void toggle_display (bool should_hide) {
+        unowned var window_actor = (Meta.WindowActor ) panel.window.get_compositor_private ();
+
 #if HAS_MUTTER45
-        hovered = panel.window.has_pointer ();
+        hovered = panel.window.has_pointer () && window_actor.visible;
 #else
-        hovered = window_has_pointer ();
+        hovered = window_has_pointer () && window_actor.visible;
 #endif
 
         if (should_hide && !hovered) {

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -177,6 +177,7 @@ public class Gala.HideTracker : Object {
     private void toggle_display (bool should_hide) {
         unowned var window_actor = (Meta.WindowActor) panel.window.get_compositor_private ();
 
+        // Window actor receives pointer events while hidden on X11: https://github.com/elementary/gala/issues/2083
 #if HAS_MUTTER45
         hovered = panel.window.has_pointer () && window_actor.visible;
 #else


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2083

HideTracker doesn't take into account that the dock window can be hidden and therefore cannot be hovered. This PR fixes it.