### PR TITLE
Gestures: Introduce GestureAction

### DIFF
--- a/src/Gestures/Gesture.vala
+++ b/src/Gestures/Gesture.vala
@@ -18,7 +18,7 @@
 
 namespace Gala {
     /**
-     * Physical direction of the gesture. This direction doesn't follow natural scroll preferences.
+     * Physical direction of the gesture.
      */
     public enum GestureDirection {
         UNKNOWN = 0,
@@ -34,26 +34,31 @@ namespace Gala {
         OUT = 6,
     }
 
-    public class Gesture {
-        public const float INVALID_COORD = float.MAX;
+    /**
+     * Action triggered by the gesture.
+     */
+    public class GestureAction {
+        public enum Type {
+            NONE,
+            CUSTOM, // Means we have less than three fingers. Usually only emitted if we are interacting with a component itself e.g. MultitaskingView
+            SWITCH_WORKSPACE,
+            MOVE_TO_WORKSPACE,
+            SWITCH_WINDOWS,
+            MULTITASKING_VIEW,
+            ZOOM
+        }
 
-        public Clutter.EventType type;
-        public GestureDirection direction;
-        public int fingers;
-        public Clutter.InputDeviceType performed_on_device_type;
+        public enum Direction {
+            FORWARD,
+            BACKWARD
+        }
 
-        /**
-         * The x coordinate of the initial contact point for the gesture.
-         * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
-         * Currently the only backend not setting this is {@link GestureTracker.enable_touchpad}.
-         */
-        public float origin_x = INVALID_COORD;
+        public GestureAction (Type type, Direction direction) {
+            this.type = type;
+            this.direction = direction;
+        }
 
-        /**
-         * The y coordinate of the initial contact point for the gesture.
-         * Doesn't have to be set. In that case it is set to {@link INVALID_COORD}.
-         * Currently the only backend not setting this is {@link GestureTracker.enable_touchpad}.
-         */
-        public float origin_y = INVALID_COORD;
+        public Type type;
+        public Direction direction;
     }
 }

--- a/src/Gestures/GestureSettings.vala
+++ b/src/Gestures/GestureSettings.vala
@@ -57,7 +57,7 @@ public class Gala.GestureSettings : Object {
         }
     }
 
-    public static GestureAction get_action (Clutter.EventType type, int fingers, GestureDirection direction) {
+    public static GestureAction get_action (int fingers, GestureDirection direction) {
         if (fingers <= 2) {
             return new GestureAction (CUSTOM, get_action_direction (direction));
         }

--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -17,7 +17,7 @@
  */
 
 public interface Gala.GestureBackend : Object {
-    public signal bool on_gesture_detected (Gesture gesture, uint32 timestamp);
+    public signal bool on_gesture_detected (GestureAction action, uint32 timestamp);
     public signal void on_begin (double delta, uint64 time);
     public signal void on_update (double delta, uint64 time);
     public signal void on_end (double delta, uint64 time);
@@ -81,20 +81,20 @@ public class Gala.GestureTracker : Object {
      * do any preparations instead those should be done in {@link on_gesture_handled}. This is because
      * the backend might have to do some preparations itself before you are allowed to do some to avoid
      * conflicts.
-     * @param gesture Information about the gesture.
+     * @param action Information about the gesture.
      * @return true if the gesture will be handled false otherwise. If false is returned the other
      * signals may still be emitted but aren't guaranteed to be.
      */
-    public signal bool on_gesture_detected (Gesture gesture);
+    public signal bool on_gesture_detected (GestureAction action);
 
     /**
      * Emitted if true was returned form {@link on_gesture_detected}. This should
      * be used to do any preparations for gesture handling and to call {@link connect_handlers} to
      * start receiving updates.
-     * @param gesture the same gesture as in {@link on_gesture_detected}
+     * @param action the same gesture as in {@link on_gesture_detected}
      * @param timestamp the timestamp of the event that initiated the gesture or {@link Meta.CURRENT_TIME}.
      */
-    public signal void on_gesture_handled (Gesture gesture, uint32 timestamp);
+    public signal void on_gesture_handled (GestureAction action, uint32 timestamp);
 
     /**
      * Emitted right after on_gesture_detected with the initial gesture information.
@@ -169,7 +169,7 @@ public class Gala.GestureTracker : Object {
      * @param orientation If we are interested in the horizontal or vertical axis.
      */
     public void enable_scroll (Clutter.Actor actor, Clutter.Orientation orientation) {
-        scroll_backend = new ScrollBackend (actor, orientation, settings);
+        scroll_backend = new ScrollBackend (actor, orientation);
         scroll_backend.on_gesture_detected.connect (gesture_detected);
         scroll_backend.on_begin.connect (gesture_begin);
         scroll_backend.on_update.connect (gesture_update);
@@ -227,10 +227,10 @@ public class Gala.GestureTracker : Object {
         return value;
     }
 
-    private bool gesture_detected (GestureBackend backend, Gesture gesture, uint32 timestamp) {
-        if (enabled && on_gesture_detected (gesture)) {
+    private bool gesture_detected (GestureBackend backend, GestureAction action, uint32 timestamp) {
+        if (enabled && on_gesture_detected (action)) {
             backend.prepare_gesture_handling ();
-            on_gesture_handled (gesture, timestamp);
+            on_gesture_handled (action, timestamp);
             return true;
         }
 

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -108,7 +108,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
             direction = delta_y > 0 ? GestureDirection.DOWN : GestureDirection.UP;
         }
 
-        return GestureSettings.get_action (SCROLL, 2, direction);
+        return GestureSettings.get_action (2, direction);
     }
 
     private double calculate_delta (double delta_x, double delta_y) {

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -64,7 +64,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
         // Standardize them so the direction matches the physical direction of the gesture and the
         // GestureTracker user can decide if it wants to follow natural scroll settings or not
         bool natural_scroll = GestureSettings.is_natural_scroll_enabled (Clutter.InputDeviceType.TOUCHPAD_DEVICE);
-        if (!natural_scroll) {
+        if (natural_scroll) {
             x *= -1;
             y *= -1;
         }

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -76,16 +76,16 @@ public class Gala.ScrollBackend : Object, GestureBackend {
             if (delta_x != 0 || delta_y != 0) {
                 float origin_x, origin_y;
                 event.get_coords (out origin_x, out origin_y);
-                GestureAction action = build_gesture (origin_x, origin_y, delta_x, delta_y, orientation, time);
+                GestureAction action = build_gesture (delta_x, delta_y);
                 started = true;
                 direction = action.direction;
                 on_gesture_detected (action, time);
 
-                double delta = calculate_delta (delta_x, delta_y, direction);
+                double delta = calculate_delta (delta_x, delta_y);
                 on_begin (delta, time);
             }
         } else {
-            double delta = calculate_delta (delta_x, delta_y, direction);
+            double delta = calculate_delta (delta_x, delta_y);
             if (x == 0 && y == 0) {
                 started = false;
                 delta_x = 0;
@@ -100,19 +100,9 @@ public class Gala.ScrollBackend : Object, GestureBackend {
         return true;
     }
 
-#if HAS_MUTTER45
-    private static bool can_handle_event (Clutter.Event event) {
-#else
-    private static bool can_handle_event (Clutter.ScrollEvent event) {
-#endif
-        return event.get_type () == Clutter.EventType.SCROLL
-            && event.get_source_device ().get_device_type () == Clutter.InputDeviceType.TOUCHPAD_DEVICE
-            && event.get_scroll_direction () == Clutter.ScrollDirection.SMOOTH;
-    }
-
-    private static GestureAction build_gesture (float origin_x, float origin_y, double delta_x, double delta_y, Clutter.Orientation orientation, uint32 timestamp) {
+    private GestureAction build_gesture (double delta_x, double delta_y) {
         GestureDirection direction;
-        if (orientation == Clutter.Orientation.HORIZONTAL) {
+        if (orientation == HORIZONTAL) {
             direction = delta_x > 0 ? GestureDirection.RIGHT : GestureDirection.LEFT;
         } else {
             direction = delta_y > 0 ? GestureDirection.DOWN : GestureDirection.UP;
@@ -121,7 +111,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
         return GestureSettings.get_action (SCROLL, 2, direction);
     }
 
-    private double calculate_delta (double delta_x, double delta_y, GestureAction.Direction direction) {
+    private double calculate_delta (double delta_x, double delta_y) {
         bool is_horizontal = orientation == HORIZONTAL;
         double used_delta = is_horizontal ? delta_x : delta_y;
         double finish_delta = is_horizontal ? FINISH_DELTA_HORIZONTAL : FINISH_DELTA_VERTICAL;
@@ -129,5 +119,15 @@ public class Gala.ScrollBackend : Object, GestureBackend {
         bool is_positive = direction == FORWARD;
 
         return (used_delta / finish_delta) * (is_positive ? 1 : -1);
+    }
+
+#if HAS_MUTTER45
+    private static bool can_handle_event (Clutter.Event event) {
+#else
+    private static bool can_handle_event (Clutter.ScrollEvent event) {
+#endif
+        return event.get_type () == Clutter.EventType.SCROLL
+            && event.get_source_device ().get_device_type () == Clutter.InputDeviceType.TOUCHPAD_DEVICE
+            && event.get_scroll_direction () == Clutter.ScrollDirection.SMOOTH;
     }
 }

--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -201,7 +201,7 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
         switch (signal_name) {
             case DBUS_ON_GESTURE_BEGIN:
                 Idle.add (() => {
-                    on_gesture_detected (make_gesture (type, direction, fingers), Meta.CURRENT_TIME);
+                    on_gesture_detected (GestureSettings.get_action (fingers, direction), Meta.CURRENT_TIME);
                     on_begin (delta, elapsed_time);
                     return false;
                 });
@@ -221,21 +221,5 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
             default:
                 break;
         }
-    }
-
-    private static GestureAction? make_gesture (GestureType type, GestureDirection direction, int fingers) {
-        Clutter.EventType event_type;
-        switch (type) {
-            case GestureType.SWIPE:
-                event_type = Clutter.EventType.TOUCHPAD_SWIPE;
-                break;
-            case GestureType.PINCH:
-                event_type = Clutter.EventType.TOUCHPAD_PINCH;
-                break;
-            default:
-                return null;
-        }
-
-        return GestureSettings.get_action (event_type, fingers, direction);
     }
 }

--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -192,10 +192,6 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
         signal_params.get ("(uudiut)", out type, out direction, out percentage, out fingers,
             out performed_on_device_type, out elapsed_time);
 
-        if (direction == LEFT || direction == RIGHT) {
-            direction = direction == RIGHT ? GestureDirection.LEFT : GestureDirection.RIGHT;
-        }
-
         var delta = percentage * DELTA_MULTIPLIER;
 
         switch (signal_name) {

--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -192,12 +192,16 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
         signal_params.get ("(uudiut)", out type, out direction, out percentage, out fingers,
             out performed_on_device_type, out elapsed_time);
 
+        if (direction == LEFT || direction == RIGHT) {
+            direction = direction == RIGHT ? GestureDirection.LEFT : GestureDirection.RIGHT;
+        }
+
         var delta = percentage * DELTA_MULTIPLIER;
 
         switch (signal_name) {
             case DBUS_ON_GESTURE_BEGIN:
                 Idle.add (() => {
-                    on_gesture_detected (make_gesture (type, direction, fingers, performed_on_device_type), Meta.CURRENT_TIME);
+                    on_gesture_detected (make_gesture (type, direction, fingers), Meta.CURRENT_TIME);
                     on_begin (delta, elapsed_time);
                     return false;
                 });
@@ -219,7 +223,7 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
         }
     }
 
-    private static Gesture? make_gesture (GestureType type, GestureDirection direction, int fingers, DeviceType performed_on_device_type) {
+    private static GestureAction? make_gesture (GestureType type, GestureDirection direction, int fingers) {
         Clutter.EventType event_type;
         switch (type) {
             case GestureType.SWIPE:
@@ -232,23 +236,6 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
                 return null;
         }
 
-        Clutter.InputDeviceType input_source;
-        switch (performed_on_device_type) {
-            case DeviceType.TOUCHPAD:
-                input_source = Clutter.InputDeviceType.TOUCHPAD_DEVICE;
-                break;
-            case DeviceType.TOUCHSCREEN:
-                input_source = Clutter.InputDeviceType.TOUCHSCREEN_DEVICE;
-                break;
-            default:
-                return null;
-        }
-
-        return new Gesture () {
-            type = event_type,
-            direction = direction,
-            fingers = fingers,
-            performed_on_device_type = input_source
-        };
+        return GestureSettings.get_action (event_type, fingers, direction);
     }
 }

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -292,40 +292,38 @@ namespace Gala {
             workspaces.add_transition ("nudge", nudge);
         }
 
-        private bool on_multitasking_gesture_detected (Gesture gesture) {
-            if (GestureSettings.get_action (gesture) != MULTITASKING_VIEW) {
+        private bool on_multitasking_gesture_detected (GestureAction action) {
+            if (action.type != MULTITASKING_VIEW) {
                 return false;
             }
 
-            if (gesture.direction == UP && !opened || gesture.direction == DOWN && opened) {
+            if (action.direction == FORWARD && !opened || action.direction == BACKWARD && opened) {
                 return true;
             }
 
             return false;
         }
 
-        private bool on_workspace_gesture_detected (Gesture gesture) {
+        private bool on_workspace_gesture_detected (GestureAction action) {
             if (!opened) {
                 return false;
             }
 
-            if (gesture.type == SCROLL || GestureSettings.get_action (gesture) == SWITCH_WORKSPACE) {
+            if (action.type == CUSTOM || action.type == SWITCH_WORKSPACE) {
                 return true;
             }
 
             return false;
         }
 
-        private void switch_workspace_with_gesture (Gesture gesture, uint32 timestamp) {
+        private void switch_workspace_with_gesture (GestureAction action, uint32 timestamp) {
             if (switching_workspace_in_progress) {
                 return;
             }
 
-            var direction = workspace_gesture_tracker.settings.get_natural_scroll_direction (gesture);
-
             unowned var manager = display.get_workspace_manager ();
             var num_workspaces = manager.get_n_workspaces ();
-            var relative_dir = (direction == Meta.MotionDirection.LEFT) ? -1 : 1;
+            var relative_dir = (action.direction == BACKWARD) ? -1 : 1;
 
             unowned var active_workspace = manager.get_active_workspace ();
 
@@ -361,8 +359,8 @@ namespace Gala {
 
             switching_workspace_with_gesture = true;
 
-            var upper_clamp = (direction == LEFT) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
-            var lower_clamp = (direction == RIGHT) ? - (active_workspace.index () + 0.1) : - (num_workspaces - active_workspace.index () - 0.9);
+            var upper_clamp = (action.direction == BACKWARD) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
+            var lower_clamp = (action.direction == FORWARD) ? - (active_workspace.index () + 0.1) : - (num_workspaces - active_workspace.index () - 0.9);
 
             new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
                 overshoot_lower_clamp = lower_clamp,

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -323,7 +323,8 @@ namespace Gala {
 
             unowned var manager = display.get_workspace_manager ();
             var num_workspaces = manager.get_n_workspaces ();
-            var relative_dir = (action.direction == BACKWARD) ? -1 : 1;
+            // If we are going forward we are moving right so in order to have the ui switch forward with us we have to go to a workspace to the left
+            var relative_dir = (action.direction == FORWARD) ? -1 : 1;
 
             unowned var active_workspace = manager.get_active_workspace ();
 
@@ -359,8 +360,8 @@ namespace Gala {
 
             switching_workspace_with_gesture = true;
 
-            var upper_clamp = (action.direction == BACKWARD) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
-            var lower_clamp = (action.direction == FORWARD) ? - (active_workspace.index () + 0.1) : - (num_workspaces - active_workspace.index () - 0.9);
+            var upper_clamp = (action.direction == FORWARD) ? (active_workspace.index () + 0.1) : (num_workspaces - active_workspace.index () - 0.9);
+            var lower_clamp = (action.direction == BACKWARD) ? - (active_workspace.index () + 0.1) : - (num_workspaces - active_workspace.index () - 0.9);
 
             new GesturePropertyTransition (workspaces, workspace_gesture_tracker, "x", null, target_x) {
                 overshoot_lower_clamp = lower_clamp,

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -277,8 +277,8 @@ public class Gala.WindowSwitcher : CanvasActor {
         }
         open_switcher ();
 
-        // if direction == LEFT we need to move to the end of the list first, thats why last_window_index is set to -1
-        var last_window_index = direction == BACKWARD ? 0 : -1;
+        // if direction == BACKWARD we need to move to the end of the list first, thats why last_window_index is set to -1
+        var last_window_index = direction == FORWARD ? 0 : -1;
         GestureTracker.OnUpdate on_animation_update = (percentage) => {
             var window_index = GestureTracker.animation_value (0, GESTURE_RANGE_LIMIT, percentage, true);
 
@@ -288,12 +288,12 @@ public class Gala.WindowSwitcher : CanvasActor {
 
             if (window_index > last_window_index) {
                 while (last_window_index < window_index) {
-                    next_window (direction == FORWARD);
+                    next_window (direction == BACKWARD);
                     last_window_index++;
                 }
             } else if (window_index < last_window_index) {
                 while (last_window_index > window_index) {
-                    next_window (direction == BACKWARD);
+                    next_window (direction == FORWARD);
                     last_window_index--;
                 }
             }

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -264,7 +264,7 @@ public class Gala.WindowSwitcher : CanvasActor {
         next_window (backward);
     }
 
-    public void handle_gesture (GestureDirection direction) {
+    public void handle_gesture (GestureAction.Direction direction) {
         handling_gesture = true;
 
         unowned var display = wm.get_display ();
@@ -278,7 +278,7 @@ public class Gala.WindowSwitcher : CanvasActor {
         open_switcher ();
 
         // if direction == LEFT we need to move to the end of the list first, thats why last_window_index is set to -1
-        var last_window_index = direction == RIGHT ? 0 : -1;
+        var last_window_index = direction == BACKWARD ? 0 : -1;
         GestureTracker.OnUpdate on_animation_update = (percentage) => {
             var window_index = GestureTracker.animation_value (0, GESTURE_RANGE_LIMIT, percentage, true);
 
@@ -288,12 +288,12 @@ public class Gala.WindowSwitcher : CanvasActor {
 
             if (window_index > last_window_index) {
                 while (last_window_index < window_index) {
-                    next_window (direction == LEFT);
+                    next_window (direction == FORWARD);
                     last_window_index++;
                 }
             } else if (window_index < last_window_index) {
                 while (last_window_index > window_index) {
-                    next_window (direction == RIGHT);
+                    next_window (direction == BACKWARD);
                     last_window_index--;
                 }
             }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -585,7 +585,8 @@ namespace Gala {
         }
 
         private void on_gesture_handled (GestureAction action, uint32 timestamp) {
-            var direction = action.direction == FORWARD ? Meta.MotionDirection.RIGHT : Meta.MotionDirection.LEFT;
+            // If we are going forward we are moving right so in order to have the ui switch forward with us we have to go to a workspace to the left
+            var direction = action.direction == FORWARD ? Meta.MotionDirection.LEFT : Meta.MotionDirection.RIGHT;
 
             switch (action.type) {
                 case MOVE_TO_WORKSPACE:

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -575,20 +575,19 @@ namespace Gala {
             }
         }
 
-        private bool on_gesture_detected (Gesture gesture) {
+        private bool on_gesture_detected (GestureAction action) {
             if (workspace_view.is_opened ()) {
                 return false;
             }
 
-            var action = GestureSettings.get_action (gesture);
-            switch_workspace_with_gesture = action == SWITCH_WORKSPACE || action == MOVE_TO_WORKSPACE;
-            return switch_workspace_with_gesture || (action == SWITCH_WINDOWS && !window_switcher.opened);
+            switch_workspace_with_gesture = action.type == SWITCH_WORKSPACE || action.type == MOVE_TO_WORKSPACE;
+            return switch_workspace_with_gesture || (action.type == SWITCH_WINDOWS && !window_switcher.opened);
         }
 
-        private void on_gesture_handled (Gesture gesture, uint32 timestamp) {
-            var direction = gesture_tracker.settings.get_natural_scroll_direction (gesture);
+        private void on_gesture_handled (GestureAction action, uint32 timestamp) {
+            var direction = action.direction == FORWARD ? Meta.MotionDirection.RIGHT : Meta.MotionDirection.LEFT;
 
-            switch (GestureSettings.get_action (gesture)) {
+            switch (action.type) {
                 case MOVE_TO_WORKSPACE:
                     unowned var display = get_display ();
                     unowned var manager = display.get_workspace_manager ();
@@ -605,7 +604,7 @@ namespace Gala {
                     break;
 
                 case SWITCH_WINDOWS:
-                    window_switcher.handle_gesture (gesture.direction);
+                    window_switcher.handle_gesture (action.direction);
                     break;
 
                 default:

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -33,7 +33,7 @@ public class Gala.Zoom : Object {
         gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
         gesture_tracker.enable_touchpad ();
         gesture_tracker.on_gesture_detected.connect (on_gesture_detected);
-        gesture_tracker.on_gesture_handled.connect ((gesture) => zoom_with_gesture (gesture.direction));
+        gesture_tracker.on_gesture_handled.connect (zoom_with_gesture);
 
         behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
 
@@ -69,20 +69,8 @@ public class Gala.Zoom : Object {
         zoom (-SHORTCUT_DELTA, true, AnimationsSettings.get_enable_animations ());
     }
 
-    private bool on_gesture_detected (Gesture gesture) {
-        if (gesture.type != Clutter.EventType.TOUCHPAD_PINCH ||
-            (gesture.direction != GestureDirection.IN && gesture.direction != GestureDirection.OUT)
-        ) {
-            return false;
-        }
-
-        if ((gesture.fingers == 3 && GestureSettings.get_string ("three-finger-pinch") == "zoom") ||
-            (gesture.fingers == 4 && GestureSettings.get_string ("four-finger-pinch") == "zoom")
-        ) {
-            return true;
-        }
-
-        return false;
+    private bool on_gesture_detected (GestureAction action) {
+        return action.type == ZOOM;
     }
 
     private bool handle_super_scroll (uint32 timestamp, double dx, double dy) {
@@ -101,9 +89,9 @@ public class Gala.Zoom : Object {
         return Clutter.EVENT_STOP;
     }
 
-    private void zoom_with_gesture (GestureDirection direction) {
+    private void zoom_with_gesture (GestureAction action, uint32 timestamp) {
         var initial_zoom = current_zoom;
-        var target_zoom = (direction == GestureDirection.IN)
+        var target_zoom = (action.direction == FORWARD)
             ? initial_zoom - MAX_ZOOM
             : initial_zoom + MAX_ZOOM;
 


### PR DESCRIPTION
Instead of presenting the consumers of gestures with all the details about the gesture we just give them the action that should be triggered, and whether we should go forward (e.g. switch to the left with workspace switches or open the multitasking view) or backward (the opposite).

This helps

1. with memory since we have to store less values (negligible but nice to have ig :)))
2. with performance because we don't have to call GestureSettings.get_action twice in e.g. WindowManager
3. with lines of code
4. with preparation for more deduplication between one to one gestures and e.g. keyboard "gestures"

So win, win, win, win I guess? Let me know what you think :)