### PR TITLE
ShellClients: Use translation y instead of clone and use gesturetransition for animation

### DIFF
--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -75,6 +75,8 @@ public class Gala.GestureTracker : Object {
      */
     public bool enabled { get; set; default = true; }
 
+    public bool recognizing { get; private set; }
+
     /**
      * Emitted when a new gesture is detected.
      * This should only be used to determine whether the gesture should be handled. This shouldn't
@@ -193,6 +195,23 @@ public class Gala.GestureTracker : Object {
         }
     }
 
+    /**
+     * Connects a callback that will only be called if != 0 completions were made.
+     * If with_gesture is false it will be called immediately, otherwise once {@link on_end} is emitted.
+     */
+    public void add_success_callback (bool with_gesture, owned OnEnd callback) {
+        if (!with_gesture) {
+            callback (1, 1, min_animation_duration);
+        } else {
+            ulong handler_id = on_end.connect ((percentage, completions, duration) => {
+                if (completions != 0) {
+                    callback (percentage, completions, duration);
+                }
+            });
+            handlers.add (handler_id);
+        }
+    }
+
     private void disconnect_all_handlers () {
         foreach (var handler in handlers) {
             disconnect (handler);
@@ -242,6 +261,7 @@ public class Gala.GestureTracker : Object {
             on_begin (percentage);
         }
 
+        recognizing = true;
         previous_percentage = percentage;
         previous_time = elapsed_time;
     }
@@ -283,6 +303,7 @@ public class Gala.GestureTracker : Object {
         }
 
         disconnect_all_handlers ();
+        recognizing = false;
         previous_percentage = 0;
         previous_time = 0;
         percentage_delta = 0;


### PR DESCRIPTION
Split out from #2150 for easier review.

This introduces some inconsistencies when opening multitasking view and switching workspaces but these will be fixed properly by the follow ups from #2150.

The changes here include using the translation-y property of the window actor to hide it instead of making it invisible and animating a clone. Also included is the use of the GesturePropertyTransition for the actual animation and the related introduction of GestureTrackers. This is preparation for moving all panel hiding stuff to the shell clients (instead of the multitasking view doing its own thing with additional clones) as well as one to one touch gestures for showing the dock.