### PR TITLE
 Introduce a new PanBackend for the gesture tracker 

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -17,6 +17,31 @@
 
 namespace Gala {
     public class Utils {
+        /**
+         * Represents a size as an object in order for it to be updatable.
+         * Additionally it has some utilities like {@link Gala.Utils.Size.actor_tracking}.
+         */
+        public class Size {
+            public float width;
+            public float height;
+
+            public Size (float width, float height) {
+                this.width = width;
+                this.height = height;
+            }
+
+            /**
+             * Constructs a new size that will keep in sync with the width and height of an actor.
+             */
+            public Size.actor_tracking (Clutter.Actor actor) {
+                actor.notify["width"].connect ((obj, pspec) => width = ((Clutter.Actor) obj).width);
+                actor.notify["height"].connect ((obj, pspec) => height = ((Clutter.Actor) obj).height);
+
+                width = actor.width;
+                height = actor.height;
+            }
+        }
+
         private struct CachedIcon {
             public Gdk.Pixbuf icon;
             public int icon_size;

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -45,12 +45,14 @@ namespace Gala {
         /**
          * The x coordinate of the initial contact point for the gesture.
          * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
+         * Currently the only backend not setting this is {@link GestureTracker.enable_touchpad}.
          */
         public float origin_x = INVALID_COORD;
 
         /**
          * The y coordinate of the initial contact point for the gesture.
          * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
+         * Currently the only backend not setting this is {@link GestureTracker.enable_touchpad}.
          */
         public float origin_y = INVALID_COORD;
     }

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -39,7 +39,17 @@ namespace Gala {
         public GestureDirection direction;
         public int fingers;
         public Clutter.InputDeviceType performed_on_device_type;
-        public float start_x;
-        public float start_y;
+
+        /**
+         * The x coordinate of the initial contact point for the gesture.
+         * Doesn't have to be set.
+         */
+        public float origin_x;
+
+        /**
+         * The y coordinate of the initial contact point for the gesture.
+         * Doesn't have to be set.
+         */
+        public float origin_y;
     }
 }

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -35,6 +35,8 @@ namespace Gala {
     }
 
     public class Gesture {
+        public const float INVALID_COORD = float.MAX;
+
         public Clutter.EventType type;
         public GestureDirection direction;
         public int fingers;
@@ -42,14 +44,14 @@ namespace Gala {
 
         /**
          * The x coordinate of the initial contact point for the gesture.
-         * Doesn't have to be set.
+         * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
          */
-        public float origin_x;
+        public float origin_x = INVALID_COORD;
 
         /**
          * The y coordinate of the initial contact point for the gesture.
-         * Doesn't have to be set.
+         * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
          */
-        public float origin_y;
+        public float origin_y = INVALID_COORD;
     }
 }

--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -39,5 +39,7 @@ namespace Gala {
         public GestureDirection direction;
         public int fingers;
         public Clutter.InputDeviceType performed_on_device_type;
+        public float start_x;
+        public float start_y;
     }
 }

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -147,9 +147,15 @@ public class Gala.GestureTracker : Object {
     /**
      * Allow to receive pan gestures.
      * @param actor Clutter actor that will receive the events.
+     * @param travel_distances {@link Utils.Size} with width and height. The given size wil be
+     * used to calculate the percentage. It should be set to the amount something will travel (e.g.
+     * when moving an actor) based on the gesture to allow exact finger tracking. It can also be used
+     * to calculate the raw pixels the finger travelled at a given time with percentage * corresponding distance
+     * (height for {@link GestureDirection.UP} or DOWN, width for LEFT or RIGHT). If set to null the size of the
+     * actor will be used. If the values change those changes will apply.
      */
-    public void enable_pan (Clutter.Actor actor) {
-        pan_backend = new PanBackend (actor);
+    public void enable_pan (Clutter.Actor actor, Utils.Size? travel_distances) {
+        pan_backend = new PanBackend (actor, travel_distances);
         pan_backend.on_gesture_detected.connect (gesture_detected);
         pan_backend.on_begin.connect (gesture_begin);
         pan_backend.on_update.connect (gesture_update);

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -71,8 +71,10 @@ public class Gala.GestureTracker : Object {
      * If the receiving code needs to handle this gesture, it should call to connect_handlers to
      * start receiving updates.
      * @param gesture Information about the gesture.
+     * @return true if the gesture will be handled false otherwise. If false is returned the other
+     * signals may still be emitted but aren't guaranteed to be.
      */
-    public signal void on_gesture_detected (Gesture gesture);
+    public signal bool on_gesture_detected (Gesture gesture);
 
     /**
      * Emitted right after on_gesture_detected with the initial gesture information.
@@ -99,6 +101,11 @@ public class Gala.GestureTracker : Object {
      * Backend used if enable_touchpad is called.
      */
     private ToucheggBackend touchpad_backend;
+
+    /**
+     * Pan backend used if enable_pan is called.
+     */
+    private PanBackend pan_backend;
 
     /**
      * Scroll backend used if enable_scroll is called.
@@ -135,6 +142,18 @@ public class Gala.GestureTracker : Object {
         touchpad_backend.on_begin.connect (gesture_begin);
         touchpad_backend.on_update.connect (gesture_update);
         touchpad_backend.on_end.connect (gesture_end);
+    }
+
+    /**
+     * Allow to receive pan gestures.
+     * @param actor Clutter actor that will receive the events.
+     */
+    public void enable_pan (Clutter.Actor actor) {
+        pan_backend = new PanBackend (actor);
+        pan_backend.on_gesture_detected.connect (gesture_detected);
+        pan_backend.on_begin.connect (gesture_begin);
+        pan_backend.on_update.connect (gesture_update);
+        pan_backend.on_end.connect (gesture_end);
     }
 
     /**
@@ -201,10 +220,12 @@ public class Gala.GestureTracker : Object {
         return value;
     }
 
-    private void gesture_detected (Gesture gesture) {
+    private bool gesture_detected (Gesture gesture) {
         if (enabled) {
-            on_gesture_detected (gesture);
+            return on_gesture_detected (gesture);
         }
+
+        return false;
     }
 
     private void gesture_begin (double percentage, uint64 elapsed_time) {

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -100,7 +100,7 @@ public class Gala.GestureTracker : Object {
     /**
      * Backend used if enable_touchpad is called.
      */
-    private ToucheggBackend touchpad_backend;
+    private ToucheggBackend? touchpad_backend;
 
     /**
      * Pan backend used if enable_pan is called.
@@ -157,9 +157,19 @@ public class Gala.GestureTracker : Object {
     public void enable_pan (Clutter.Actor actor, Utils.Size? travel_distances) {
         pan_backend = new PanBackend (actor, travel_distances);
         pan_backend.on_gesture_detected.connect (gesture_detected);
-        pan_backend.on_begin.connect (gesture_begin);
+        pan_backend.on_begin.connect ((percentage, time) => {
+            gesture_begin (percentage, time);
+            if (touchpad_backend != null) {
+                touchpad_backend.ignore_touchscreen = true;
+            }
+        });
         pan_backend.on_update.connect (gesture_update);
-        pan_backend.on_end.connect (gesture_end);
+        pan_backend.on_end.connect ((percentage, time) => {
+            gesture_end (percentage, time);
+            if (touchpad_backend != null) {
+                touchpad_backend.ignore_touchscreen = false;
+            }
+        });
     }
 
     /**

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -50,11 +50,11 @@ public class Gala.PanBackend : Object {
     }
 
     private void on_gesture_end () {
-        direction = GestureDirection.UNKNOWN;
-
         float x_coord, y_coord;
         pan_action.get_motion_coords (0, out x_coord, out y_coord);
         on_end (calculate_percentage (x_coord, y_coord), pan_action.get_last_event (0).get_time ());
+
+        direction = GestureDirection.UNKNOWN;
     }
 
     private bool on_pan (Clutter.PanAction pan_action, Clutter.Actor actor, bool interpolate) {
@@ -71,11 +71,11 @@ public class Gala.PanBackend : Object {
     private double calculate_percentage (float current_x, float current_y) {
         float current, origin, size;
         if (pan_axis == X_AXIS) {
-            current = current_x;
+            current = direction == RIGHT ? float.max (current_x, origin_x) : float.min (current_x, origin_x);
             origin = origin_x;
             size = travel_distances != null ? travel_distances.width : actor.width;
         } else {
-            current = current_y;
+            current = direction == DOWN ? float.max (current_y, origin_y) : float.min (current_y, origin_y);
             origin = origin_y;
             size = travel_distances != null ? travel_distances.height : actor.height;
         }

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -12,8 +12,8 @@ public class Gala.PanBackend : Object {
 
     private GestureDirection direction;
 
-    private float start_val_x;
-    private float start_val_y;
+    private float origin_x;
+    private float origin_y;
 
     public PanBackend (Clutter.Actor actor) {
         Object (actor: actor);
@@ -35,8 +35,8 @@ public class Gala.PanBackend : Object {
         float x_coord, y_coord;
         pan_action.get_press_coords (0, out x_coord, out y_coord);
 
-        start_val_x = x_coord;
-        start_val_y = y_coord;
+        origin_x = x_coord;
+        origin_y = y_coord;
 
         var handled = on_gesture_detected (build_gesture ());
 
@@ -68,17 +68,17 @@ public class Gala.PanBackend : Object {
         return true;
     }
 
-    private double calculate_percentage (double current_val_x, double current_val_y) {
-        double current_val, start_val;
+    private double calculate_percentage (float current_x, float current_y) {
+        float current, origin;
         if (pan_axis == X_AXIS) {
-            current_val = current_val_x;
-            start_val = start_val_x;
+            current = current_x;
+            origin = origin_x;
         } else {
-            current_val = current_val_y;
-            start_val = start_val_y;
+            current = current_y;
+            origin = origin_y;
         }
 
-        return (current_val - start_val).abs () / actor.get_width ();
+        return (current - origin).abs () / actor.get_width ();
     }
 
     private Gesture build_gesture () {
@@ -98,8 +98,8 @@ public class Gala.PanBackend : Object {
             direction = direction,
             fingers = (int) pan_action.get_n_current_points (),
             performed_on_device_type = Clutter.InputDeviceType.TOUCHPAD_DEVICE,
-            start_x = start_val_x,
-            start_y = start_val_y
+            origin_x = origin_x,
+            origin_y = origin_y
         };
     }
 }

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2024 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
 public class Gala.PanBackend : Object {
     public signal bool on_gesture_detected (Gesture gesture);
     public signal void on_begin (double delta, uint64 time);

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -1,0 +1,105 @@
+public class Gala.PanBackend : Object {
+    public signal bool on_gesture_detected (Gesture gesture);
+    public signal void on_begin (double delta, uint64 time);
+    public signal void on_update (double delta, uint64 time);
+    public signal void on_end (double delta, uint64 time);
+
+    public Clutter.Actor actor { get; construct; }
+    public GestureSettings settings { get; construct; }
+
+    private Clutter.PanAxis pan_axis;
+    private Clutter.PanAction pan_action;
+
+    private GestureDirection direction;
+
+    private float start_val_x;
+    private float start_val_y;
+
+    public PanBackend (Clutter.Actor actor) {
+        Object (actor: actor);
+    }
+
+    construct {
+        pan_action = new Clutter.PanAction () {
+            n_touch_points = 1
+        };
+
+        actor.add_action_full ("pan-gesture", CAPTURE, pan_action);
+
+        pan_action.gesture_begin.connect (on_gesture_begin);
+        pan_action.pan.connect (on_pan);
+        pan_action.gesture_end.connect (on_gesture_end);
+    }
+
+    private bool on_gesture_begin () {
+        float x_coord, y_coord;
+        pan_action.get_press_coords (0, out x_coord, out y_coord);
+
+        start_val_x = x_coord;
+        start_val_y = y_coord;
+
+        var handled = on_gesture_detected (build_gesture ());
+
+        if (!handled) {
+            return false;
+        }
+
+        on_begin (0, pan_action.get_last_event (0).get_time ());
+
+        return true;
+    }
+
+    private void on_gesture_end () {
+        direction = GestureDirection.UNKNOWN;
+
+        float x_coord, y_coord;
+        pan_action.get_motion_coords (0, out x_coord, out y_coord);
+        on_end (calculate_percentage (x_coord, y_coord), pan_action.get_last_event (0).get_time ());
+    }
+
+    private bool on_pan (Clutter.PanAction pan_action, Clutter.Actor actor, bool interpolate) {
+        uint64 time = pan_action.get_last_event (0).get_time ();
+
+        float x_coord, y_coord;
+        pan_action.get_motion_coords (0, out x_coord, out y_coord);
+
+        on_update (calculate_percentage (x_coord, y_coord), time);
+
+        return true;
+    }
+
+    private double calculate_percentage (double current_val_x, double current_val_y) {
+        double current_val, start_val;
+        if (pan_axis == X_AXIS) {
+            current_val = current_val_x;
+            start_val = start_val_x;
+        } else {
+            current_val = current_val_y;
+            start_val = start_val_y;
+        }
+
+        return (current_val - start_val).abs () / actor.get_width ();
+    }
+
+    private Gesture build_gesture () {
+        float delta_x, delta_y;
+        ((Clutter.GestureAction) pan_action).get_motion_delta (0, out delta_x, out delta_y);
+
+        pan_axis = delta_x.abs () > delta_y.abs () ? Clutter.PanAxis.X_AXIS : Clutter.PanAxis.Y_AXIS;
+
+        if (pan_axis == X_AXIS) {
+            direction = delta_x > 0 ? GestureDirection.RIGHT : GestureDirection.LEFT;
+        } else {
+            direction = delta_y > 0 ? GestureDirection.DOWN : GestureDirection.UP;
+        }
+
+        return new Gesture () {
+            type = Clutter.EventType.TOUCHPAD_SWIPE,
+            direction = direction,
+            fingers = (int) pan_action.get_n_current_points (),
+            performed_on_device_type = Clutter.InputDeviceType.TOUCHPAD_DEVICE,
+            start_x = start_val_x,
+            start_y = start_val_y
+        };
+    }
+}

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -99,7 +99,7 @@ public class Gala.PanBackend : Object {
             type = Clutter.EventType.TOUCHPAD_SWIPE,
             direction = direction,
             fingers = (int) pan_action.get_n_current_points (),
-            performed_on_device_type = Clutter.InputDeviceType.TOUCHPAD_DEVICE,
+            performed_on_device_type = Clutter.InputDeviceType.TOUCHSCREEN_DEVICE,
             origin_x = origin_x,
             origin_y = origin_y
         };

--- a/src/Gestures/PanBackend.vala
+++ b/src/Gestures/PanBackend.vala
@@ -5,7 +5,7 @@ public class Gala.PanBackend : Object {
     public signal void on_end (double delta, uint64 time);
 
     public Clutter.Actor actor { get; construct; }
-    public GestureSettings settings { get; construct; }
+    public Utils.Size? travel_distances { get; construct; }
 
     private Clutter.PanAxis pan_axis;
     private Clutter.PanAction pan_action;
@@ -15,8 +15,8 @@ public class Gala.PanBackend : Object {
     private float origin_x;
     private float origin_y;
 
-    public PanBackend (Clutter.Actor actor) {
-        Object (actor: actor);
+    public PanBackend (Clutter.Actor actor, Utils.Size? travel_distances) {
+        Object (actor: actor, travel_distances: travel_distances);
     }
 
     construct {
@@ -69,16 +69,18 @@ public class Gala.PanBackend : Object {
     }
 
     private double calculate_percentage (float current_x, float current_y) {
-        float current, origin;
+        float current, origin, size;
         if (pan_axis == X_AXIS) {
             current = current_x;
             origin = origin_x;
+            size = travel_distances != null ? travel_distances.width : actor.width;
         } else {
             current = current_y;
             origin = origin_y;
+            size = travel_distances != null ? travel_distances.height : actor.height;
         }
 
-        return (current - origin).abs () / actor.get_width ();
+        return (current - origin).abs () / size;
     }
 
     private Gesture build_gesture () {

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -80,7 +80,9 @@ public class Gala.ScrollBackend : Object {
 
         if (!started) {
             if (delta_x != 0 || delta_y != 0) {
-                Gesture gesture = build_gesture (delta_x, delta_y, orientation);
+                float origin_x, origin_y;
+                event.get_coords (out origin_x, out origin_y);
+                Gesture gesture = build_gesture (origin_x, origin_y, delta_x, delta_y, orientation);
                 started = true;
                 direction = gesture.direction;
                 on_gesture_detected (gesture);
@@ -114,7 +116,7 @@ public class Gala.ScrollBackend : Object {
             && event.get_scroll_direction () == Clutter.ScrollDirection.SMOOTH;
     }
 
-    private static Gesture build_gesture (double delta_x, double delta_y, Clutter.Orientation orientation) {
+    private static Gesture build_gesture (float origin_x, float origin_y, double delta_x, double delta_y, Clutter.Orientation orientation) {
         GestureDirection direction;
         if (orientation == Clutter.Orientation.HORIZONTAL) {
             direction = delta_x > 0 ? GestureDirection.RIGHT : GestureDirection.LEFT;
@@ -126,7 +128,9 @@ public class Gala.ScrollBackend : Object {
             type = Clutter.EventType.SCROLL,
             direction = direction,
             fingers = 2,
-            performed_on_device_type = Clutter.InputDeviceType.TOUCHPAD_DEVICE
+            performed_on_device_type = Clutter.InputDeviceType.TOUCHPAD_DEVICE,
+            origin_x = origin_x,
+            origin_y = origin_y
         };
     }
 

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -26,7 +26,7 @@ public class Gala.ScrollBackend : Object {
     private const double FINISH_DELTA_HORIZONTAL = 40;
     private const double FINISH_DELTA_VERTICAL = 30;
 
-    public signal void on_gesture_detected (Gesture gesture);
+    public signal bool on_gesture_detected (Gesture gesture);
     public signal void on_begin (double delta, uint64 time);
     public signal void on_update (double delta, uint64 time);
     public signal void on_end (double delta, uint64 time);

--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -26,6 +26,8 @@ public class Gala.ToucheggBackend : Object {
     public signal void on_update (double delta, uint64 time);
     public signal void on_end (double delta, uint64 time);
 
+    public bool ignore_touchscreen { get; set; default = false; }
+
     /**
      * Gesture type as returned by the daemon.
      */
@@ -196,6 +198,10 @@ public class Gala.ToucheggBackend : Object {
 
         signal_params.get ("(uudiut)", out type, out direction, out percentage, out fingers,
             out performed_on_device_type, out elapsed_time);
+
+        if (ignore_touchscreen && performed_on_device_type == TOUCHSCREEN) {
+            return;
+        }
 
         var delta = percentage * DELTA_MULTIPLIER;
 

--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -21,7 +21,7 @@
  * See: [[https://github.com/JoseExposito/touchegg]]
  */
 public class Gala.ToucheggBackend : Object {
-    public signal void on_gesture_detected (Gesture gesture);
+    public signal bool on_gesture_detected (Gesture gesture);
     public signal void on_begin (double delta, uint64 time);
     public signal void on_update (double delta, uint64 time);
     public signal void on_end (double delta, uint64 time);

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -290,24 +290,28 @@ namespace Gala {
             workspaces.add_transition ("nudge", nudge);
         }
 
-        private void on_multitasking_gesture_detected (Gesture gesture) {
+        private bool on_multitasking_gesture_detected (Gesture gesture) {
             if (gesture.type != Clutter.EventType.TOUCHPAD_SWIPE ||
                 (gesture.fingers == 3 && GestureSettings.get_string ("three-finger-swipe-up") != "multitasking-view") ||
                 (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-swipe-up") != "multitasking-view")
             ) {
-                return;
+                return false;
             }
 
             if (gesture.direction == GestureDirection.UP && !opened) {
                 toggle (true, false);
+                return true;
             } else if (gesture.direction == GestureDirection.DOWN && opened) {
                 toggle (true, false);
+                return true;
             }
+
+            return false;
         }
 
-        private void on_workspace_gesture_detected (Gesture gesture) {
+        private bool on_workspace_gesture_detected (Gesture gesture) {
             if (!opened) {
-                return;
+                return false;
             }
 
             var can_handle_swipe = gesture.type == Clutter.EventType.TOUCHPAD_SWIPE &&
@@ -319,7 +323,10 @@ namespace Gala {
             if (gesture.type == Clutter.EventType.SCROLL || (can_handle_swipe && fingers)) {
                 var direction = workspace_gesture_tracker.settings.get_natural_scroll_direction (gesture);
                 switch_workspace_with_gesture (direction);
+                return true;
             }
+
+            return false;
         }
 
         private void switch_workspace_with_gesture (Meta.MotionDirection direction) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -539,14 +539,14 @@ namespace Gala {
             }
         }
 
-        private void on_gesture_detected (Gesture gesture) {
+        private bool on_gesture_detected (Gesture gesture) {
             if (workspace_view.is_opened ()) {
-                return;
+                return false;
             }
 
             if (gesture.type != Clutter.EventType.TOUCHPAD_SWIPE ||
                 (gesture.direction != GestureDirection.LEFT && gesture.direction != GestureDirection.RIGHT)) {
-                return;
+                return false;
             }
 
             unowned var display = get_display ();
@@ -569,7 +569,7 @@ namespace Gala {
             if (switch_workspace_with_gesture) {
                 var direction = gesture_tracker.settings.get_natural_scroll_direction (gesture);
                 switch_to_next_workspace (direction, display.get_current_time ());
-                return;
+                return true;
             }
 
             switch_workspace_with_gesture = three_fingers_move_to_workspace || four_fingers_move_to_workspace;
@@ -584,13 +584,16 @@ namespace Gala {
                 }
 
                 switch_to_next_workspace (direction, display.get_current_time ());
-                return;
+                return true;
             }
 
             var switch_windows = three_fingers_switch_windows || four_fingers_switch_windows;
             if (switch_windows && !window_switcher.opened) {
                 window_switcher.handle_gesture (gesture.direction);
+                return true;
             }
+
+            return false;
         }
 
         /**

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -61,18 +61,21 @@ public class Gala.Zoom : Object {
         zoom (-SHORTCUT_DELTA, true, wm.enable_animations);
     }
 
-    private void on_gesture_detected (Gesture gesture) {
+    private bool on_gesture_detected (Gesture gesture) {
         if (gesture.type != Clutter.EventType.TOUCHPAD_PINCH ||
             (gesture.direction != GestureDirection.IN && gesture.direction != GestureDirection.OUT)
         ) {
-            return;
+            return false;
         }
 
         if ((gesture.fingers == 3 && GestureSettings.get_string ("three-finger-pinch") == "zoom") ||
             (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-pinch") == "zoom")
         ) {
             zoom_with_gesture (gesture.direction);
+            return true;
         }
+
+        return false;
     }
 
     private void zoom_with_gesture (GestureDirection direction) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ gala_bin_sources = files(
     'Gestures/Gesture.vala',
     'Gestures/GestureSettings.vala',
     'Gestures/GestureTracker.vala',
+    'Gestures/PanBackend.vala',
     'Gestures/ScrollBackend.vala',
     'Gestures/ToucheggBackend.vala',
     'HotCorners/Barrier.vala',


### PR DESCRIPTION
This will allow exact finger tracking for touchscreen devices. Once used this will f*x #1272 

Currently this isn't used anywhere but it prepares for handling all touchscreen gestures with this in order to achieve one to one finger tracking. In the long term with some coming mutter changes it will handle all gestures (touchpad as well) in order to remove the need of touchegg which currently only works because of xwayland.

This will also allow us to have much more precise gestures: e.g. swipe up from the bottom to reveal the dock one to one will be trivial to implement (PR incoming). It can also be used to do swipe in from corners to use hotcorners on touchscreen (another PR incoming :) ).

The ugly workaround with toucheggbackend.ignore_touchscreen can be removed once everything uses the new pan backend for touchscreen gestures by just ignoring all touchscreen events from touchegg.

TODO:
- [x] If the initial touch point lifts the percentage jumps which doesn't look good