### PR TITLE
Smoother session start

### DIFF
--- a/src/PantheonShell.vala
+++ b/src/PantheonShell.vala
@@ -243,25 +243,7 @@ namespace Gala {
             return;
         }
 
-        Meta.Side side = TOP;
-        switch (anchor) {
-            case TOP:
-                break;
-
-            case BOTTOM:
-                side = BOTTOM;
-                break;
-
-            case LEFT:
-                side = LEFT;
-                break;
-
-            case RIGHT:
-                side = RIGHT;
-                break;
-        }
-
-        ShellClientsManager.get_instance ().set_anchor (window, side);
+        ShellClientsManager.get_instance ().set_anchor (window, anchor);
     }
 
     internal static void focus_panel (Wl.Client client, Wl.Resource resource) {

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -152,7 +152,13 @@ public class Gala.HideTracker : Object {
         });
     }
 
-    private void update_overlap () {
+    /**
+     * Immediately updates the overlap. Usually {@link schedule_update} should be used instead which
+     * internally calls this but throttles it since it's a somewhat expensive operation.
+     * On very rare use cases however it is required to update immediately. In that case you can call
+     * this directly.
+     */
+    public void update_overlap () {
         overlap = false;
         focus_overlap = false;
         focus_maximized_overlap = false;

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -16,17 +16,7 @@ public class Gala.HideTracker : Object {
     public Meta.Display display { get; construct; }
     public unowned PanelWindow panel { get; construct; }
 
-    private Pantheon.Desktop.HideMode _hide_mode = NEVER;
-    public Pantheon.Desktop.HideMode hide_mode {
-        get {
-            return _hide_mode;
-        }
-        set {
-            _hide_mode = value;
-
-            setup_barrier ();
-        }
-    }
+    public Pantheon.Desktop.HideMode hide_mode { get; set; }
 
     private Clutter.PanAction pan_action;
 
@@ -97,6 +87,16 @@ public class Gala.HideTracker : Object {
         pan_action.pan.connect (on_pan);
 
         display.get_stage ().add_action_full ("panel-swipe-gesture", CAPTURE, pan_action);
+
+        panel.notify["anchor"].connect (setup_barrier);
+
+        var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
+        monitor_manager.monitors_changed.connect (() => {
+            setup_barrier (); //Make sure barriers are still on the primary monitor
+            schedule_update ();
+        });
+
+        setup_barrier ();
     }
 
 #if !HAS_MUTTER45
@@ -171,7 +171,7 @@ public class Gala.HideTracker : Object {
                 continue;
             }
 
-            if (!panel.get_custom_window_rect ().overlap (window.get_frame_rect ())) {
+            if (!panel.window.get_frame_rect ().overlap (window.get_frame_rect ())) {
                 continue;
             }
 

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -143,16 +143,16 @@ public class Gala.ShellClientsManager : Object {
         xdisplay.change_property (x_window, atom, (X.Atom) 4, 32, 0, (uchar[]) dock_atom, 1);
     }
 
-    public void set_anchor (Meta.Window window, Meta.Side side) {
+    public void set_anchor (Meta.Window window, Pantheon.Desktop.Anchor anchor) {
         if (window in panel_windows) {
-            panel_windows[window].update_anchor (side);
+            panel_windows[window].anchor = anchor;
             return;
         }
 
         make_dock (window);
         // TODO: Return if requested by window that's not a trusted client?
 
-        panel_windows[window] = new PanelWindow (wm, window, side);
+        panel_windows[window] = new PanelWindow (wm, window, anchor);
 
         // connect_after so we make sure the PanelWindow can destroy its barriers and struts
         window.unmanaging.connect_after ((_window) => panel_windows.remove (_window));
@@ -226,8 +226,30 @@ public class Gala.ShellClientsManager : Object {
 
             switch (key) {
                 case "anchor":
-                    int parsed; // Will be used as Meta.Side which is a 4 value bitfield so check bounds for that
-                    if (int.try_parse (val, out parsed) && 0 <= parsed && parsed <= 15) {
+                    int meta_side_parsed; // Will be used as Meta.Side which is a 4 value bitfield so check bounds for that
+                    if (int.try_parse (val, out meta_side_parsed) && 0 <= meta_side_parsed && meta_side_parsed <= 15) {
+                        //FIXME: Next major release change dock and wingpanel calls to get rid of this
+                        Pantheon.Desktop.Anchor parsed = TOP;
+                        switch ((Meta.Side) meta_side_parsed) {
+                            case BOTTOM:
+                                parsed = BOTTOM;
+                                break;
+
+                            case LEFT:
+                                parsed = LEFT;
+                                break;
+
+                            case RIGHT:
+                                parsed = RIGHT;
+                                break;
+
+                            default:
+                                break;
+                        }
+
+                        set_anchor (window, parsed);
+                        // We need to set a second time because the intention is to call this before the window is shown which it is on wayland
+                        // but on X the window was already shown when we get here so we have to call again to instantly apply it.
                         set_anchor (window, parsed);
                     } else {
                         warning ("Failed to parse %s as anchor", val);

--- a/src/ShellClients/WindowPositioner.vala
+++ b/src/ShellClients/WindowPositioner.vala
@@ -7,13 +7,28 @@
 
 public class Gala.WindowPositioner : Object {
     public enum Position {
-        CENTER
+        TOP,
+        BOTTOM,
+        CENTER;
+
+        public static Position from_anchor (Pantheon.Desktop.Anchor anchor) {
+            if (anchor > 1) {
+                warning ("Position %s not supported yet", anchor.to_string ());
+                return CENTER;
+            }
+
+            return (Position) anchor;
+        }
     }
 
     public Meta.Display display { get; construct; }
     public Meta.Window window { get; construct; }
-    public Position position { get; private set; }
-    public Variant? position_data { get; private set; }
+    /**
+     * This may only be set after the window was shown.
+     * The initial position should only be given in the constructor.
+     */
+    public Position position { get; construct set; }
+    public Variant? position_data { get; construct set; }
 
     public WindowPositioner (Meta.Display display, Meta.Window window, Position position, Variant? position_data = null) {
         Object (display: display, window: window, position: position, position_data: position_data);
@@ -29,28 +44,33 @@ public class Gala.WindowPositioner : Object {
         unowned var monitor_manager = display.get_context ().get_backend ().get_monitor_manager ();
         monitor_manager.monitors_changed.connect (position_window);
         monitor_manager.monitors_changed_internal.connect (position_window);
-    }
 
-    /**
-     * This may only be called after the window was shown.
-     */
-    public void update_position (Position new_position, Variant? new_position_data = null) {
-        position = new_position;
-        position_data = new_position_data;
-
-        position_window ();
+        notify["position"].connect (position_window);
+        notify["position-data"].connect (position_window);
     }
 
     private void position_window () {
         int x = 0, y = 0;
 
+        var window_rect = window.get_frame_rect ();
+
         switch (position) {
             case CENTER:
                 var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
-                var window_rect = window.get_frame_rect ();
-
                 x = monitor_geom.x + (monitor_geom.width - window_rect.width) / 2;
                 y = monitor_geom.y + (monitor_geom.height - window_rect.height) / 2;
+                break;
+
+            case TOP:
+                var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
+                x = monitor_geom.x + (monitor_geom.width - window_rect.width) / 2;
+                y = monitor_geom.y;
+                break;
+
+            case BOTTOM:
+                var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
+                x = monitor_geom.x + (monitor_geom.width - window_rect.width) / 2;
+                y = monitor_geom.y + monitor_geom.height - window_rect.height;
                 break;
         }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -398,13 +398,13 @@ namespace Gala {
 
             stage.show ();
 
-            Idle.add (() => {
+            Idle.add_once (() => {
                 // let the session manager move to the next phase
 #if WITH_SYSTEMD
                 Systemd.Daemon.notify (true, "READY=1");
 #endif
-                display.get_context ().notify_ready ();
-                return GLib.Source.REMOVE;
+                get_display ().get_context ().notify_ready ();
+                ShellClientsManager.get_instance ().notify_stage_ready ();
             });
         }
 


### PR DESCRIPTION
For easier review do the individual commits (or rather 87b7321 only since the other one is just #2109 squashed)

Rebase merge if merged before #2109

Ok this is now mostly for wayland because on X the window was already shown when we know it's a panel so we can't really say wait for anything.

On wayland the way it now works is we wait for all clients that have requested being a panel to show and then immediately reveal them in sync. As a fail safe the WM lets the ShellClientsManager know when the stage is ready which will start a 5 second timer which will reveal all clients that are ready. After the panels have been revealed the first time we won't do anything like that again until the next session start so e.g. when a panel crashes and restarts it will show as soon as it's ready.

Unfortunately I can't make a recording since it's at session start but if you try it you should definitely see it :)