### PR TITLE
DragDropAction: Fix actor_clicked emission on touch event

### DIFF
--- a/lib/DragDropAction.vala
+++ b/lib/DragDropAction.vala
@@ -229,7 +229,7 @@ namespace Gala {
 
                         // release has happened within bounds of actor
                         if (clicked && x < ex && x + actor.width > ex && y < ey && y + actor.height > ey) {
-                            actor_clicked (event.get_button ());
+                            actor_clicked (event.get_type () == BUTTON_RELEASE ? event.get_button () : Clutter.Button.PRIMARY);
                         }
 
                         if (clicked) {


### PR DESCRIPTION
Fixes #1960

This fixes tapping a window in the multitasking view to select it.

A warning was generated along the lines of assertion event type == BUTTON_PRESS/RELEASE/etc. failed.