### PR TITLE
InternalUtils: Introduce wait_for_window_actor utility

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -348,5 +348,25 @@ namespace Gala {
 
             return actor_box;
         }
+
+        public delegate void WindowActorReadyCallback (Meta.WindowActor window_actor);
+
+        public static void wait_for_window_actor (Meta.Window window, owned WindowActorReadyCallback callback) {
+            unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
+            if (window_actor != null) {
+                callback (window_actor);
+                return;
+            }
+
+            Idle.add (() => {
+                window_actor = (Meta.WindowActor) window.get_compositor_private ();
+
+                if (window_actor != null) {
+                    callback (window_actor);
+                }
+
+                return Source.REMOVE;
+            });
+        }
     }
 }

--- a/src/Widgets/WindowClone.vala
+++ b/src/Widgets/WindowClone.vala
@@ -143,7 +143,7 @@ public class Gala.WindowClone : Clutter.Actor {
 
         reallocate ();
 
-        load_clone ();
+        InternalUtils.wait_for_window_actor (window, load_clone);
 
         window.notify["title"].connect (() => window_title.set_text (window.get_title () ?? ""));
         window_title.set_text (window.get_title () ?? "");
@@ -182,19 +182,7 @@ public class Gala.WindowClone : Clutter.Actor {
      * itself at the location of the original window. Also adds the shadow
      * effect and makes sure the shadow is updated on size changes.
      */
-    private void load_clone () {
-        var actor = (Meta.WindowActor) window.get_compositor_private ();
-        if (actor == null) {
-            Idle.add (() => {
-                if (window.get_compositor_private () != null) {
-                    load_clone ();
-                }
-                return Source.REMOVE;
-            });
-
-            return;
-        }
-
+    private void load_clone (Meta.WindowActor actor) {
         if (overview_mode) {
             actor.hide ();
         }


### PR DESCRIPTION
Tries to achieve the same as #2176 without introducing a whole class just to wait for something. Instead we add a function to internalutils that takes a callback which it will call immediately if the windowactor is already available or wait a single idle for it.