### PR TITLE
Shortcuts: Add an interactive screenshot shortcut

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -76,6 +76,11 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="s" name="interactive-screenshot-action">
+      <default>'flatpak run io.elementary.screenshot'</default>
+      <summary>Interactive screenshot action</summary>
+      <description>Sets the command to run when the interactive-screenshot keybinding is pressed.</description>
+    </key>
     <key type="b" name="move-maximized-workspace">
       <default>false</default>
       <summary>Automatically move maximized windows to a new workspace</summary>

--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -144,6 +144,10 @@
       <default><![CDATA[['Print']]]></default>
       <summary>Take a screenshot</summary>
     </key>
+    <key name="interactive-screenshot" type="as">
+      <default><![CDATA[['<Super>Print']]]></default>
+      <summary>Launch the interactive screenshot tool</summary>
+    </key>
     <key name="window-screenshot" type="as">
       <default><![CDATA[['<Alt>Print']]]></default>
       <summary>Take a screenshot of a window</summary>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -255,6 +255,7 @@ namespace Gala {
             display.add_keybinding ("switch-input-source-backward", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_switch_input_source);
 
             display.add_keybinding ("screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
+            display.add_keybinding ("interactive-screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
             display.add_keybinding ("window-screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
             display.add_keybinding ("area-screenshot", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
             display.add_keybinding ("screenshot-clip", keybinding_settings, Meta.KeyBindingFlags.IGNORE_AUTOREPEAT, (Meta.KeyHandlerFunc) handle_screenshot);
@@ -515,6 +516,13 @@ namespace Gala {
             switch (binding.get_name ()) {
                 case "screenshot":
                     screenshot_screen.begin ();
+                    break;
+                case "interactive-screenshot":
+                    try {
+                        Process.spawn_command_line_async ("io.elementary.screenshot");
+                    } catch (Error e) {
+                        warning ("Failed to launch interactive screenshot: %s", e.message);
+                    }
                     break;
                 case "area-screenshot":
                     screenshot_area.begin ();

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -518,11 +518,7 @@ namespace Gala {
                     screenshot_screen.begin ();
                     break;
                 case "interactive-screenshot":
-                    try {
-                        Process.spawn_command_line_async ("io.elementary.screenshot");
-                    } catch (Error e) {
-                        warning ("Failed to launch interactive screenshot: %s", e.message);
-                    }
+                    launch_action ("interactive-screenshot-action");
                     break;
                 case "area-screenshot":
                     screenshot_area.begin ();


### PR DESCRIPTION
Add a keyboard shortcut to launch the screenshot app.
Default is `Super` + `Print`

This is useful as an alternative to having to remember all of the shortcuts for screen, window, area and their clipboard variants or just in general if you prefer the interactive way.
As a bonus it also has the save dialog.
(As prior art: e.g. GNOME launches its interactive UI by default for the Print key, windows has snipping tool, etc.)

Needs to be added to the keyboard plug