### PR TITLE
HideTracker: Remove queued update in destructor

### DIFF
--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -51,6 +51,10 @@ public class Gala.HideTracker : Object {
         if (hide_timeout_id != 0) {
             Source.remove (hide_timeout_id);
         }
+
+        if (update_timeout_id != 0) {
+            Source.remove (update_timeout_id);
+        }
     }
 
     construct {


### PR DESCRIPTION
Fixes a rare crash that occurred when a panel client was killed while an overlap update was queued.