### PR TITLE
Overshoot gestures

### DIFF
--- a/src/Gestures/GesturePropertyTransition.vala
+++ b/src/Gestures/GesturePropertyTransition.vala
@@ -113,6 +113,7 @@ public class Gala.GesturePropertyTransition : Object {
             return;
         }
 
+        // Pre calculate some things, so we don't have to do it on every update
         var from_value_float = value_to_float (actual_from_value);
         var to_value_float = value_to_float (intermediate_value ?? to_value);
         var lower_clamp_int = (int) overshoot_lower_clamp;

--- a/src/Gestures/GesturePropertyTransition.vala
+++ b/src/Gestures/GesturePropertyTransition.vala
@@ -123,19 +123,19 @@ public class Gala.GesturePropertyTransition : Object {
         };
 
         GestureTracker.OnUpdate on_animation_update = (percentage) => {
-            double end_percentage = 0;
+            double stretched_percentage = 0;
             if (percentage < lower_clamp_int) {
-                end_percentage = (percentage - lower_clamp_int) * -(overshoot_lower_clamp - lower_clamp_int);
+                stretched_percentage = (percentage - lower_clamp_int) * -(overshoot_lower_clamp - lower_clamp_int);
             } else if (percentage > upper_clamp_int) {
-                end_percentage = (percentage - upper_clamp_int) * (overshoot_upper_clamp - upper_clamp_int);
+                stretched_percentage = (percentage - upper_clamp_int) * (overshoot_upper_clamp - upper_clamp_int);
             }
 
             percentage = percentage.clamp (lower_clamp_int, upper_clamp_int);
 
             var animation_value = GestureTracker.animation_value (from_value_float, to_value_float, percentage, false);
 
-            if (end_percentage != 0) {
-                animation_value += (float) end_percentage * (to_value_float - from_value_float);
+            if (stretched_percentage != 0) {
+                animation_value += (float) stretched_percentage * (to_value_float - from_value_float);
             }
 
             actor.set_property (property, value_from_float (animation_value));

--- a/src/Gestures/GesturePropertyTransition.vala
+++ b/src/Gestures/GesturePropertyTransition.vala
@@ -57,6 +57,8 @@ public class Gala.GesturePropertyTransition : Object {
      * value of the target property, when calling {@link start}.
      */
     private Value actual_from_value;
+    private float from_value_float; // Only valid in the time between start () and finish ()
+    private float to_value_float; // Only valid in the time between start () and finish ()
 
     private DoneCallback? done_callback;
 
@@ -107,16 +109,17 @@ public class Gala.GesturePropertyTransition : Object {
         }
 
         // Pre calculate some things, so we don't have to do it on every update
-        var from_value_float = value_to_float (actual_from_value);
-        var to_value_float = value_to_float (to_value);
-        var lower_clamp_int = (int) overshoot_lower_clamp;
-        var upper_clamp_int = (int) overshoot_upper_clamp;
+        from_value_float = value_to_float (actual_from_value);
+        to_value_float = value_to_float (to_value);
 
         GestureTracker.OnBegin on_animation_begin = () => {
             actor.set_property (property, actual_from_value);
         };
 
         GestureTracker.OnUpdate on_animation_update = (percentage) => {
+            var lower_clamp_int = (int) overshoot_lower_clamp;
+            var upper_clamp_int = (int) overshoot_upper_clamp;
+
             double stretched_percentage = 0;
             if (percentage < lower_clamp_int) {
                 stretched_percentage = (percentage - lower_clamp_int) * - (overshoot_lower_clamp - lower_clamp_int);
@@ -136,7 +139,7 @@ public class Gala.GesturePropertyTransition : Object {
         };
 
         GestureTracker.OnEnd on_animation_end = (percentage, completions, calculated_duration) => {
-            completions = completions.clamp (lower_clamp_int, upper_clamp_int);
+            completions = completions.clamp ((int) overshoot_lower_clamp, (int) overshoot_upper_clamp);
             var target_value = from_value_float + completions * (to_value_float - from_value_float);
 
             actor.save_easing_state ();

--- a/src/Gestures/GesturePropertyTransition.vala
+++ b/src/Gestures/GesturePropertyTransition.vala
@@ -119,7 +119,7 @@ public class Gala.GesturePropertyTransition : Object {
         GestureTracker.OnUpdate on_animation_update = (percentage) => {
             double stretched_percentage = 0;
             if (percentage < lower_clamp_int) {
-                stretched_percentage = (percentage - lower_clamp_int) * -(overshoot_lower_clamp - lower_clamp_int);
+                stretched_percentage = (percentage - lower_clamp_int) * - (overshoot_lower_clamp - lower_clamp_int);
             } else if (percentage > upper_clamp_int) {
                 stretched_percentage = (percentage - upper_clamp_int) * (overshoot_upper_clamp - upper_clamp_int);
             }

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -187,15 +187,11 @@ public class Gala.GestureTracker : Object {
      * values not divisible by physical pixels.
      * @return The linear animation value at the specified percentage.
      */
-    public static float animation_value (float initial_value, float target_value, double percentage, bool rounded = false, double end_percentage = 0) {
+    public static float animation_value (float initial_value, float target_value, double percentage, bool rounded = false) {
         float value = initial_value;
 
         if (initial_value != target_value) {
             value = ((target_value - initial_value) * (float) percentage) + initial_value;
-        }
-
-        if (end_percentage != 0) {
-            value += (float) end_percentage * (target_value - initial_value);
         }
 
         if (rounded) {

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -88,6 +88,10 @@ public class Gala.GestureTracker : Object {
 
     /**
      * @param percentage Value between 0 and 1.
+     * @param completions How often a full cycle of the gesture was completed in this go. Can be
+     * negative if the gesture was started in one direction but ended in the other. This is used to update
+     * the UI to the according state. 0 for example means that the UI should go back to the same state
+     * it was in before the gesture started.
      */
     public signal void on_end (double percentage, int completions, int calculated_duration);
 

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -89,11 +89,11 @@ public class Gala.GestureTracker : Object {
     /**
      * @param percentage Value between 0 and 1.
      */
-    public signal void on_end (double percentage, bool cancel_action, int calculated_duration);
+    public signal void on_end (double percentage, int completions, int calculated_duration);
 
     public delegate void OnBegin (double percentage);
     public delegate void OnUpdate (double percentage);
-    public delegate void OnEnd (double percentage, bool cancel_action, int calculated_duration);
+    public delegate void OnEnd (double percentage, int completions, int calculated_duration);
 
     /**
      * Backend used if enable_touchpad is called.
@@ -187,11 +187,15 @@ public class Gala.GestureTracker : Object {
      * values not divisible by physical pixels.
      * @return The linear animation value at the specified percentage.
      */
-    public static float animation_value (float initial_value, float target_value, double percentage, bool rounded = false) {
+    public static float animation_value (float initial_value, float target_value, double percentage, bool rounded = false, double end_percentage = 0) {
         float value = initial_value;
 
         if (initial_value != target_value) {
             value = ((target_value - initial_value) * (float) percentage) + initial_value;
+        }
+
+        if (end_percentage != 0) {
+            value += (float) end_percentage * (target_value - initial_value);
         }
 
         if (rounded) {
@@ -244,7 +248,7 @@ public class Gala.GestureTracker : Object {
         int calculated_duration = calculate_end_animation_duration (end_percentage, cancel_action);
 
         if (enabled) {
-            on_end (end_percentage, cancel_action, calculated_duration);
+            on_end (end_percentage, cancel_action ? 0 : 1, calculated_duration);
         }
 
         disconnect_all_handlers ();
@@ -254,8 +258,8 @@ public class Gala.GestureTracker : Object {
         velocity = 0;
     }
 
-    private static double applied_percentage (double percentage, double percentage_delta) {
-        return (percentage - percentage_delta).clamp (0, 1);
+    private static inline double applied_percentage (double percentage, double percentage_delta) {
+        return percentage - percentage_delta;
     }
 
     /**

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -88,7 +88,7 @@ public class Gala.GestureTracker : Object {
 
     /**
      * @param percentage Value between 0 and 1.
-     * @param completions How often a full cycle of the gesture was completed in this go. Can be
+     * @param completions The number of times a full cycle of the gesture was completed in this go. Can be
      * negative if the gesture was started in one direction but ended in the other. This is used to update
      * the UI to the according state. 0 for example means that the UI should go back to the same state
      * it was in before the gesture started.

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -243,12 +243,17 @@ public class Gala.GestureTracker : Object {
 
     private void gesture_end (double percentage, uint64 elapsed_time) {
         double end_percentage = applied_percentage (percentage, percentage_delta);
-        bool cancel_action = (end_percentage < SUCCESS_PERCENTAGE_THRESHOLD)
-            && ((end_percentage <= previous_percentage) && (velocity < SUCCESS_VELOCITY_THRESHOLD));
+        int completions = (int) end_percentage;
+        bool cancel_action = (end_percentage.abs () < SUCCESS_PERCENTAGE_THRESHOLD)
+            && ((end_percentage.abs () <= previous_percentage.abs ()) && (velocity < SUCCESS_VELOCITY_THRESHOLD));
         int calculated_duration = calculate_end_animation_duration (end_percentage, cancel_action);
 
+        if (!cancel_action) {
+            completions += end_percentage < 0 ? -1 : 1;
+        }
+
         if (enabled) {
-            on_end (end_percentage, cancel_action ? 0 : 1, calculated_duration);
+            on_end (end_percentage, completions, calculated_duration);
         }
 
         disconnect_all_handlers ();

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -136,11 +136,7 @@ public class Gala.ScrollBackend : Object {
         double finish_delta = is_horizontal ? FINISH_DELTA_HORIZONTAL : FINISH_DELTA_VERTICAL;
 
         bool is_positive = (direction == GestureDirection.RIGHT || direction == GestureDirection.DOWN);
-        double clamp_low = is_positive ? 0 : -1;
-        double clamp_high = is_positive ? 1 : 0;
 
-        //  double normalized_delta = (used_delta / finish_delta).clamp (clamp_low, clamp_high).abs ();
-        double normalized_delta = (used_delta / finish_delta) * (is_positive ? 1 : -1);
-        return normalized_delta;
+        return (used_delta / finish_delta) * (is_positive ? 1 : -1);
     }
 }

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -139,7 +139,8 @@ public class Gala.ScrollBackend : Object {
         double clamp_low = is_positive ? 0 : -1;
         double clamp_high = is_positive ? 1 : 0;
 
-        double normalized_delta = (used_delta / finish_delta).clamp (clamp_low, clamp_high).abs ();
+        //  double normalized_delta = (used_delta / finish_delta).clamp (clamp_low, clamp_high).abs ();
+        double normalized_delta = (used_delta / finish_delta) * (is_positive ? 1 : -1);
         return normalized_delta;
     }
 }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -380,26 +380,21 @@ namespace Gala {
 
             switching_workspace_with_gesture = true;
 
-            if (is_nudge_animation) {
-                new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, initial_x, initial_x + nudge_gap * -relative_dir).start (true);
-            } else {
-                var upper_clamp = (direction == LEFT) ? (-active_workspace.index () - 0.1) * relative_dir : (num_workspaces - active_workspace.index () - 0.9) * relative_dir;
-                var lower_clamp = (direction == RIGHT) ? (-active_workspace.index () - 0.1) * relative_dir : (num_workspaces - active_workspace.index () - 0.9) * relative_dir;
+            var upper_clamp = (direction == LEFT) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
+            var lower_clamp = (direction == RIGHT) ? (-active_workspace.index () - 0.1) : -(num_workspaces - active_workspace.index () - 0.9);
 
-                new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
-                    overshoot_lower_clamp = lower_clamp,
-                    overshoot_upper_clamp = upper_clamp
-                }.start (true);
-                new GesturePropertyTransition (active_icon_group, workspace_gesture_tracker, "backdrop-opacity", 1f, 0f).start (true);
-                new GesturePropertyTransition (target_icon_group, workspace_gesture_tracker, "backdrop-opacity", 0f, 1f).start (true);
-            }
+            new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
+                overshoot_lower_clamp = lower_clamp,
+                overshoot_upper_clamp = upper_clamp
+            }.start (true);
+            //  new GesturePropertyTransition (active_icon_group, workspace_gesture_tracker, "backdrop-opacity", 1f, 0f).start (true);
+            //  new GesturePropertyTransition (target_icon_group, workspace_gesture_tracker, "backdrop-opacity", 0f, 1f).start (true);
 
             GestureTracker.OnEnd on_animation_end = (percentage, completions, calculated_duration) => {
                 switching_workspace_with_gesture = false;
 
-                if (!is_nudge_animation) {
-                    manager.get_workspace_by_index (active_workspace.index () + completions * relative_dir).activate (display.get_current_time ());
-                }
+                completions = completions.clamp ((int) lower_clamp, (int) upper_clamp);
+                manager.get_workspace_by_index (active_workspace.index () + completions * relative_dir).activate (display.get_current_time ());
             };
 
             if (!AnimationsSettings.get_enable_animations ()) {

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -366,7 +366,7 @@ namespace Gala {
             switching_workspace_with_gesture = true;
 
             var upper_clamp = (direction == LEFT) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
-            var lower_clamp = (direction == RIGHT) ? -(active_workspace.index () + 0.1) : -(num_workspaces - active_workspace.index () - 0.9);
+            var lower_clamp = (direction == RIGHT) ? - (active_workspace.index () + 0.1) : - (num_workspaces - active_workspace.index () - 0.9);
 
             new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
                 overshoot_lower_clamp = lower_clamp,

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -381,7 +381,7 @@ namespace Gala {
             switching_workspace_with_gesture = true;
 
             var upper_clamp = (direction == LEFT) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
-            var lower_clamp = (direction == RIGHT) ? (-active_workspace.index () - 0.1) : -(num_workspaces - active_workspace.index () - 0.9);
+            var lower_clamp = (direction == RIGHT) ? -(active_workspace.index () + 0.1) : -(num_workspaces - active_workspace.index () - 0.9);
 
             new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
                 overshoot_lower_clamp = lower_clamp,

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -340,11 +340,6 @@ namespace Gala {
             float initial_x = workspaces.x;
             float target_x = 0;
             bool is_nudge_animation = !target_workspace_exists;
-            var scale = display.get_monitor_scale (display.get_primary_monitor ());
-            var nudge_gap = InternalUtils.scale_to_int (WindowManagerGala.NUDGE_GAP, scale);
-
-            unowned IconGroup active_icon_group = null;
-            unowned IconGroup? target_icon_group = null;
 
             if (is_nudge_animation) {
                 var workspaces_geometry = InternalUtils.get_workspaces_geometry (display);
@@ -355,19 +350,9 @@ namespace Gala {
                     var workspace = workspace_clone.workspace;
 
                     if (workspace == target_workspace) {
-                        target_icon_group = workspace_clone.icon_group;
                         target_x = -workspace_clone.multitasking_view_x ();
-                    } else if (workspace == active_workspace) {
-                        active_icon_group = workspace_clone.icon_group;
                     }
                 }
-            }
-
-            if (!is_nudge_animation && active_icon_group.get_transition ("backdrop-opacity") != null) {
-                active_icon_group.remove_transition ("backdrop-opacity");
-            }
-            if (!is_nudge_animation && target_icon_group.get_transition ("backdrop-opacity") != null) {
-                target_icon_group.remove_transition ("backdrop-opacity");
             }
 
             debug ("Starting MultitaskingView switch workspace animation:");
@@ -387,8 +372,6 @@ namespace Gala {
                 overshoot_lower_clamp = lower_clamp,
                 overshoot_upper_clamp = upper_clamp
             }.start (true);
-            //  new GesturePropertyTransition (active_icon_group, workspace_gesture_tracker, "backdrop-opacity", 1f, 0f).start (true);
-            //  new GesturePropertyTransition (target_icon_group, workspace_gesture_tracker, "backdrop-opacity", 0f, 1f).start (true);
 
             GestureTracker.OnEnd on_animation_end = (percentage, completions, calculated_duration) => {
                 switching_workspace_with_gesture = false;
@@ -427,9 +410,6 @@ namespace Gala {
 
                 if (workspace == active_workspace) {
                     active_x = dest_x;
-                    workspace_clone.icon_group.backdrop_opacity = 1.0f;
-                } else {
-                    workspace_clone.icon_group.backdrop_opacity = 0.0f;
                 }
 
                 workspace_clone.save_easing_state ();

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -307,8 +307,8 @@ public class Gala.WindowClone : Clutter.Actor {
             set_window_icon_position (width, height, scale, false);
         };
 
-        GestureTracker.OnEnd on_animation_end = (percentage, cancel_action) => {
-            if (cancel_action) {
+        GestureTracker.OnEnd on_animation_end = (percentage, completions) => {
+            if (completions == 0) {
                 return;
             }
 
@@ -322,7 +322,7 @@ public class Gala.WindowClone : Clutter.Actor {
         };
 
         if (gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
-            on_animation_end (1, false, 0);
+            on_animation_end (1, 1, 0);
         } else {
             gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
         }
@@ -369,8 +369,8 @@ public class Gala.WindowClone : Clutter.Actor {
             set_window_icon_position (width, height, scale, false);
         };
 
-        GestureTracker.OnEnd on_animation_end = (percentage, cancel_action) => {
-            if (cancel_action) {
+        GestureTracker.OnEnd on_animation_end = (percentage, completions) => {
+            if (completions == 0) {
                 return;
             }
 
@@ -386,7 +386,7 @@ public class Gala.WindowClone : Clutter.Actor {
         };
 
         if (gesture_tracker == null || !with_gesture || !AnimationsSettings.get_enable_animations ()) {
-            on_animation_end (1, false, 0);
+            on_animation_end (1, 1, 0);
         } else {
             gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
         }

--- a/src/Widgets/WorkspaceClone.vala
+++ b/src/Widgets/WorkspaceClone.vala
@@ -232,6 +232,14 @@ namespace Gala {
 
             var listener = WindowListener.get_default ();
             listener.window_no_longer_on_all_workspaces.connect (add_window);
+
+            parent_set.connect ((old_parent) => {
+                if (old_parent != null) {
+                    old_parent.notify["x"].disconnect (update_icon_group_opacity);
+                }
+
+                get_parent ().notify["x"].connect (update_icon_group_opacity);
+            });
         }
 
         ~WorkspaceClone () {
@@ -248,6 +256,14 @@ namespace Gala {
             background.destroy ();
             window_container.destroy ();
             icon_group.destroy ();
+        }
+
+        private void update_icon_group_opacity () {
+            var offset = (multitasking_view_x () + get_parent ().x).abs ();
+
+            var adjusted_width = width - InternalUtils.scale_to_int (X_OFFSET, scale_factor);
+
+            icon_group.backdrop_opacity = (1 - (offset / adjusted_width)).clamp (0, 1);
         }
 
         private void reallocate () {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2145,9 +2145,9 @@ namespace Gala {
                 wallpaper_clone.x = x_in;
             };
 
-            GestureTracker.OnEnd on_animation_end = (percentage, cancel_action, duration) => {
+            GestureTracker.OnEnd on_animation_end = (percentage, completions, duration) => {
                 if (switch_workspace_with_gesture && (percentage == 1 || percentage == 0)) {
-                    switch_workspace_animation_finished (direction, cancel_action);
+                    switch_workspace_animation_finished (direction, completions == 0);
                     return;
                 }
 
@@ -2167,30 +2167,30 @@ namespace Gala {
                 wallpaper.set_easing_mode (animation_mode);
                 wallpaper.set_easing_duration (duration);
 
-                out_group.x = cancel_action ? 0.0f : x2;
+                out_group.x = completions * x2;
                 out_group.restore_easing_state ();
 
-                in_group.x = cancel_action ? -x2 : 0.0f;
+                in_group.x = completions == 0 ? -x2 : 0.0f;
                 in_group.restore_easing_state ();
 
-                wallpaper.x = cancel_action ? 0.0f : x2;
+                wallpaper.x = completions == 0 ? 0.0f : x2;
                 wallpaper.restore_easing_state ();
 
-                wallpaper_clone.x = cancel_action ? -x2 : 0.0f;
+                wallpaper_clone.x = completions == 0 ? -x2 : 0.0f;
                 wallpaper_clone.restore_easing_state ();
 
                 var transition = in_group.get_transition ("x");
                 if (transition != null) {
                     transition.completed.connect (() => {
-                        switch_workspace_animation_finished (direction, cancel_action);
+                        switch_workspace_animation_finished (direction, completions == 0);
                     });
                 } else {
-                    switch_workspace_animation_finished (direction, cancel_action);
+                    switch_workspace_animation_finished (direction, completions == 0);
                 }
             };
 
             if (!switch_workspace_with_gesture) {
-                on_animation_end (1, false, AnimationDuration.WORKSPACE_SWITCH_MIN);
+                on_animation_end (1, 1, AnimationDuration.WORKSPACE_SWITCH_MIN);
             } else {
                 gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
             }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -660,15 +660,21 @@ namespace Gala {
             prepare_workspace_switch (active_index, active_index, direction);
 
             var monitor_scale = display.get_monitor_scale (display.get_primary_monitor ());
+            var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
 
-            var nudge_gap = InternalUtils.scale_to_int (NUDGE_GAP, monitor_scale);
+            var to_value = monitor_geom.width + WORKSPACE_GAP * monitor_scale;
 
             if (direction == RIGHT) {
-                nudge_gap *= -1;
+                to_value *= -1;
             }
 
-            new GesturePropertyTransition (out_group, gesture_tracker, "x", 0f, 0f, nudge_gap).start (switch_workspace_with_gesture);
-            new GesturePropertyTransition (wallpaper, gesture_tracker, "x", 0f, 0f, nudge_gap).start (switch_workspace_with_gesture, () => {
+            new GesturePropertyTransition (out_group, gesture_tracker, "x", 0f, to_value) {
+                overshoot_upper_clamp = 0.1
+            }.start (switch_workspace_with_gesture);
+
+            new GesturePropertyTransition (wallpaper, gesture_tracker, "x", 0f, to_value) {
+                overshoot_upper_clamp = 0.1
+            }.start (switch_workspace_with_gesture, () => {
                 switch_workspace_animation_finished (direction, false, true);
                 animating_switch_workspace = false;
             });


### PR DESCRIPTION
This currently only works when using a non touchegg backend because the touchegg backend only sends progress between 0 and 1. This means that this only works when using two fingers to switch workspaces in the multitasking view.

This puts the required infrastructure in place to allow gestures to go as far as they want also in the opposite direction than they were started in. It's then used for the workspace switch in the multitasking view while clamping it to the respective number on workspaces on either side.

It also puts a system in place that when clamping to a fractional value this last bit will feel stretched to show that in this direction the gesture is bounded.

F*xes #1057 and #1140 but only in the multitaskingview due to the aforementioned issues with touchegg.