### PR TITLE
X11: move dock window out of bounds when hidden

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -36,6 +36,7 @@
         </ul>
       </description>
       <issues>
+        <issue url="https://github.com/elementary/gala/issues/2101">Dock interacts with the mouse even with the window overlapping</issue>
       </issues>
     </release>
 

--- a/src/ShellClients/DelegateActor.vala
+++ b/src/ShellClients/DelegateActor.vala
@@ -4,7 +4,7 @@
  */
 
 /* This class is used to workaround https://github.com/elementary/gala/issues/2101 */
-public class Gala.DummyActor : GLib.Object {
+public class Gala.DelegateActor : GLib.Object {
     public const int OUT_OF_BOUNDS = 1000000;
 
     public Meta.WindowActor actor { get; construct; }
@@ -17,14 +17,13 @@ public class Gala.DummyActor : GLib.Object {
     public int actual_x { get; private set; default = 0; }
     public int actual_y { get; private set; default = 0; }
 
-    public DummyActor (Meta.WindowActor actor) {
+    public DelegateActor (Meta.WindowActor actor) {
         Object (actor: actor);
     }
 
     construct {
         actor.meta_window.position_changed.connect ((_window) => {
             var rect = _window.get_frame_rect ();
-            warning ("Position changed %d %d", rect.x, rect.y);
 
             if (rect.x != OUT_OF_BOUNDS) {
                 actual_x = rect.x;

--- a/src/ShellClients/DelegateActor.vala
+++ b/src/ShellClients/DelegateActor.vala
@@ -8,7 +8,7 @@ public class Gala.DelegateActor : GLib.Object {
     public const int OUT_OF_BOUNDS = 1000000;
 
     public Meta.WindowActor actor { get; construct; }
-    
+
     /* Current window actor position or position before the window was moved out of bounds */
     public float x { get; private set; default = 0.0f; }
     public float y { get; private set; default = 0.0f; }

--- a/src/ShellClients/DummyActor.vala
+++ b/src/ShellClients/DummyActor.vala
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
+ */
+
+/* This class is used to workaround https://github.com/elementary/gala/issues/2101 */
+public class Gala.DummyActor : GLib.Object {
+    public const int OUT_OF_BOUNDS = 1000000;
+
+    public Meta.WindowActor actor { get; construct; }
+    
+    /* Current window actor position or position before the window was moved out of bounds */
+    public float x { get; private set; default = 0.0f; }
+    public float y { get; private set; default = 0.0f; }
+
+    /* Current window position or position before it was moved out of bounds */
+    public int actual_x { get; private set; default = 0; }
+    public int actual_y { get; private set; default = 0; }
+
+    public DummyActor (Meta.WindowActor actor) {
+        Object (actor: actor);
+    }
+
+    construct {
+        actor.meta_window.position_changed.connect ((_window) => {
+            var rect = _window.get_frame_rect ();
+            warning ("Position changed %d %d", rect.x, rect.y);
+
+            if (rect.x != OUT_OF_BOUNDS) {
+                actual_x = rect.x;
+                Idle.add_once (() => {
+                    x = actor.x;
+                });
+            }
+            if (rect.y != OUT_OF_BOUNDS) {
+                actual_y = rect.y;
+                Idle.add_once (() => {
+                    y = actor.y;
+                });
+            }
+        });
+    }
+}

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -48,8 +48,8 @@ public class Gala.PanelClone : Object {
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
         // WindowActor position and Window position aren't necessarily the same.
         // The clone needs the actor position
-        panel.dummy_actor.notify["x"].connect (update_clone_position);
-        panel.dummy_actor.notify["y"].connect (update_clone_position);
+        panel.delegate_actor.notify["x"].connect (update_clone_position);
+        panel.delegate_actor.notify["y"].connect (update_clone_position);
         // Actor visibility might be changed by something else e.g. workspace switch
         // but we want to keep it in sync with us
         actor.notify["visible"].connect (update_visible);
@@ -97,7 +97,7 @@ public class Gala.PanelClone : Object {
         switch (panel.anchor) {
             case TOP:
             case BOTTOM:
-                return panel.dummy_actor.x;
+                return panel.delegate_actor.x;
             default:
                 return 0;
         }
@@ -106,9 +106,9 @@ public class Gala.PanelClone : Object {
     private float calculate_clone_y (bool hidden) {
         switch (panel.anchor) {
             case TOP:
-                return hidden ? panel.dummy_actor.y - actor.height : panel.dummy_actor.y;
+                return hidden ? panel.delegate_actor.y - actor.height : panel.delegate_actor.y;
             case BOTTOM:
-                return hidden ? panel.dummy_actor.y + actor.height : panel.dummy_actor.y;
+                return hidden ? panel.delegate_actor.y + actor.height : panel.delegate_actor.y;
             default:
                 return 0;
         }
@@ -128,7 +128,7 @@ public class Gala.PanelClone : Object {
         panel_hidden = true;
 
         if (!Meta.Util.is_wayland_compositor ()) {
-            panel.window.move_frame (false, DummyActor.OUT_OF_BOUNDS, DummyActor.OUT_OF_BOUNDS);
+            panel.window.move_frame (false, DelegateActor.OUT_OF_BOUNDS, DelegateActor.OUT_OF_BOUNDS);
         }
 
         if (panel.anchor != TOP && panel.anchor != BOTTOM) {
@@ -151,7 +151,7 @@ public class Gala.PanelClone : Object {
         }
 
         if (!Meta.Util.is_wayland_compositor ()) {
-            panel.window.move_frame (false, panel.dummy_actor.actual_x, panel.dummy_actor.actual_y);
+            panel.window.move_frame (false, panel.delegate_actor.actual_x, panel.delegate_actor.actual_y);
         }
 
         var animation_duration = get_animation_duration ();

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -48,8 +48,8 @@ public class Gala.PanelClone : Object {
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
         // WindowActor position and Window position aren't necessarily the same.
         // The clone needs the actor position
-        actor.notify["x"].connect (update_clone_position);
-        actor.notify["y"].connect (update_clone_position);
+        panel.dummy_actor.notify["x"].connect (update_clone_position);
+        panel.dummy_actor.notify["y"].connect (update_clone_position);
         // Actor visibility might be changed by something else e.g. workspace switch
         // but we want to keep it in sync with us
         actor.notify["visible"].connect (update_visible);
@@ -97,7 +97,7 @@ public class Gala.PanelClone : Object {
         switch (panel.anchor) {
             case TOP:
             case BOTTOM:
-                return actor.x;
+                return panel.dummy_actor.x;
             default:
                 return 0;
         }
@@ -106,9 +106,9 @@ public class Gala.PanelClone : Object {
     private float calculate_clone_y (bool hidden) {
         switch (panel.anchor) {
             case TOP:
-                return hidden ? actor.y - actor.height : actor.y;
+                return hidden ? panel.dummy_actor.y - actor.height : panel.dummy_actor.y;
             case BOTTOM:
-                return hidden ? actor.y + actor.height : actor.y;
+                return hidden ? panel.dummy_actor.y + actor.height : panel.dummy_actor.y;
             default:
                 return 0;
         }
@@ -127,6 +127,10 @@ public class Gala.PanelClone : Object {
 
         panel_hidden = true;
 
+        if (!Meta.Util.is_wayland_compositor ()) {
+            panel.window.move_frame (false, DummyActor.OUT_OF_BOUNDS, DummyActor.OUT_OF_BOUNDS);
+        }
+
         if (panel.anchor != TOP && panel.anchor != BOTTOM) {
             warning ("Animated hide not supported for side yet.");
             return;
@@ -144,6 +148,10 @@ public class Gala.PanelClone : Object {
     private void show () {
         if (!panel_hidden) {
             return;
+        }
+
+        if (!Meta.Util.is_wayland_compositor ()) {
+            panel.window.move_frame (false, panel.dummy_actor.actual_x, panel.dummy_actor.actual_y);
         }
 
         var animation_duration = get_animation_duration ();

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -15,6 +15,7 @@ public class Gala.PanelWindow : Object {
 
     public Meta.Side anchor;
 
+    public DummyActor dummy_actor;
     private PanelClone clone;
 
     private uint idle_move_id = 0;
@@ -45,6 +46,7 @@ public class Gala.PanelWindow : Object {
 
         window.stick ();
 
+        dummy_actor = new DummyActor ((Meta.WindowActor) window.get_compositor_private ());
         clone = new PanelClone (wm, this);
 
         var monitor_manager = wm.get_display ().get_context ().get_backend ().get_monitor_manager ();
@@ -62,6 +64,8 @@ public class Gala.PanelWindow : Object {
     public Meta.Rectangle get_custom_window_rect () {
 #endif
         var window_rect = window.get_frame_rect ();
+        window_rect.x = dummy_actor.actual_x;
+        window_rect.y = dummy_actor.actual_y;
 
         if (width > 0) {
             window_rect.width = width;

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -15,7 +15,7 @@ public class Gala.PanelWindow : Object {
 
     public Meta.Side anchor;
 
-    public DummyActor dummy_actor;
+    public DelegateActor delegate_actor;
     private PanelClone clone;
 
     private uint idle_move_id = 0;
@@ -46,7 +46,7 @@ public class Gala.PanelWindow : Object {
 
         window.stick ();
 
-        dummy_actor = new DummyActor ((Meta.WindowActor) window.get_compositor_private ());
+        delegate_actor = new DelegateActor ((Meta.WindowActor) window.get_compositor_private ());
         clone = new PanelClone (wm, this);
 
         var monitor_manager = wm.get_display ().get_context ().get_backend ().get_monitor_manager ();
@@ -64,8 +64,8 @@ public class Gala.PanelWindow : Object {
     public Meta.Rectangle get_custom_window_rect () {
 #endif
         var window_rect = window.get_frame_rect ();
-        window_rect.x = dummy_actor.actual_x;
-        window_rect.y = dummy_actor.actual_y;
+        window_rect.x = delegate_actor.actual_x;
+        window_rect.y = delegate_actor.actual_y;
 
         if (width > 0) {
             window_rect.width = width;

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,7 @@ gala_bin_sources = files(
     'HotCorners/Barrier.vala',
     'HotCorners/HotCorner.vala',
     'HotCorners/HotCornerManager.vala',
+    'ShellClients/DummyActor.vala',
     'ShellClients/HideTracker.vala',
     'ShellClients/ManagedClient.vala',
     'ShellClients/NotificationsClient.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,7 +41,7 @@ gala_bin_sources = files(
     'HotCorners/Barrier.vala',
     'HotCorners/HotCorner.vala',
     'HotCorners/HotCornerManager.vala',
-    'ShellClients/DummyActor.vala',
+    'ShellClients/DelegateActor.vala',
     'ShellClients/HideTracker.vala',
     'ShellClients/ManagedClient.vala',
     'ShellClients/NotificationsClient.vala',


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2101

This is very very bad code but I just couldn't find other solution. So far I tried:
* Minimizing window
* Using `_NET_WM_STATE_HIDDEN` (which is basically minimizing AFAIK)
* Blocking X11 window events by changing its event mask
* Using XShape extension

Nothing worked. If you know any other solution please let me know.