### PR TITLE
HideTracker: Use custom window rect for overlap calculation

### DIFF
--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -171,7 +171,7 @@ public class Gala.HideTracker : Object {
                 continue;
             }
 
-            if (!panel.window.get_frame_rect ().overlap (window.get_frame_rect ())) {
+            if (!panel.get_custom_window_rect ().overlap (window.get_frame_rect ())) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes an issue that caused dock to autohide way before a window actually overlapped it (due to elementary/dock#328)