### PR TITLE
Introduce InternalUtils.wait_for_window_actor_visible

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -340,7 +340,7 @@ namespace Gala {
 
         public static void wait_for_window_actor (Meta.Window window, owned WindowActorReadyCallback callback) {
             unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
-            if (window_actor != null && window_actor.visible) {
+            if (window_actor != null) {
                 callback (window_actor);
                 return;
             }
@@ -348,17 +348,25 @@ namespace Gala {
             Idle.add (() => {
                 window_actor = (Meta.WindowActor) window.get_compositor_private ();
 
-                if (window_actor != null && window_actor.visible) {
+                if (window_actor != null) {
                     callback (window_actor);
-                } else if (window_actor != null) {
+                }
+
+                return Source.REMOVE;
+            });
+        }
+
+        public static void wait_for_window_actor_visible (Meta.Window window, owned WindowActorReadyCallback callback) {
+            wait_for_window_actor (window, (window_actor) => {
+                if (window_actor.visible) {
+                    callback (window_actor);
+                } else {
                     ulong show_handler = 0;
                     show_handler = window_actor.show.connect (() => {
                         window_actor.disconnect (show_handler);
                         callback (window_actor);
                     });
                 }
-
-                return Source.REMOVE;
             });
         }
     }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2120,7 +2120,7 @@ namespace Gala {
             // TODO: currently only notifications are handled here, other windows should be too
             switch_workspace_window_created_id = window_created.connect ((window) => {
                 if (NotificationStack.is_notification (window)) {
-                    InternalUtils.wait_for_window_actor (window, (actor) => {
+                    InternalUtils.wait_for_window_actor_visible (window, (actor) => {
                         clutter_actor_reparent (actor, notification_group);
                         notification_stack.show_notification (actor);
                     });


### PR DESCRIPTION
Fixes #2187 

Sometimes we ourselves have to hide window actors so we can't always wait for them to be visible, e.g. if we just want to create a clone for them.