### PR TITLE
Introduce WindowActorFetcher

### DIFF
--- a/src/WindowActorFetcher.vala
+++ b/src/WindowActorFetcher.vala
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2024 elementary, Inc. (https://elementary.io)
+ */
+
+/*
+ * Sends a signal when a window texture is ready.
+ * Useful when you need to use window actor when the window was created.
+ */
+public class Gala.WindowActorFetcher : GLib.Object {
+    public signal void window_actor_ready ();
+
+    public Meta.Window window { get; construct; }
+
+    public WindowActorFetcher (Meta.Window window) {
+        Object (window: window);
+    }
+
+    construct {
+        start_check.begin ();
+    }
+
+    private async void start_check () {
+        Idle.add (() => {
+            unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
+
+            if (window_actor != null) {
+                window_actor_ready ();
+
+                return Source.REMOVE;
+            }
+
+            return Source.CONTINUE;
+        });
+    }
+}

--- a/src/WindowActorFetcher.vala
+++ b/src/WindowActorFetcher.vala
@@ -4,7 +4,7 @@
  */
 
 /*
- * Sends a signal when a window texture is ready.
+ * Sends a signal when a window actor is ready.
  * Useful when you need to use window actor when the window was created.
  */
 public class Gala.WindowActorFetcher : GLib.Object {
@@ -17,11 +17,11 @@ public class Gala.WindowActorFetcher : GLib.Object {
     }
 
     construct {
-        start_check.begin ();
-    }
-
-    private async void start_check () {
         Idle.add (() => {
+            if (window == null) {
+                return Source.REMOVE;
+            }
+
             unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
 
             if (window_actor != null) {

--- a/src/WindowActorFetcher.vala
+++ b/src/WindowActorFetcher.vala
@@ -12,13 +12,22 @@ public class Gala.WindowActorFetcher : GLib.Object {
 
     public Meta.Window window { get; construct; }
 
+    private uint idle_id = 0;
+
     public WindowActorFetcher (Meta.Window window) {
         Object (window: window);
     }
 
+    ~WindowActorFetcher () {
+        if (idle_id > 0) {
+            Source.remove (idle_id);
+        }
+    }
+
     construct {
-        Idle.add (() => {
+        idle_id = Idle.add (() => {
             if (window == null) {
+                idle_id = 0;
                 return Source.REMOVE;
             }
 
@@ -26,6 +35,7 @@ public class Gala.WindowActorFetcher : GLib.Object {
 
             if (window_actor != null) {
                 window_actor_ready ();
+                idle_id = 0;
 
                 return Source.REMOVE;
             }

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ gala_bin_sources = files(
     'ScreenSaverManager.vala',
     'ScreenshotManager.vala',
     'SessionManager.vala',
+    'WindowActorFetcher.vala',
     'WindowAttentionTracker.vala',
     'WindowGrabTracker.vala',
     'WindowListener.vala',


### PR DESCRIPTION
I want to use this as a replacement for `Meta.Window.shown` since it has proven to be wrong in e.g. https://github.com/elementary/gala/issues/2088.

I don't even think `Meta.Window.shown` was intended to be used for determining whether the window actor was shown. But in short, when the new window is created the Wayland windows are 'hidden' by default but X11 are not. because of this the `Meta.Window.shown` sometimes is not called.

The code here only touches WindowClone to show that it works, I'll propose PR to replace the use of 'shown' later.