### PR TITLE
WorkspaceManager: Exclude a window that's about to be removed from count

### DIFF
--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -266,10 +266,15 @@ namespace Gala {
 
         /**
          * Get the number of toplevel windows on a workspace excluding those that are
-         * on all workspaces
+         * on all workspaces.
+         *
+         * We need `exclude` here because on Meta.Workspace.window_removed
+         * the windows gets removed from workspace's internal window list but not display's window list
+         * which Meta.Workspace uses for Meta.Workspace.list_windows ().
          *
          * @param workspace The workspace on which to count the windows
          * @param exclude a window to not count
+         * 
          */
         public static uint get_n_windows (Meta.Workspace workspace, bool on_primary = false, Meta.Window? exclude = null) {
             var n = 0;

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -269,11 +269,12 @@ namespace Gala {
          * on all workspaces
          *
          * @param workspace The workspace on which to count the windows
+         * @param exclude a window to not count
          */
-        public static uint get_n_windows (Meta.Workspace workspace, bool on_primary = false) {
+        public static uint get_n_windows (Meta.Workspace workspace, bool on_primary = false, Meta.Window? exclude = null) {
             var n = 0;
             foreach (unowned var window in workspace.list_windows ()) {
-                if (window.on_all_workspaces) {
+                if (window.on_all_workspaces || window == exclude) {
                     continue;
                 }
 

--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -156,7 +156,7 @@ namespace Gala {
             // or we are in modal-mode
             if ((!is_active_workspace || wm.is_modal ())
                 && remove_freeze_count < 1
-                && Utils.get_n_windows (workspace, true) == 0
+                && Utils.get_n_windows (workspace, true, window) == 0
                 && workspace != last_workspace) {
                 remove_workspace (workspace);
             }
@@ -164,7 +164,7 @@ namespace Gala {
             // if window is the second last and empty, make it the last workspace
             if (is_active_workspace
                 && remove_freeze_count < 1
-                && Utils.get_n_windows (workspace, true) == 0
+                && Utils.get_n_windows (workspace, true, window) == 0
                 && workspace.index () == last_workspace_index - 1) {
                 remove_workspace (last_workspace);
             }


### PR DESCRIPTION
Fixes #2145 

Though probably not the same as #2145 (I've seen this one before the gesturepropertytransition got merged and the system version says stable) this probably also fixes #2159 

We have to do this because a window that's about to be removed still appears in the list returned by Meta.Workspace.list_windows when window_removed is emitted (at least if it's just moved and not closed).

Also fixes an inconsistency, where when in the multitasking view, a workspace would be immediately removed when the last window on it was closed but not when it was moved to another one.