### PR TITLE
Add fullscreen effect and move to old ws on close

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -39,8 +39,10 @@
       </description>
       <issues>
         <issue url="https://github.com/elementary/gala/issues/397">Prevent PIP overlapping wingpanel?</issue>
+        <issue url="https://github.com/elementary/gala/issues/551">Return to original workspace if a fullscreen window is closed and there is no more windows open</issue>
         <issue url="https://github.com/elementary/gala/issues/857">Toggling the active window's maximization state during multitasking view messes up the window preview size</issue>
         <issue url="https://github.com/elementary/gala/issues/1967">Some apps ignore HiDPI mode</issue>
+        <issue url="https://github.com/elementary/gala/issues/1986">Does not return to the first virtual desktop after exiting fullscreen mode.</issue>
         <issue url="https://github.com/elementary/gala/issues/2088">Invisible window clones</issue>
         <issue url="https://github.com/elementary/gala/issues/2113">gnome-session-x11-services-ready.target isn't started on Wayland session</issue>
         <issue url="https://github.com/elementary/gala/issues/2131">Unthemed cursor style and glitchy menus on some applications</issue>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1564,7 +1564,7 @@ namespace Gala {
         public override void destroy (Meta.WindowActor actor) {
             unowned var window = actor.get_meta_window ();
 
-            actor.destroy.connect (() => {
+            actor.destroy.connect (() => Idle.add (() => {
                 if (ws_assoc.contains (window)) {
                     var old_ws_index = ws_assoc[window];
                     var old_ws = get_display ().get_workspace_manager ().get_workspace_by_index (old_ws_index);
@@ -1573,7 +1573,9 @@ namespace Gala {
                         old_ws.activate (Meta.CURRENT_TIME);
                     }
                 }
-            });
+
+                return Source.REMOVE;
+            }));
 
             actor.remove_all_transitions ();
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1168,50 +1168,6 @@ namespace Gala {
          * effects
          */
 
-        private void handle_fullscreen_window (Meta.Window window, Meta.SizeChange which_change) {
-            // Only handle windows which are located on the primary monitor
-            if (!window.is_on_primary_monitor () || !behavior_settings.get_boolean ("move-fullscreened-workspace"))
-                return;
-
-            // Due to how this is implemented, by relying on the functionality
-            // offered by the dynamic workspace handler, let's just bail out
-            // if that's not available.
-            if (!Meta.Prefs.get_dynamic_workspaces ())
-                return;
-
-            unowned Meta.Display display = get_display ();
-            var time = display.get_current_time ();
-            unowned Meta.Workspace win_ws = window.get_workspace ();
-            unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
-
-            if (which_change == Meta.SizeChange.FULLSCREEN) {
-                // Do nothing if the current workspace would be empty
-                if (Utils.get_n_windows (win_ws) <= 1)
-                    return;
-
-                var old_ws_index = win_ws.index ();
-                var new_ws_index = old_ws_index + 1;
-                InternalUtils.insert_workspace_with_window (new_ws_index, window);
-
-                unowned var new_ws = manager.get_workspace_by_index (new_ws_index);
-                window.change_workspace (new_ws);
-                new_ws.activate_with_focus (window, time);
-
-                ws_assoc.insert (window, old_ws_index);
-            } else if (ws_assoc.contains (window)) {
-                var old_ws_index = ws_assoc.get (window);
-                var new_ws_index = win_ws.index ();
-
-                if (new_ws_index != old_ws_index && old_ws_index < manager.get_n_workspaces ()) {
-                    unowned var old_ws = manager.get_workspace_by_index (old_ws_index);
-                    window.change_workspace (old_ws);
-                    old_ws.activate_with_focus (window, time);
-                }
-
-                ws_assoc.remove (window);
-            }
-        }
-
         // must wait for size_changed to get updated frame_rect
         // as which_change is not passed to size_changed, save it as instance variable
 #if HAS_MUTTER45
@@ -1257,8 +1213,10 @@ namespace Gala {
                     unmaximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
                     break;
                 case Meta.SizeChange.FULLSCREEN:
+                    maximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
+                    break;
                 case Meta.SizeChange.UNFULLSCREEN:
-                    handle_fullscreen_window (window, which_change_local);
+                    unmaximize (actor, new_rect.x, new_rect.y, new_rect.width, new_rect.height);
                     break;
                 default:
                     break;
@@ -1347,7 +1305,8 @@ namespace Gala {
             kill_window_effects (actor);
 
             unowned var window = actor.get_meta_window ();
-            if (window.maximized_horizontally && behavior_settings.get_boolean ("move-maximized-workspace")) {
+            if (window.maximized_horizontally && behavior_settings.get_boolean ("move-maximized-workspace")
+                || window.fullscreen && behavior_settings.get_boolean ("move-fullscreened-workspace")) {
                 move_window_to_next_ws (window);
             }
 
@@ -1605,7 +1564,16 @@ namespace Gala {
         public override void destroy (Meta.WindowActor actor) {
             unowned var window = actor.get_meta_window ();
 
-            ws_assoc.remove (window);
+            actor.destroy.connect (() => {
+                if (ws_assoc.contains (window)) {
+                    var old_ws_index = ws_assoc[window];
+                    var old_ws = get_display ().get_workspace_manager ().get_workspace_by_index (old_ws_index);
+
+                    if (old_ws != null) {
+                        old_ws.activate (Meta.CURRENT_TIME);
+                    }
+                }
+            });
 
             actor.remove_all_transitions ();
 
@@ -1728,9 +1696,7 @@ namespace Gala {
             kill_window_effects (actor);
             unowned var window = actor.get_meta_window ();
 
-            if (behavior_settings.get_boolean ("move-maximized-workspace")) {
-                move_window_to_old_ws (window);
-            }
+            move_window_to_old_ws (window);
 
             if (window.window_type == Meta.WindowType.NORMAL) {
                 float offset_x, offset_y;


### PR DESCRIPTION
Fullscreening/Unfullscreening will now play the same effect as maximizing and unmaximizing (since it's pretty much just an extended version of that action I think it fits)

Also we will now move to the old ws if a window that was moved to a new ws is closed.

Fixes #1986
Fixes https://github.com/elementary/gala/issues/551
Closes #2146