### PR TITLE
WindowManager: Only show notifications after their window was shown

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -355,5 +355,17 @@ namespace Gala {
                 return Source.REMOVE;
             });
         }
+
+        public static void wait_for_window_actor_to_show (Meta.Window window, owned WindowActorReadyCallback callback) {
+            unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
+            if (window_actor.visible) {
+                callback (window_actor);
+                return;
+            }
+
+            InternalUtils.wait_for_window_actor (window, (actor) => {
+                actor.show.connect (() => callback (actor));
+            }); 
+        }
     }
 }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -365,7 +365,7 @@ namespace Gala {
 
             InternalUtils.wait_for_window_actor (window, (actor) => {
                 actor.show.connect (() => callback (actor));
-            }); 
+            });
         }
     }
 }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -358,7 +358,7 @@ namespace Gala {
                     });
                 }
 
-                return window_actor != null ? Source.REMOVE : Source.CONTINUE;
+                return Source.REMOVE;
             });
         }
     }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -340,7 +340,7 @@ namespace Gala {
 
         public static void wait_for_window_actor (Meta.Window window, owned WindowActorReadyCallback callback) {
             unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
-            if (window_actor != null) {
+            if (window_actor != null && window_actor.visible) {
                 callback (window_actor);
                 return;
             }
@@ -348,23 +348,17 @@ namespace Gala {
             Idle.add (() => {
                 window_actor = (Meta.WindowActor) window.get_compositor_private ();
 
-                if (window_actor != null) {
+                if (window_actor != null && window_actor.visible) {
                     callback (window_actor);
+                } else if (window_actor != null) {
+                    ulong show_handler = 0;
+                    show_handler = window_actor.show.connect (() => {
+                        window_actor.disconnect (show_handler);
+                        callback (window_actor);
+                    });
                 }
 
-                return Source.REMOVE;
-            });
-        }
-
-        public static void wait_for_window_actor_to_show (Meta.Window window, owned WindowActorReadyCallback callback) {
-            unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
-            if (window_actor.visible) {
-                callback (window_actor);
-                return;
-            }
-
-            InternalUtils.wait_for_window_actor (window, (actor) => {
-                actor.show.connect (() => callback (actor));
+                return window_actor != null ? Source.REMOVE : Source.CONTINUE;
             });
         }
     }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2120,7 +2120,7 @@ namespace Gala {
             // TODO: currently only notifications are handled here, other windows should be too
             switch_workspace_window_created_id = window_created.connect ((window) => {
                 if (NotificationStack.is_notification (window)) {
-                    InternalUtils.wait_for_window_actor_to_show (window, (actor) => {
+                    InternalUtils.wait_for_window_actor (window, (actor) => {
                         clutter_actor_reparent (actor, notification_group);
                         notification_stack.show_notification (actor);
                     });

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2120,9 +2120,10 @@ namespace Gala {
             // TODO: currently only notifications are handled here, other windows should be too
             switch_workspace_window_created_id = window_created.connect ((window) => {
                 if (NotificationStack.is_notification (window)) {
-                    unowned var actor = (Meta.WindowActor) window.get_compositor_private ();
-                    clutter_actor_reparent (actor, notification_group);
-                    notification_stack.show_notification (actor);
+                    InternalUtils.wait_for_window_actor_to_show (window, (actor) => {
+                        clutter_actor_reparent (actor, notification_group);
+                        notification_stack.show_notification (actor);
+                    });
                 }
             });
 


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2175
Fixes https://github.com/elementary/gala/issues/2102

Closes https://github.com/elementary/gala/pull/2129

Now `InternalUtils.wait_for_window_actor` is basically the same as `Meta.Window.shown`