### PR TITLE
WindowClone: Show small, transparent thumbnail during DND

### DIFF
--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -159,8 +159,6 @@ public class Gala.WindowClone : Clutter.Actor {
     }
 
     private void reallocate () {
-        var window_frame_rect = window.get_frame_rect ();
-
         close_button = new Gala.CloseButton (monitor_scale_factor) {
             opacity = 0
         };
@@ -169,7 +167,6 @@ public class Gala.WindowClone : Clutter.Actor {
         window_icon = new WindowIcon (window, WINDOW_ICON_SIZE, (int)Math.round (monitor_scale_factor));
         window_icon.opacity = 0;
         window_icon.set_pivot_point (0.5f, 0.5f);
-        set_window_icon_position (window_frame_rect.width, window_frame_rect.height, monitor_scale_factor);
 
         add_child (close_button);
         add_child (window_icon);
@@ -276,16 +273,8 @@ public class Gala.WindowClone : Clutter.Actor {
 
         unowned var display = window.get_display ();
         var monitor_geom = display.get_monitor_geometry (window.get_monitor ());
-        var initial_scale = monitor_scale_factor;
-        var target_scale = display.get_monitor_scale (window.get_monitor ());
-        var offset_x = monitor_geom.x;
-        var offset_y = monitor_geom.y;
-
-        var initial_width = width;
-        var initial_height = height;
-
-        var target_x = outer_rect.x - offset_x;
-        var target_y = outer_rect.y - offset_y;
+        var target_x = outer_rect.x - monitor_geom.x;
+        var target_y = outer_rect.y - monitor_geom.y;
 
         active = false;
         update_hover_widgets (true);
@@ -297,35 +286,8 @@ public class Gala.WindowClone : Clutter.Actor {
         new GesturePropertyTransition (this, gesture_tracker, "shadow-opacity", (uint8) 255, (uint8) 0).start (with_gesture);
         new GesturePropertyTransition (window_icon, gesture_tracker, "opacity", 255u, 0u).start (with_gesture, () => {
             update_hover_widgets (false);
-        });
-
-        GestureTracker.OnUpdate on_animation_update = (percentage) => {
-            var width = GestureTracker.animation_value (initial_width, outer_rect.width, percentage);
-            var height = GestureTracker.animation_value (initial_height, outer_rect.height, percentage);
-            var scale = GestureTracker.animation_value (initial_scale, target_scale, percentage);
-
-            set_window_icon_position (width, height, scale, false);
-        };
-
-        GestureTracker.OnEnd on_animation_end = (percentage, cancel_action) => {
-            if (cancel_action) {
-                return;
-            }
-
             toggle_shadow (false);
-
-            window_icon.save_easing_state ();
-            window_icon.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-            window_icon.set_easing_duration (AnimationsSettings.get_animation_duration (MultitaskingView.ANIMATION_DURATION));
-            set_window_icon_position (outer_rect.width, outer_rect.height, target_scale);
-            window_icon.restore_easing_state ();
-        };
-
-        if (gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
-            on_animation_end (1, false, 0);
-        } else {
-            gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
-        }
+        });
     }
 
     /**
@@ -348,10 +310,7 @@ public class Gala.WindowClone : Clutter.Actor {
         float intial_x = from_window_position ? outer_rect.x - monitor_geom.x : x;
         float intial_y = from_window_position ? outer_rect.y - monitor_geom.y : y;
 
-        var scale = display.get_monitor_scale (display.get_monitor_index_for_rect (rect));
-
         update_hover_widgets (true);
-        set_window_icon_position (initial_width, initial_height, scale);
 
         new GesturePropertyTransition (this, gesture_tracker, "x", intial_x, (float) rect.x).start (with_gesture);
         new GesturePropertyTransition (this, gesture_tracker, "y", intial_y, (float) rect.y).start (with_gesture);
@@ -360,42 +319,14 @@ public class Gala.WindowClone : Clutter.Actor {
         new GesturePropertyTransition (this, gesture_tracker, "shadow-opacity", (uint8) 0, (uint8) 255).start (with_gesture);
         new GesturePropertyTransition (window_icon, gesture_tracker, "opacity", 0u, 255u).start (with_gesture, () => {
             update_hover_widgets (false);
-        });
-
-        GestureTracker.OnUpdate on_animation_update = (percentage) => {
-            var width = GestureTracker.animation_value (initial_width, rect.width, percentage);
-            var height = GestureTracker.animation_value (initial_height, rect.height, percentage);
-
-            set_window_icon_position (width, height, scale, false);
-        };
-
-        GestureTracker.OnEnd on_animation_end = (percentage, cancel_action) => {
-            if (cancel_action) {
-                return;
-            }
-
-            var duration = AnimationsSettings.get_animation_duration (MultitaskingView.ANIMATION_DURATION);
-
-            window_icon.save_easing_state ();
-            window_icon.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-            window_icon.set_easing_duration (duration);
-            set_window_icon_position (rect.width, rect.height, scale);
-            window_icon.restore_easing_state ();
-
             toggle_shadow (true);
-        };
-
-        if (gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
-            on_animation_end (1, false, 0);
-        } else {
-            gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
-        }
+        });
     }
 
     public override void allocate (Clutter.ActorBox box) {
         base.allocate (box);
 
-        if (clone == null || (drag_action != null && drag_action.dragging)) {
+        if (clone == null) {
             return;
         }
 
@@ -448,6 +379,13 @@ public class Gala.WindowClone : Clutter.Actor {
 
         var window_title_alloc = InternalUtils.actor_box_from_rect (window_title_x, window_title_y, window_title_width, window_title_height);
         window_title.allocate (window_title_alloc);
+
+        var window_icon_size = InternalUtils.scale_to_int (WINDOW_ICON_SIZE, monitor_scale);
+        var window_icon_x = (box.get_width () - window_icon_size) / 2;
+        var window_icon_y = box.get_height () - (window_icon_size * 0.75f);
+
+        var window_icon_alloc = InternalUtils.actor_box_from_rect (window_icon_x, window_icon_y, window_icon_size, window_icon_size);
+        window_icon.allocate (window_icon_alloc);
     }
 
 #if HAS_MUTTER45
@@ -563,12 +501,8 @@ public class Gala.WindowClone : Clutter.Actor {
      * position we just freed is immediately filled by the WindowCloneContainer.
      */
     private Clutter.Actor drag_begin (float click_x, float click_y) {
-        float abs_x, abs_y;
-        float prev_parent_x, prev_parent_y;
-
         prev_parent = get_parent ();
         prev_index = prev_parent.get_children ().index (this);
-        prev_parent.get_transformed_position (out prev_parent_x, out prev_parent_y);
 
         var stage = get_stage ();
         prev_parent.remove_child (this);
@@ -576,32 +510,22 @@ public class Gala.WindowClone : Clutter.Actor {
 
         active_shape.hide ();
 
-        var scale = window_icon.width / clone.width;
         var duration = AnimationsSettings.get_animation_duration (FADE_ANIMATION_DURATION);
 
-        clone.get_transformed_position (out abs_x, out abs_y);
-        clone.save_easing_state ();
-        clone.set_easing_duration (duration);
-        clone.set_easing_mode (Clutter.AnimationMode.EASE_IN_CUBIC);
-        clone.set_pivot_point ((click_x - abs_x) / clone.width, (click_y - abs_y) / clone.height);
-        clone.set_scale (scale, scale);
-        clone.opacity = 0;
-        clone.restore_easing_state ();
-
-        request_reposition ();
-
+        float abs_x, abs_y;
         get_transformed_position (out abs_x, out abs_y);
 
-        set_position (abs_x + prev_parent_x, abs_y + prev_parent_y);
+        set_position (abs_x, abs_y);
+        set_pivot_point ((click_x - abs_x) / width, (click_y - abs_y) / height);
 
-        window_icon.save_easing_state ();
-        window_icon.set_easing_duration (duration);
-        window_icon.set_easing_mode (Clutter.AnimationMode.EASE_IN_OUT_CUBIC);
-        window_icon.set_position (
-            click_x - (abs_x + prev_parent_x) - window_icon.width / 2,
-            click_y - (abs_y + prev_parent_y) - window_icon.height / 2
-        );
-        window_icon.restore_easing_state ();
+        save_easing_state ();
+        set_easing_duration (duration);
+        set_easing_mode (EASE_IN_CUBIC);
+        set_scale (0.3, 0.3);
+        opacity = 200;
+        restore_easing_state ();
+
+        request_reposition ();
 
         close_button.opacity = 0;
         window_title.opacity = 0;
@@ -742,42 +666,25 @@ public class Gala.WindowClone : Clutter.Actor {
      */
     private void drag_canceled () {
         get_parent ().remove_child (this);
-        prev_parent.insert_child_at_index (this, prev_index);
+        prev_parent.add_child (this); // Add above so that it is above while animates back to its place
 
         var duration = AnimationsSettings.get_animation_duration (MultitaskingView.ANIMATION_DURATION);
 
-        clone.set_pivot_point (0.0f, 0.0f);
-        clone.save_easing_state ();
-        clone.set_easing_duration (duration);
-        clone.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-        clone.set_scale (1, 1);
-        clone.opacity = 255;
-        clone.restore_easing_state ();
+        save_easing_state ();
+        set_easing_duration (duration);
+        set_easing_mode (EASE_OUT_QUAD);
+        set_scale (1, 1);
+        opacity = 255;
+        restore_easing_state ();
 
         request_reposition ();
 
-        window_icon.save_easing_state ();
-        window_icon.set_easing_duration (duration);
-        window_icon.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-
-        set_window_icon_position (slot.width, slot.height, monitor_scale_factor);
-        window_icon.restore_easing_state ();
-
         display.set_cursor (Meta.Cursor.DEFAULT);
-    }
 
-    private void set_window_icon_position (float window_width, float window_height, float scale_factor, bool aligned = true) {
-        var size = InternalUtils.scale_to_int (WINDOW_ICON_SIZE, scale_factor);
-        var x = (window_width - size) / 2;
-        var y = window_height - (size * 0.75f);
-
-        if (aligned) {
-            x = (int) Math.round (x);
-            y = (int) Math.round (y);
-        }
-
-        window_icon.set_size (size, size);
-        window_icon.set_position (x, y);
+        Timeout.add (duration, () => {
+            prev_parent.set_child_at_index (this, prev_index); // Set the correct index so that correct stacking order is kept
+            return Source.REMOVE;
+        });
     }
 
     private static bool is_close_button_on_left () {


### PR DESCRIPTION
Instead of just showing the application icon, we now shrink the whole clone to 30% size and make it a bit transparent when it is grabbed for a drag and drop. I couldn't figure out whether that existed at some point and was replaced with icon only for some reason but I find it more intuitive this way (also e.g. GNOME does it like this).

This also allows us to not special case the window icon position so we can drop a lot of code here.

Fixes #320 