### PR TITLE
Introduce AnimationsSettings

### DIFF
--- a/lib/AnimationsSettings.vala
+++ b/lib/AnimationsSettings.vala
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
+ */
+
+namespace AnimationsSettings {
+    private GLib.Settings? animations_settings;
+    private bool enable_animations = true;
+
+    /**
+     * Whether animations should be displayed.
+     */
+    public bool get_enable_animations () {
+        if (animations_settings == null) {
+            animations_settings = new GLib.Settings ("io.elementary.desktop.wm.animations");
+            animations_settings.changed["enable-animations"].connect (() => {
+                enable_animations = animations_settings.get_boolean ("enable-animations");
+            });
+
+            enable_animations = animations_settings.get_boolean ("enable-animations");
+        }
+
+        return enable_animations;
+    }
+}

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -124,11 +124,6 @@ namespace Gala {
         public abstract Gala.ActivatableComponent workspace_view { get; protected set; }
 
         /**
-         * Whether animations should be displayed.
-         */
-        public abstract bool enable_animations { get; protected set; }
-
-        /**
          * Enters the modal mode, which means that all events are directed to the stage instead
          * of the windows. This is the only way to receive keyboard events besides shortcut listeners.
          *

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,5 +1,6 @@
 gala_lib_sources = files(
     'ActivatableComponent.vala',
+    'AnimationsSettings.vala',
     'App.vala',
     'AppCache.vala',
     'AppSystem.vala',

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -143,7 +143,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
         opacity = 0;
 
         save_easing_state ();
-        set_easing_duration (wm.enable_animations ? 200 : 0);
+        set_easing_duration (AnimationsSettings.get_enable_animations () ? 200 : 0);
         opacity = 255;
         restore_easing_state ();
     }
@@ -151,7 +151,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     public override void hide () {
         opacity = 255;
 
-        var duration = wm.enable_animations ? 200 : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? 200 : 0;
         save_easing_state ();
         set_easing_duration (duration);
         opacity = 0;
@@ -173,7 +173,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
 #else
     public override bool enter_event (Clutter.CrossingEvent event) {
 #endif
-        var duration = wm.enable_animations ? 300 : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? 300 : 0;
 
         close_button.save_easing_state ();
         close_button.set_easing_duration (duration);
@@ -193,7 +193,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
 #else
     public override bool leave_event (Clutter.CrossingEvent event) {
 #endif
-        var duration = wm.enable_animations ? 300 : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? 300 : 0;
 
         close_button.save_easing_state ();
         close_button.set_easing_duration (duration);
@@ -315,7 +315,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     }
 
     private void on_close_click_clicked () {
-        var duration = wm.enable_animations ? FADE_OUT_TIMEOUT : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? FADE_OUT_TIMEOUT : 0;
 
         save_easing_state ();
         set_easing_duration (duration);
@@ -449,7 +449,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
         var screen_limit_start_y = SCREEN_MARGIN + monitor_y;
         var screen_limit_end_y = monitor_height + monitor_y - SCREEN_MARGIN - height;
 
-        var duration = wm.enable_animations ? 300 : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? 300 : 0;
 
         save_easing_state ();
         set_easing_mode (Clutter.AnimationMode.EASE_OUT_BACK);
@@ -462,7 +462,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
     private bool place_window_off_screen () {
         off_screen = false;
 
-        var duration = wm.enable_animations ? 300 : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? 300 : 0;
 
         save_easing_state ();
         set_easing_mode (Clutter.AnimationMode.EASE_OUT_BACK);

--- a/src/Background/BackgroundManager.vala
+++ b/src/Background/BackgroundManager.vala
@@ -61,7 +61,7 @@ public class Gala.BackgroundManager : Meta.BackgroundGroup, Gala.BackgroundManag
             return;
         }
 
-        if (animate && wm.enable_animations) {
+        if (animate && AnimationsSettings.get_enable_animations ()) {
             var transition = new Clutter.PropertyTransition ("opacity");
             transition.set_from_value (255);
             transition.set_to_value (0);

--- a/src/NotificationStack.vala
+++ b/src/NotificationStack.vala
@@ -48,7 +48,7 @@ public class Gala.NotificationStack : Object {
         update_stack_allocation ();
     }
 
-    public void show_notification (Meta.WindowActor notification, bool animate)
+    public void show_notification (Meta.WindowActor notification)
         requires (notification != null && !notification.is_destroyed () && !notifications.contains (notification)) {
 
         notification.set_pivot_point (0.5f, 0.5f);
@@ -62,7 +62,7 @@ public class Gala.NotificationStack : Object {
         var window_rect = window.get_frame_rect ();
         window.stick ();
 
-        if (animate) {
+        if (AnimationsSettings.get_enable_animations ()) {
             // Don't flicker at the beginning of the animation
             notification.opacity = 0;
             notification.rotation_angle_x = 90;
@@ -96,7 +96,7 @@ public class Gala.NotificationStack : Object {
          * by shifting all current notifications by height
          * and then add it to the notifications list.
          */
-        update_positions (animate, scale, window_rect.height);
+        update_positions (scale, window_rect.height);
 
         int notification_x_pos = area.x + area.width - window_rect.width;
         if (Clutter.get_default_text_direction () == Clutter.TextDirection.RTL) {
@@ -117,7 +117,7 @@ public class Gala.NotificationStack : Object {
         stack_y = area.y;
     }
 
-    private void update_positions (bool animate, float scale, float add_y = 0.0f) {
+    private void update_positions (float scale, float add_y = 0.0f) {
         var y = stack_y + TOP_OFFSET + add_y + InternalUtils.scale_to_int (ADDITIONAL_MARGIN, scale);
         var i = notifications.size;
         var delay_step = i > 0 ? 150 / i : 0;
@@ -131,7 +131,7 @@ public class Gala.NotificationStack : Object {
                 continue;
             }
 
-            if (animate) {
+            if (AnimationsSettings.get_enable_animations ()) {
                 actor.save_easing_state ();
                 actor.set_easing_mode (Clutter.AnimationMode.EASE_OUT_BACK);
                 actor.set_easing_duration (200);
@@ -140,7 +140,7 @@ public class Gala.NotificationStack : Object {
 
             move_window (actor, -1, (int)y);
 
-            if (animate) {
+            if (AnimationsSettings.get_enable_animations ()) {
                 actor.restore_easing_state ();
             }
 
@@ -160,8 +160,8 @@ public class Gala.NotificationStack : Object {
         }
     }
 
-    public void destroy_notification (Meta.WindowActor notification, bool animate) {
-        if (animate) {
+    public void destroy_notification (Meta.WindowActor notification) {
+        if (AnimationsSettings.get_enable_animations ()) {
             notification.save_easing_state ();
             notification.set_easing_duration (100);
             notification.set_easing_mode (Clutter.AnimationMode.EASE_IN_QUAD);
@@ -178,7 +178,7 @@ public class Gala.NotificationStack : Object {
         var scale = display.get_monitor_scale (primary);
 
         notifications.remove (notification);
-        update_positions (animate, scale);
+        update_positions (scale);
     }
 
     /**

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -116,7 +116,7 @@ public class Gala.PanelClone : Object {
 
     private int get_animation_duration () {
         var fullscreen = wm.get_display ().get_monitor_in_fullscreen (panel.window.get_monitor ());
-        var should_animate = wm.enable_animations && !wm.workspace_view.is_opened () && !fullscreen;
+        var should_animate = AnimationsSettings.get_enable_animations () && !wm.workspace_view.is_opened () && !fullscreen;
         return should_animate ? ANIMATION_DURATION : 0;
     }
 

--- a/src/Widgets/IconGroup.vala
+++ b/src/Widgets/IconGroup.vala
@@ -165,7 +165,7 @@ namespace Gala {
                     if (animate) {
                         icon.save_easing_state ();
                         icon.set_easing_mode (Clutter.AnimationMode.LINEAR);
-                        icon.set_easing_duration (wm.enable_animations ? 200 : 0);
+                        icon.set_easing_duration (AnimationsSettings.get_enable_animations () ? 200 : 0);
                         icon.opacity = 0;
                         icon.restore_easing_state ();
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -263,7 +263,7 @@ namespace Gala {
         }
 
         public void play_nudge_animation (Meta.MotionDirection direction) {
-            if (!wm.enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 return;
             }
 
@@ -413,7 +413,7 @@ namespace Gala {
                 workspaces.restore_easing_state ();
 
                 if (!is_nudge_animation) {
-                    if (wm.enable_animations) {
+                    if (AnimationsSettings.get_enable_animations ()) {
                         var active_transition = new Clutter.PropertyTransition ("backdrop-opacity") {
                             duration = duration,
                             remove_on_complete = true
@@ -440,7 +440,7 @@ namespace Gala {
                 }
             };
 
-            if (!wm.enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 on_animation_end (1, false, 0);
             } else {
                 workspace_gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
@@ -476,14 +476,14 @@ namespace Gala {
                 }
 
                 workspace_clone.save_easing_state ();
-                workspace_clone.set_easing_duration ((animate && wm.enable_animations) ? 200 : 0);
+                workspace_clone.set_easing_duration ((animate && AnimationsSettings.get_enable_animations ()) ? 200 : 0);
                 workspace_clone.x = dest_x;
                 workspace_clone.restore_easing_state ();
             }
 
             workspaces.save_easing_state ();
             workspaces.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-            workspaces.set_easing_duration ((animate && wm.enable_animations) ? AnimationDuration.WORKSPACE_SWITCH_MIN : 0);
+            workspaces.set_easing_duration ((animate && AnimationsSettings.get_enable_animations ()) ? AnimationDuration.WORKSPACE_SWITCH_MIN : 0);
             workspaces.x = -active_x;
             workspaces.restore_easing_state ();
 
@@ -668,7 +668,7 @@ namespace Gala {
             }
 
             // we don't want to handle cancel animation when animation are off
-            if (is_cancel_animation && !wm.enable_animations) {
+            if (is_cancel_animation && !AnimationsSettings.get_enable_animations ()) {
                 return;
             }
 
@@ -840,12 +840,12 @@ namespace Gala {
 
                     clone.save_easing_state ();
                     clone.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    clone.set_easing_duration ((!is_cancel_animation && wm.enable_animations) ? ANIMATION_DURATION : 0);
+                    clone.set_easing_duration ((!is_cancel_animation && AnimationsSettings.get_enable_animations ()) ? ANIMATION_DURATION : 0);
                     clone.y = target_y;
                     clone.restore_easing_state ();
                 };
 
-                if (!with_gesture || !wm.enable_animations) {
+                if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
                     on_animation_end (1, false, 0);
                 } else {
                     multitasking_gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
@@ -871,12 +871,12 @@ namespace Gala {
 
                     dock.save_easing_state ();
                     dock.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    dock.set_easing_duration (wm.enable_animations ? ANIMATION_DURATION : 0);
+                    dock.set_easing_duration (AnimationsSettings.get_enable_animations () ? ANIMATION_DURATION : 0);
                     dock.y = target_y;
                     dock.restore_easing_state ();
                 };
 
-                if (!with_gesture || !wm.enable_animations) {
+                if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
                     on_animation_end (1, false, 0);
                 } else {
                     multitasking_gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);

--- a/src/Widgets/ScreenShield.vala
+++ b/src/Widgets/ScreenShield.vala
@@ -336,7 +336,7 @@ namespace Gala {
             grab_key_focus ();
             modal_proxy = wm.push_modal (this);
 
-            if (wm.enable_animations && animate) {
+            if (AnimationsSettings.get_enable_animations () && animate) {
                 animate_and_lock (animation_time);
             } else {
                 _set_active (true);

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -47,7 +47,7 @@ public class Gala.WindowClone : Clutter.Actor {
     public bool active {
         set {
             active_shape.save_easing_state ();
-            active_shape.set_easing_duration (wm.enable_animations ? FADE_ANIMATION_DURATION : 0);
+            active_shape.set_easing_duration (AnimationsSettings.get_enable_animations () ? FADE_ANIMATION_DURATION : 0);
             active_shape.opacity = value ? 255 : 0;
             active_shape.restore_easing_state ();
         }
@@ -313,7 +313,7 @@ public class Gala.WindowClone : Clutter.Actor {
                 return;
             }
 
-            var duration = (animate && wm.enable_animations) ? MultitaskingView.ANIMATION_DURATION : 0;
+            var duration = (animate && AnimationsSettings.get_enable_animations ()) ? MultitaskingView.ANIMATION_DURATION : 0;
 
             save_easing_state ();
             set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
@@ -351,7 +351,7 @@ public class Gala.WindowClone : Clutter.Actor {
             }
         };
 
-        if (!animate || gesture_tracker == null || !with_gesture || !wm.enable_animations) {
+        if (!animate || gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
             on_animation_end (1, false, 0);
         } else {
             gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
@@ -400,7 +400,7 @@ public class Gala.WindowClone : Clutter.Actor {
                 return;
             }
 
-            var duration = wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0;
+            var duration = AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0;
 
             save_easing_state ();
             set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
@@ -432,7 +432,7 @@ public class Gala.WindowClone : Clutter.Actor {
             }
         };
 
-        if (gesture_tracker == null || !with_gesture || !wm.enable_animations) {
+        if (gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
             on_animation_end (1, false, 0);
         } else {
             gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
@@ -485,7 +485,7 @@ public class Gala.WindowClone : Clutter.Actor {
             return Clutter.EVENT_PROPAGATE;
         }
 
-        var duration = wm.enable_animations ? FADE_ANIMATION_DURATION : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? FADE_ANIMATION_DURATION : 0;
 
         close_button.save_easing_state ();
         close_button.set_easing_mode (Clutter.AnimationMode.LINEAR);
@@ -507,7 +507,7 @@ public class Gala.WindowClone : Clutter.Actor {
 #else
     public override bool leave_event (Clutter.CrossingEvent event) {
 #endif
-        var duration = wm.enable_animations ? FADE_ANIMATION_DURATION : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? FADE_ANIMATION_DURATION : 0;
 
         close_button.save_easing_state ();
         close_button.set_easing_mode (Clutter.AnimationMode.LINEAR);
@@ -551,7 +551,7 @@ public class Gala.WindowClone : Clutter.Actor {
             remove_transition ("shadow-opacity");
         }
 
-        if (wm.enable_animations) {
+        if (AnimationsSettings.get_enable_animations ()) {
             var shadow_transition = new Clutter.PropertyTransition ("shadow-opacity") {
                 duration = MultitaskingView.ANIMATION_DURATION,
                 remove_on_complete = true,
@@ -643,7 +643,7 @@ public class Gala.WindowClone : Clutter.Actor {
         active_shape.hide ();
 
         var scale = window_icon.width / clone.width;
-        var duration = wm.enable_animations ? FADE_ANIMATION_DURATION : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? FADE_ANIMATION_DURATION : 0;
 
         clone.get_transformed_position (out abs_x, out abs_y);
         clone.save_easing_state ();
@@ -702,7 +702,7 @@ public class Gala.WindowClone : Clutter.Actor {
         var scale = hovered ? 0.4 : 1.0;
         var opacity = hovered ? 0 : 255;
         var duration = hovered && insert_thumb != null ? insert_thumb.delay : 100;
-        duration = wm.enable_animations ? duration : 0;
+        duration = AnimationsSettings.get_enable_animations () ? duration : 0;
 
         window_icon.save_easing_state ();
 
@@ -810,7 +810,7 @@ public class Gala.WindowClone : Clutter.Actor {
         get_parent ().remove_child (this);
         prev_parent.insert_child_at_index (this, prev_index);
 
-        var duration = wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0;
+        var duration = AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0;
 
         clone.set_pivot_point (0.0f, 0.0f);
         clone.save_easing_state ();

--- a/src/Widgets/WindowIconActor.vala
+++ b/src/Widgets/WindowIconActor.vala
@@ -65,7 +65,7 @@ namespace Gala {
             set {
                 if (_temporary && !value) {
                     remove_transition ("pulse");
-                } else if (!_temporary && value && wm.enable_animations) {
+                } else if (!_temporary && value && AnimationsSettings.get_enable_animations ()) {
                     var transition = new Clutter.TransitionGroup () {
                         duration = 800,
                         auto_reverse = true,
@@ -147,7 +147,7 @@ namespace Gala {
 
             new_icon.save_easing_state ();
             new_icon.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-            new_icon.set_easing_duration (wm.enable_animations ? 500 : 0);
+            new_icon.set_easing_duration (AnimationsSettings.get_enable_animations () ? 500 : 0);
             new_icon.restore_easing_state ();
 
             if (icon == null) {

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -414,7 +414,7 @@ public class Gala.WindowSwitcher : CanvasActor {
         }
 
         save_easing_state ();
-        set_easing_duration (wm.enable_animations ? ANIMATION_DURATION : 0);
+        set_easing_duration (AnimationsSettings.get_enable_animations () ? ANIMATION_DURATION : 0);
         opacity = show ? 255 : 0;
         restore_easing_state ();
     }

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -388,18 +388,18 @@ namespace Gala {
 
                 save_easing_state ();
                 set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                set_easing_duration (wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0);
+                set_easing_duration (AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0);
                 set_x (target_x);
                 restore_easing_state ();
 
                 background.save_easing_state ();
                 background.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                background.set_easing_duration (wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0);
+                background.set_easing_duration (AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0);
                 background.set_scale (scale, scale);
                 background.restore_easing_state ();
             };
 
-            if (!with_gesture || !wm.enable_animations) {
+            if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
                 on_animation_begin (0);
                 on_animation_end (1, false, 0);
             } else {
@@ -464,18 +464,18 @@ namespace Gala {
 
                 save_easing_state ();
                 set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                set_easing_duration (wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0);
+                set_easing_duration (AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0);
                 set_x (target_x);
                 restore_easing_state ();
 
                 background.save_easing_state ();
                 background.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                background.set_easing_duration (wm.enable_animations ? MultitaskingView.ANIMATION_DURATION : 0);
+                background.set_easing_duration (AnimationsSettings.get_enable_animations () ? MultitaskingView.ANIMATION_DURATION : 0);
                 background.set_scale (1, 1);
                 background.restore_easing_state ();
             };
 
-            if (!with_gesture || !wm.enable_animations) {
+            if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
                 on_animation_end (1, false, 0);
             } else {
                 gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);

--- a/src/Widgets/WorkspaceInsertThumb.vala
+++ b/src/Widgets/WorkspaceInsertThumb.vala
@@ -84,7 +84,7 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     private new void transform (bool expand) {
         save_easing_state ();
         set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-        set_easing_duration (wm.enable_animations ? 200 : 0);
+        set_easing_duration (AnimationsSettings.get_enable_animations () ? 200 : 0);
 
         if (!expand) {
             remove_transition ("pulse");
@@ -102,7 +102,7 @@ public class Gala.WorkspaceInsertThumb : Clutter.Actor {
     }
 
     private void add_pulse_animation () {
-        if (!wm.enable_animations) {
+        if (!AnimationsSettings.get_enable_animations ()) {
             return;
         }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -49,11 +49,6 @@ namespace Gala {
          */
          public Gala.ActivatableComponent workspace_view { get; protected set; }
 
-        /**
-         * {@inheritDoc}
-         */
-        public bool enable_animations { get; protected set; }
-
         public ScreenShield? screen_shield { get; private set; }
 
         public PointerLocator pointer_locator { get; private set; }
@@ -104,7 +99,6 @@ namespace Gala {
 #endif
         private Clutter.Actor latest_window_snapshot;
 
-        private GLib.Settings animations_settings;
         private GLib.Settings behavior_settings;
         private GLib.Settings new_behavior_settings;
 
@@ -132,11 +126,8 @@ namespace Gala {
             info = Meta.PluginInfo () {name = "Gala", version = Config.VERSION, author = "Gala Developers",
                 license = "GPLv3", description = "A nice elementary window manager"};
 
-            animations_settings = new GLib.Settings ("io.elementary.desktop.wm.animations");
-            animations_settings.bind ("enable-animations", this, "enable-animations", GLib.SettingsBindFlags.GET);
             behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
             new_behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
-            enable_animations = animations_settings.get_boolean ("enable-animations");
 
             //Make it start watching the settings daemon bus
             Drawing.StyleManager.get_instance ();
@@ -618,7 +609,7 @@ namespace Gala {
         }
 
         private void play_nudge_animation (Meta.MotionDirection direction) {
-            if (!enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 return;
             }
 
@@ -738,7 +729,7 @@ namespace Gala {
             }
 
             unowned var bottom_actor = (Meta.WindowActor) bottom_window.get_compositor_private ();
-            if (enable_animations) {
+            if (AnimationsSettings.get_enable_animations ()) {
                 animate_bottom_window_scale (bottom_actor);
             }
 
@@ -766,7 +757,7 @@ namespace Gala {
                 }
 
                 unowned var actor = (Meta.WindowActor) window.get_compositor_private ();
-                if (enable_animations) {
+                if (AnimationsSettings.get_enable_animations ()) {
                     var op_trans = new Clutter.KeyframeTransition ("opacity") {
                         duration = fade_out_duration,
                         remove_on_complete = true,
@@ -1179,7 +1170,7 @@ namespace Gala {
             tile_preview.set_size (rect.width, rect.height);
             tile_preview.show ();
 
-            if (enable_animations) {
+            if (AnimationsSettings.get_enable_animations ()) {
                 tile_preview.save_easing_state ();
                 tile_preview.set_easing_mode (Clutter.AnimationMode.EASE_IN_OUT_QUAD);
                 tile_preview.set_easing_duration (duration);
@@ -1267,7 +1258,7 @@ namespace Gala {
             which_change = which_change_local;
             old_rect_size_change = old_frame_rect;
 
-            if (enable_animations) {
+            if (AnimationsSettings.get_enable_animations ()) {
                 latest_window_snapshot = Utils.get_window_actor_snapshot (actor, old_frame_rect);
             }
         }
@@ -1311,14 +1302,13 @@ namespace Gala {
         }
 
         public override void minimize (Meta.WindowActor actor) {
-            var duration = AnimationDuration.HIDE;
-
-            if (!enable_animations
-                || duration == 0
-                || actor.get_meta_window ().window_type != Meta.WindowType.NORMAL) {
+            if (!AnimationsSettings.get_enable_animations () ||
+                actor.get_meta_window ().window_type != Meta.WindowType.NORMAL) {
                 minimize_completed (actor);
                 return;
             }
+
+            var duration = AnimationDuration.HIDE;
 
             kill_window_effects (actor);
             minimizing.add (actor);
@@ -1382,12 +1372,11 @@ namespace Gala {
         }
 
         private void maximize (Meta.WindowActor actor, int ex, int ey, int ew, int eh) {
-            var duration = AnimationDuration.SNAP;
-
-            if (!enable_animations
-                || duration == 0) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 return;
             }
+
+            var duration = AnimationDuration.SNAP;
 
             kill_window_effects (actor);
 
@@ -1470,15 +1459,13 @@ namespace Gala {
         }
 
         public override void unminimize (Meta.WindowActor actor) {
-            var duration = AnimationDuration.HIDE;
-
-            if (!enable_animations
-                || duration == 0) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 actor.show ();
                 unminimize_completed (actor);
                 return;
             }
 
+            var duration = AnimationDuration.HIDE;
             unowned var window = actor.get_meta_window ();
 
             actor.remove_all_transitions ();
@@ -1530,13 +1517,13 @@ namespace Gala {
             // (also regardless of the animation setting)
             if (NotificationStack.is_notification (window)) {
                 clutter_actor_reparent (actor, notification_group);
-                notification_stack.show_notification (actor, enable_animations);
+                notification_stack.show_notification (actor);
 
                 map_completed (actor);
                 return;
             }
 
-            if (!enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 map_completed (actor);
 
                 if (InternalUtils.get_window_is_normal (window) && window.get_layer () == Meta.StackLayer.BOTTOM) {
@@ -1657,13 +1644,13 @@ namespace Gala {
             actor.remove_all_transitions ();
 
             if (NotificationStack.is_notification (window)) {
-                if (enable_animations) {
+                if (AnimationsSettings.get_enable_animations ()) {
                     destroying.add (actor);
                 }
 
-                notification_stack.destroy_notification (actor, enable_animations);
+                notification_stack.destroy_notification (actor);
 
-                if (enable_animations) {
+                if (AnimationsSettings.get_enable_animations ()) {
                     ulong destroy_handler_id = 0UL;
                     destroy_handler_id = actor.transitions_completed.connect (() => {
                         actor.disconnect (destroy_handler_id);
@@ -1677,7 +1664,7 @@ namespace Gala {
                 return;
             }
 
-            if (!enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 destroy_completed (actor);
 
                 if (window.window_type == Meta.WindowType.NORMAL) {
@@ -1766,11 +1753,11 @@ namespace Gala {
         }
 
         private void unmaximize (Meta.WindowActor actor, int ex, int ey, int ew, int eh) {
-            var duration = AnimationDuration.SNAP;
-            if (!enable_animations
-                || duration == 0) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 return;
             }
+
+            var duration = AnimationDuration.SNAP;
 
             kill_window_effects (actor);
             unowned var window = actor.get_meta_window ();
@@ -2147,8 +2134,7 @@ namespace Gala {
         }
 
         public override void switch_workspace (int from, int to, Meta.MotionDirection direction) {
-            if (!enable_animations
-                || AnimationDuration.WORKSPACE_SWITCH == 0
+            if (!AnimationsSettings.get_enable_animations ()
                 || (direction != Meta.MotionDirection.LEFT && direction != Meta.MotionDirection.RIGHT)
                 || animating_switch_workspace
                 || workspace_view.is_opened ()
@@ -2168,7 +2154,7 @@ namespace Gala {
                 if (NotificationStack.is_notification (window)) {
                     unowned var actor = (Meta.WindowActor) window.get_compositor_private ();
                     clutter_actor_reparent (actor, notification_group);
-                    notification_stack.show_notification (actor, enable_animations);
+                    notification_stack.show_notification (actor);
                 }
             });
 

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -52,13 +52,13 @@ public class Gala.Zoom : Object {
     [CCode (instance_pos = -1)]
     private void zoom_in (Meta.Display display, Meta.Window? window,
         Clutter.KeyEvent event, Meta.KeyBinding binding) {
-        zoom (SHORTCUT_DELTA, true, wm.enable_animations);
+        zoom (SHORTCUT_DELTA, true, AnimationsSettings.get_enable_animations ());
     }
 
     [CCode (instance_pos = -1)]
     private void zoom_out (Meta.Display display, Meta.Window? window,
         Clutter.KeyEvent event, Meta.KeyBinding binding) {
-        zoom (-SHORTCUT_DELTA, true, wm.enable_animations);
+        zoom (-SHORTCUT_DELTA, true, AnimationsSettings.get_enable_animations ());
     }
 
     private void on_gesture_detected (Gesture gesture) {
@@ -85,7 +85,7 @@ public class Gala.Zoom : Object {
             var zoom_level = GestureTracker.animation_value (initial_zoom, target_zoom, percentage);
             var delta = zoom_level - current_zoom;
 
-            if (!wm.enable_animations) {
+            if (!AnimationsSettings.get_enable_animations ()) {
                 if (delta.abs () >= SHORTCUT_DELTA) {
                     delta = (delta > 0) ? SHORTCUT_DELTA : -SHORTCUT_DELTA;
                 } else {


### PR DESCRIPTION
Moves WindowManager.enable_animations to a separate AnimationsSettings namespace. There are a lot of objects that use wm only to get that value, in this case AnimationsSettings will simplify that. Also will help avoid passing window manager object all over the code.

Motivated by a duplicate enable_animations value in https://github.com/elementary/gala/pull/2074