### PR TITLE
WIP: Move panel hiding to shellclients from multitaskingview

### DIFF
--- a/src/Gestures/GestureTracker.vala
+++ b/src/Gestures/GestureTracker.vala
@@ -75,6 +75,8 @@ public class Gala.GestureTracker : Object {
      */
     public bool enabled { get; set; default = true; }
 
+    public bool recognizing { get; private set; }
+
     /**
      * Emitted when a new gesture is detected.
      * This should only be used to determine whether the gesture should be handled. This shouldn't
@@ -193,6 +195,23 @@ public class Gala.GestureTracker : Object {
         }
     }
 
+    /**
+     * Connects a callback that will only be called if != 0 completions were made.
+     * If with_gesture is false it will be called immediately, otherwise once {@link on_end} is emitted.
+     */
+    public void add_success_callback (bool with_gesture, owned OnEnd callback) {
+        if (!with_gesture) {
+            callback (1, 1, min_animation_duration);
+        } else {
+            ulong handler_id = on_end.connect ((percentage, completions, duration) => {
+                if (completions != 0) {
+                    callback (percentage, completions, duration);
+                }
+            });
+            handlers.add (handler_id);
+        }
+    }
+
     private void disconnect_all_handlers () {
         foreach (var handler in handlers) {
             disconnect (handler);
@@ -242,6 +261,7 @@ public class Gala.GestureTracker : Object {
             on_begin (percentage);
         }
 
+        recognizing = true;
         previous_percentage = percentage;
         previous_time = elapsed_time;
     }
@@ -283,6 +303,7 @@ public class Gala.GestureTracker : Object {
         }
 
         disconnect_all_handlers ();
+        recognizing = false;
         previous_percentage = 0;
         previous_time = 0;
         percentage_delta = 0;

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -18,10 +18,10 @@ public class Gala.PanelClone : Object {
         set {
             if (value == NEVER) {
                 hide_tracker = null;
-                show ();
+                show (default_gesture_tracker, false);
                 return;
             } else if (hide_tracker == null) {
-                hide_tracker = new HideTracker (wm.get_display (), panel);
+                hide_tracker = new HideTracker (wm.get_display (), panel, default_gesture_tracker);
                 hide_tracker.hide.connect (hide);
                 hide_tracker.show.connect (show);
             }
@@ -32,8 +32,10 @@ public class Gala.PanelClone : Object {
 
     public bool panel_hidden { get; private set; default = true; }
 
-    private SafeWindowClone clone;
     private Meta.WindowActor actor;
+
+    private GestureTracker default_gesture_tracker;
+    private GestureTracker last_gesture_tracker;
 
     private HideTracker? hide_tracker;
 
@@ -42,20 +44,11 @@ public class Gala.PanelClone : Object {
     }
 
     construct {
-        clone = new SafeWindowClone (panel.window, true);
-        wm.ui_group.add_child (clone);
+        last_gesture_tracker = default_gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
 
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
-        // WindowActor position and Window position aren't necessarily the same.
-        // The clone needs the actor position
-        actor.notify["x"].connect (update_clone_position);
-        actor.notify["y"].connect (update_clone_position);
-        // Actor visibility might be changed by something else e.g. workspace switch
-        // but we want to keep it in sync with us
-        actor.notify["visible"].connect (update_visible);
 
         notify["panel-hidden"].connect (() => {
-            update_visible ();
             // When hidden changes schedule an update to make sure it's actually
             // correct since things might have changed during the animation
             if (hide_tracker != null) {
@@ -63,69 +56,32 @@ public class Gala.PanelClone : Object {
             }
         });
 
-        // Make sure the actor is visible once it's focused FIXME: better event not only focused
-        // https://github.com/elementary/gala/issues/2080
-        panel.window.focused.connect (update_visible);
-
-        update_visible ();
-        update_clone_position ();
-
         Idle.add_once (() => {
             if (hide_mode == NEVER) {
-                show ();
+                show (default_gesture_tracker, false);
             } else {
                 hide_tracker.schedule_update ();
             }
         });
     }
 
-    private void update_visible () {
-        actor.visible = !panel_hidden;
-
-        if (actor.visible && !wm.get_display ().get_monitor_in_fullscreen (panel.window.get_monitor ())) {
-            // The actor has just been revealed, make sure it's at the top
-            // https://github.com/elementary/gala/issues/2080
-            actor.get_parent ().set_child_above_sibling (actor, null);
-        }
-    }
-
-    private void update_clone_position () {
-        clone.set_position (calculate_clone_x (panel_hidden), calculate_clone_y (panel_hidden));
-    }
-
-    private float calculate_clone_x (bool hidden) {
+    private float calculate_y (bool hidden) {
         switch (panel.anchor) {
             case TOP:
+                return hidden ? -actor.height : 0;
             case BOTTOM:
-                return actor.x;
+                return hidden ? actor.height : 0;
             default:
                 return 0;
         }
     }
 
-    private float calculate_clone_y (bool hidden) {
-        switch (panel.anchor) {
-            case TOP:
-                return hidden ? actor.y - actor.height : actor.y;
-            case BOTTOM:
-                return hidden ? actor.y + actor.height : actor.y;
-            default:
-                return 0;
-        }
-    }
-
-    private int get_animation_duration () {
-        var fullscreen = wm.get_display ().get_monitor_in_fullscreen (panel.window.get_monitor ());
-        var should_animate = AnimationsSettings.get_enable_animations () && !wm.workspace_view.is_opened () && !fullscreen;
-        return should_animate ? ANIMATION_DURATION : 0;
-    }
-
-    private void hide () {
-        if (panel_hidden) {
+    private void hide (GestureTracker gesture_tracker, bool with_gesture) {
+        if (panel_hidden || last_gesture_tracker.recognizing) {
             return;
         }
 
-        panel_hidden = true;
+        last_gesture_tracker = gesture_tracker;
 
         if (!Meta.Util.is_wayland_compositor ()) {
             Utils.x11_set_window_pass_through (panel.window);
@@ -136,39 +92,24 @@ public class Gala.PanelClone : Object {
             return;
         }
 
-        clone.visible = true;
+        new GesturePropertyTransition (actor, gesture_tracker, "translation-y", null, calculate_y (true)).start (with_gesture);
 
-        clone.save_easing_state ();
-        clone.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-        clone.set_easing_duration (get_animation_duration ());
-        clone.y = calculate_clone_y (true);
-        clone.restore_easing_state ();
+        gesture_tracker.add_success_callback (with_gesture, () => panel_hidden = true);
     }
 
-    private void show () {
-        if (!panel_hidden) {
+    private void show (GestureTracker gesture_tracker, bool with_gesture) {
+        if (!panel_hidden || last_gesture_tracker.recognizing) {
             return;
         }
+
+        last_gesture_tracker = gesture_tracker;
 
         if (!Meta.Util.is_wayland_compositor ()) {
             Utils.x11_unset_window_pass_through (panel.window);
         }
 
-        clone.save_easing_state ();
-        clone.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-        clone.set_easing_duration (get_animation_duration ());
-        clone.y = calculate_clone_y (false);
-        clone.restore_easing_state ();
+        new GesturePropertyTransition (actor, gesture_tracker, "translation-y", null, calculate_y (false)).start (with_gesture);
 
-        unowned var y_transition = clone.get_transition ("y");
-        if (y_transition != null) {
-            y_transition.completed.connect (() => {
-                clone.visible = false;
-                panel_hidden = false;
-            });
-        } else {
-            clone.visible = false;
-            panel_hidden = false;
-        }
+        gesture_tracker.add_success_callback (with_gesture, () => panel_hidden = false);
     }
 }

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -8,7 +8,7 @@
 public class Gala.PanelWindow : Object {
     private static HashTable<Meta.Window, Meta.Strut?> window_struts = new HashTable<Meta.Window, Meta.Strut?> (null, null);
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
     public Meta.Window window { get; construct; }
     public Pantheon.Desktop.Anchor anchor { get; construct set; }
 
@@ -19,7 +19,7 @@ public class Gala.PanelWindow : Object {
     private int width = -1;
     private int height = -1;
 
-    public PanelWindow (WindowManager wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
+    public PanelWindow (WindowManagerGala wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
         Object (wm: wm, window: window, anchor: anchor);
     }
 
@@ -142,5 +142,9 @@ public class Gala.PanelWindow : Object {
             default:
                 return TOP;
         }
+    }
+
+    public void set_force_hide (bool force_hide, GestureTracker gesture_tracker, bool with_gesture) {
+        clone.set_force_hide (force_hide, gesture_tracker, with_gesture);
     }
 }

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -8,7 +8,7 @@
 public class Gala.ShellClientsManager : Object {
     private static ShellClientsManager instance;
 
-    public static void init (WindowManager wm) {
+    public static void init (WindowManagerGala wm) {
         if (instance != null) {
             return;
         }
@@ -20,7 +20,7 @@ public class Gala.ShellClientsManager : Object {
         return instance;
     }
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
 
     private NotificationsClient notifications_client;
     private ManagedClient[] protocol_clients = {};
@@ -28,7 +28,7 @@ public class Gala.ShellClientsManager : Object {
     private GLib.HashTable<Meta.Window, PanelWindow> panel_windows = new GLib.HashTable<Meta.Window, PanelWindow> (null, null);
     private GLib.HashTable<Meta.Window, WindowPositioner> positioned_windows = new GLib.HashTable<Meta.Window, WindowPositioner> (null, null);
 
-    private ShellClientsManager (WindowManager wm) {
+    private ShellClientsManager (WindowManagerGala wm) {
         Object (wm: wm);
     }
 
@@ -205,6 +205,12 @@ public class Gala.ShellClientsManager : Object {
         });
 
         return positioned;
+    }
+
+    public void set_force_hide_panels (bool force_hide, GestureTracker gesture_tracker, bool with_gesture) {
+        foreach (var panel in panel_windows.get_values ()) {
+            panel.set_force_hide (force_hide, gesture_tracker, with_gesture);
+        }
     }
 
     //X11 only

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -39,7 +39,6 @@ namespace Gala {
 
         private IconGroupContainer icon_groups;
         private Clutter.Actor workspaces;
-        private Clutter.Actor dock_clones;
         private Clutter.Actor primary_monitor_container;
         private Clutter.BrightnessContrastEffect brightness_effect;
 
@@ -83,8 +82,6 @@ namespace Gala {
 
             icon_groups = new IconGroupContainer (display.get_monitor_scale (display.get_primary_monitor ()));
 
-            dock_clones = new Clutter.Actor ();
-
             brightness_effect = new Clutter.BrightnessContrastEffect ();
             update_brightness_effect ();
 
@@ -101,7 +98,6 @@ namespace Gala {
             primary_monitor_container.add_child (icon_groups);
             primary_monitor_container.add_child (workspaces);
             add_child (primary_monitor_container);
-            add_child (dock_clones);
 
             unowned var manager = display.get_workspace_manager ();
             manager.workspace_added.connect (add_workspace);
@@ -675,9 +671,9 @@ namespace Gala {
             }
 
             if (opening) {
-                show_docks (with_gesture, is_cancel_animation);
+                ShellClientsManager.get_instance ().set_force_hide_panels (true, multitasking_gesture_tracker, with_gesture);
             } else {
-                hide_docks (with_gesture, is_cancel_animation);
+                ShellClientsManager.get_instance ().set_force_hide_panels (false, multitasking_gesture_tracker, with_gesture);
             }
 
             GestureTracker.OnEnd on_animation_end = (percentage, completions) => {
@@ -693,8 +689,6 @@ namespace Gala {
                         wm.background_group.show ();
                         wm.window_group.show ();
                         wm.top_window_group.show ();
-
-                        dock_clones.destroy_all_children ();
 
                         wm.pop_modal (modal_proxy);
                     }
@@ -713,107 +707,6 @@ namespace Gala {
                 on_animation_end (1, 1, 0);
             } else {
                 multitasking_gesture_tracker.connect_handlers (null, null, (owned) on_animation_end);
-            }
-        }
-
-        private void show_docks (bool with_gesture, bool is_cancel_animation) {
-            unowned GLib.List<Meta.WindowActor> window_actors = display.get_window_actors ();
-            foreach (unowned Meta.WindowActor actor in window_actors) {
-                const int MAX_OFFSET = 200;
-
-                if (actor.is_destroyed () || !actor.visible) {
-                    continue;
-                }
-
-                unowned Meta.Window window = actor.get_meta_window ();
-                var monitor = window.get_monitor ();
-
-                if (window.window_type != Meta.WindowType.DOCK) {
-                    continue;
-                }
-
-                if (NotificationStack.is_notification (window)) {
-                    continue;
-                }
-
-                if (display.get_monitor_in_fullscreen (monitor)) {
-                    continue;
-                }
-
-                var monitor_geom = display.get_monitor_geometry (monitor);
-
-                var window_geom = window.get_frame_rect ();
-                var top = monitor_geom.y + MAX_OFFSET > window_geom.y;
-                var bottom = monitor_geom.y + monitor_geom.height - MAX_OFFSET < window_geom.y;
-
-                if (!top && !bottom) {
-                    continue;
-                }
-
-                var initial_x = actor.x;
-                var initial_y = actor.y;
-                var target_y = (top)
-                    ? actor.y - actor.height
-                    : actor.y + actor.height;
-
-                var clone = new SafeWindowClone (window, true);
-                dock_clones.add_child (clone);
-
-                clone.set_position (initial_x, initial_y);
-
-                GestureTracker.OnUpdate on_animation_update = (percentage) => {
-                    var y = GestureTracker.animation_value (initial_y, target_y, percentage);
-                    clone.y = y;
-                };
-
-                GestureTracker.OnEnd on_animation_end = (percentage, completions) => {
-                    if (completions == 0) {
-                        return;
-                    }
-
-                    clone.save_easing_state ();
-                    clone.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    clone.set_easing_duration ((!is_cancel_animation && AnimationsSettings.get_enable_animations ()) ? ANIMATION_DURATION : 0);
-                    clone.y = target_y;
-                    clone.restore_easing_state ();
-                };
-
-                if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
-                    on_animation_end (1, 1, 0);
-                } else {
-                    multitasking_gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
-                }
-            }
-        }
-
-        private void hide_docks (bool with_gesture, bool is_cancel_animation) {
-            foreach (unowned var child in dock_clones.get_children ()) {
-                var dock = (Clutter.Clone) child;
-                var initial_y = dock.y;
-                var target_y = dock.source.y;
-
-                GestureTracker.OnUpdate on_animation_update = (percentage) => {
-                    var y = GestureTracker.animation_value (initial_y, target_y, percentage);
-                    dock.y = y;
-                };
-
-                GestureTracker.OnEnd on_animation_end = (percentage, completions) => {
-                    if (completions == 0) {
-                        return;
-                    }
-
-                    dock.save_easing_state ();
-                    dock.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    dock.set_easing_duration (AnimationsSettings.get_animation_duration (ANIMATION_DURATION));
-                    dock.y = target_y;
-                    dock.restore_easing_state ();
-                };
-
-                if (!with_gesture || !AnimationsSettings.get_enable_animations ()) {
-                    on_animation_end (1, 1, 0);
-                } else {
-                    multitasking_gesture_tracker.connect_handlers (null, (owned) on_animation_update, (owned) on_animation_end);
-                }
             }
         }
 


### PR DESCRIPTION
Includes #2192.

Same as #2150 but cleaned up for a rebase instead of squash for easier review

The additional changes here on top of #2192 are:

- Introduce a shell_group clutter actor that will be the parent of all shell UI WindowActors (e.g. panels, notifications, centered windows, etc.). This has the advantage that we have full control when and above what we show these. For example with this we can fix #2130, have wingpanel and dock interactable in the windowoverview (currently they show but you can't do anything with them) or eventually we can keep e.g. the dock visible and interactable in the multitasking view.
- Introduce a ShellClients.set_force_hide_panels to have all hiding/showing be done in the ShellClients instead of having the multitasking view do their own thing. This has to be done together with the shell group or else we get duplicate dock clones, etc.

Closes #2192 if merged before it.