### PR TITLE
PanelWindow: Don't use custom size for positioning, correct y for bottom panels

### DIFF
--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -75,6 +75,11 @@ public class Gala.PanelWindow : Object {
 
         if (height > 0) {
             window_rect.height = height;
+
+            if (anchor == BOTTOM) {
+                var geom = wm.get_display ().get_monitor_geometry (window.get_monitor ());
+                window_rect.y = geom.y + geom.height - height;
+            }
         }
 
         return window_rect;
@@ -98,7 +103,7 @@ public class Gala.PanelWindow : Object {
     private void position_window () {
         var display = wm.get_display ();
         var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
-        var window_rect = get_custom_window_rect ();
+        var window_rect = window.get_frame_rect ();
 
         switch (anchor) {
             case TOP:


### PR DESCRIPTION
Required for elementary/dock#307.

For positioning we should always use the full size.

If we are at the bottom we need to update the y coordinate for the custom rect so that it's plane with the screen edge otherwise we are too far up and have a gap at the bottom.

