### PR TITLE
Introduce a shell group

### DIFF
--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -388,5 +388,15 @@ namespace Gala {
             Clutter.get_default_backend ().get_default_seat ().bell_notify ();
 #endif
         }
+
+        public static void update_transients_visible (Meta.Window window, bool visible) {
+            window.foreach_transient ((transient) => {
+                var actor = (Meta.WindowActor) transient.get_compositor_private ();
+
+                actor.visible = visible;
+
+                return true;
+            });
+        }
     }
 }

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -391,7 +391,7 @@ namespace Gala {
 
         public static void update_transients_visible (Meta.Window window, bool visible) {
             window.foreach_transient ((transient) => {
-                var actor = (Meta.WindowActor) transient.get_compositor_private ();
+                unowned var actor = (Meta.WindowActor) transient.get_compositor_private ();
 
                 actor.visible = visible;
 

--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -152,7 +152,7 @@ public class Gala.HideTracker : Object {
         });
     }
 
-    private void update_overlap () {
+    public void update_overlap () {
         overlap = false;
         focus_overlap = false;
         focus_maximized_overlap = false;

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -8,7 +8,7 @@
 public class Gala.PanelClone : Object {
     private const int ANIMATION_DURATION = 250;
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
     public unowned PanelWindow panel { get; construct; }
 
     public Pantheon.Desktop.HideMode hide_mode {
@@ -38,7 +38,7 @@ public class Gala.PanelClone : Object {
 
     private HideTracker? hide_tracker;
 
-    public PanelClone (WindowManager wm, PanelWindow panel) {
+    public PanelClone (WindowManagerGala wm, PanelWindow panel) {
         Object (wm: wm, panel: panel);
     }
 
@@ -46,6 +46,8 @@ public class Gala.PanelClone : Object {
         default_gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
 
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
+        actor.get_parent ().remove_child (actor);
+        wm.shell_group.add_child (actor);
 
         notify["panel-hidden"].connect (() => {
             // When hidden changes schedule an update to make sure it's actually
@@ -54,6 +56,8 @@ public class Gala.PanelClone : Object {
                 hide_tracker.schedule_update ();
             }
         });
+
+        wm.get_display ().in_fullscreen_changed.connect (check_hide);
 
         Idle.add_once (() => {
             if (hide_mode == NEVER) {
@@ -89,13 +93,17 @@ public class Gala.PanelClone : Object {
             return;
         }
 
-        new GesturePropertyTransition (actor, default_gesture_tracker, "translation-y", null, calculate_translation_y (true)).start (false);
+        InternalUtils.update_transients_visible (panel.window, false);
+
+        new GesturePropertyTransition (
+            actor, default_gesture_tracker, "translation-y", null, calculate_translation_y (true)
+        ).start (false, () => InternalUtils.update_transients_visible (panel.window, !panel_hidden));
 
         default_gesture_tracker.add_success_callback (false, () => panel_hidden = true);
     }
 
     private void show () {
-        if (!panel_hidden || default_gesture_tracker.recognizing) {
+        if (!panel_hidden || default_gesture_tracker.recognizing || wm.get_display ().get_monitor_in_fullscreen (panel.window.get_monitor ())) {
             return;
         }
 
@@ -103,8 +111,20 @@ public class Gala.PanelClone : Object {
             Utils.x11_unset_window_pass_through (panel.window);
         }
 
-        new GesturePropertyTransition (actor, default_gesture_tracker, "translation-y", null, calculate_translation_y (false)).start (false);
+        new GesturePropertyTransition (
+            actor, default_gesture_tracker, "translation-y", null, calculate_translation_y (false)
+        ).start (false, () => InternalUtils.update_transients_visible (panel.window, !panel_hidden));
 
         default_gesture_tracker.add_success_callback (false, () => panel_hidden = false);
+    }
+
+    private void check_hide () {
+        if (wm.get_display ().get_monitor_in_fullscreen (panel.window.get_monitor ())) {
+            hide ();
+        } else if (hide_mode == NEVER) {
+            show ();
+        } else {
+            hide_tracker.update_overlap ();
+        }
     }
 }

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -8,7 +8,7 @@
 public class Gala.PanelClone : Object {
     private const int ANIMATION_DURATION = 250;
 
-    public WindowManagerGala wm { get; construct; }
+    public WindowManager wm { get; construct; }
     public unowned PanelWindow panel { get; construct; }
 
     public Pantheon.Desktop.HideMode hide_mode {
@@ -38,7 +38,7 @@ public class Gala.PanelClone : Object {
 
     private HideTracker? hide_tracker;
 
-    public PanelClone (WindowManagerGala wm, PanelWindow panel) {
+    public PanelClone (WindowManager wm, PanelWindow panel) {
         Object (wm: wm, panel: panel);
     }
 
@@ -46,7 +46,6 @@ public class Gala.PanelClone : Object {
         default_gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
 
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
-        InternalUtils.clutter_actor_reparent (actor, wm.shell_group);
 
         notify["panel-hidden"].connect (() => {
             // When hidden changes schedule an update to make sure it's actually

--- a/src/ShellClients/PanelClone.vala
+++ b/src/ShellClients/PanelClone.vala
@@ -46,8 +46,7 @@ public class Gala.PanelClone : Object {
         default_gesture_tracker = new GestureTracker (ANIMATION_DURATION, ANIMATION_DURATION);
 
         actor = (Meta.WindowActor) panel.window.get_compositor_private ();
-        actor.get_parent ().remove_child (actor);
-        wm.shell_group.add_child (actor);
+        InternalUtils.clutter_actor_reparent (actor, wm.shell_group);
 
         notify["panel-hidden"].connect (() => {
             // When hidden changes schedule an update to make sure it's actually

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -8,7 +8,7 @@
 public class Gala.PanelWindow : Object {
     private static HashTable<Meta.Window, Meta.Strut?> window_struts = new HashTable<Meta.Window, Meta.Strut?> (null, null);
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
     public Meta.Window window { get; construct; }
     public Pantheon.Desktop.Anchor anchor { get; construct set; }
 
@@ -19,7 +19,7 @@ public class Gala.PanelWindow : Object {
     private int width = -1;
     private int height = -1;
 
-    public PanelWindow (WindowManager wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
+    public PanelWindow (WindowManagerGala wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
         Object (wm: wm, window: window, anchor: anchor);
     }
 

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -8,7 +8,7 @@
 public class Gala.PanelWindow : Object {
     private static HashTable<Meta.Window, Meta.Strut?> window_struts = new HashTable<Meta.Window, Meta.Strut?> (null, null);
 
-    public WindowManagerGala wm { get; construct; }
+    public WindowManager wm { get; construct; }
     public Meta.Window window { get; construct; }
     public Pantheon.Desktop.Anchor anchor { get; construct set; }
 
@@ -19,7 +19,7 @@ public class Gala.PanelWindow : Object {
     private int width = -1;
     private int height = -1;
 
-    public PanelWindow (WindowManagerGala wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
+    public PanelWindow (WindowManager wm, Meta.Window window, Pantheon.Desktop.Anchor anchor) {
         Object (wm: wm, window: window, anchor: anchor);
     }
 

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -8,7 +8,7 @@
 public class Gala.ShellClientsManager : Object {
     private static ShellClientsManager instance;
 
-    public static void init (WindowManagerGala wm) {
+    public static void init (WindowManager wm) {
         if (instance != null) {
             return;
         }

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -20,7 +20,7 @@ public class Gala.ShellClientsManager : Object {
         return instance;
     }
 
-    public WindowManagerGala wm { get; construct; }
+    public WindowManager wm { get; construct; }
 
     private NotificationsClient notifications_client;
     private ManagedClient[] protocol_clients = {};
@@ -28,7 +28,7 @@ public class Gala.ShellClientsManager : Object {
     private GLib.HashTable<Meta.Window, PanelWindow> panel_windows = new GLib.HashTable<Meta.Window, PanelWindow> (null, null);
     private GLib.HashTable<Meta.Window, WindowPositioner> positioned_windows = new GLib.HashTable<Meta.Window, WindowPositioner> (null, null);
 
-    private ShellClientsManager (WindowManagerGala wm) {
+    private ShellClientsManager (WindowManager wm) {
         Object (wm: wm);
     }
 
@@ -191,7 +191,7 @@ public class Gala.ShellClientsManager : Object {
     }
 
     private bool is_itself_positioned (Meta.Window window) {
-        return (window in positioned_windows) || (window in panel_windows);
+        return (window in positioned_windows) || (window in panel_windows) || NotificationStack.is_notification (window);
     }
 
     public bool is_positioned_window (Meta.Window window) {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -8,7 +8,7 @@
 public class Gala.ShellClientsManager : Object {
     private static ShellClientsManager instance;
 
-    public static void init (WindowManager wm) {
+    public static void init (WindowManagerGala wm) {
         if (instance != null) {
             return;
         }
@@ -20,7 +20,7 @@ public class Gala.ShellClientsManager : Object {
         return instance;
     }
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
 
     private NotificationsClient notifications_client;
     private ManagedClient[] protocol_clients = {};
@@ -28,7 +28,7 @@ public class Gala.ShellClientsManager : Object {
     private GLib.HashTable<Meta.Window, PanelWindow> panel_windows = new GLib.HashTable<Meta.Window, PanelWindow> (null, null);
     private GLib.HashTable<Meta.Window, WindowPositioner> positioned_windows = new GLib.HashTable<Meta.Window, WindowPositioner> (null, null);
 
-    private ShellClientsManager (WindowManager wm) {
+    private ShellClientsManager (WindowManagerGala wm) {
         Object (wm: wm);
     }
 

--- a/src/Widgets/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView.vala
@@ -28,7 +28,7 @@ namespace Gala {
         private GestureTracker multitasking_gesture_tracker;
         private GestureTracker workspace_gesture_tracker;
 
-        public WindowManager wm { get; construct; }
+        public WindowManagerGala wm { get; construct; }
 
         private Meta.Display display;
         private ModalProxy modal_proxy;
@@ -53,7 +53,7 @@ namespace Gala {
             }
         }
 
-        public MultitaskingView (WindowManager wm) {
+        public MultitaskingView (WindowManagerGala wm) {
             Object (wm: wm);
         }
 
@@ -631,6 +631,7 @@ namespace Gala {
                 wm.background_group.hide ();
                 wm.window_group.hide ();
                 wm.top_window_group.hide ();
+                wm.shell_group.hide ();
                 show ();
                 grab_key_focus ();
 
@@ -693,6 +694,7 @@ namespace Gala {
                         wm.background_group.show ();
                         wm.window_group.show ();
                         wm.top_window_group.show ();
+                        wm.shell_group.show ();
 
                         dock_clones.destroy_all_children ();
 
@@ -721,7 +723,7 @@ namespace Gala {
             foreach (unowned Meta.WindowActor actor in window_actors) {
                 const int MAX_OFFSET = 200;
 
-                if (actor.is_destroyed () || !actor.visible) {
+                if (actor.is_destroyed () || !actor.visible || actor.translation_y != 0) {
                     continue;
                 }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1170,9 +1170,7 @@ namespace Gala {
 
         private void check_shell_window (Meta.WindowActor actor) {
             unowned var window = actor.get_meta_window ();
-            if (ShellClientsManager.get_instance ().is_positioned_window (window)
-                || NotificationStack.is_notification (window)
-            ) {
+            if (ShellClientsManager.get_instance ().is_positioned_window (window)) {
                 InternalUtils.clutter_actor_reparent (actor, shell_group);
             }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -39,7 +39,7 @@ namespace Gala {
 
         /**
          * The group that contains all WindowActors that make shell elements, that is all windows reported as
-         * ShellClientsManager.is_positioned_window and notifications, as well as manually added elements.
+         * ShellClientsManager.is_positioned_window.
          * It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
          * responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).
          */

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2159,9 +2159,9 @@ namespace Gala {
             }
         }
 
-        private bool end_switch_workspace () {
+        private void end_switch_workspace () {
             if ((windows == null || parents == null) && tmp_actors == null)
-                return false;
+                return;
 
             unowned var display = get_display ();
             unowned var active_workspace = display.get_workspace_manager ().get_active_workspace ();
@@ -2225,14 +2225,10 @@ namespace Gala {
 
             switch_workspace_with_gesture = false;
             animating_switch_workspace = false;
-
-            return true;
         }
 
         public override void kill_switch_workspace () {
-            if (end_switch_workspace ()) {
-                switch_workspace_completed ();
-            }
+            end_switch_workspace ();
         }
 
         public override void locate_pointer () {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1173,8 +1173,7 @@ namespace Gala {
             if (ShellClientsManager.get_instance ().is_positioned_window (window)
                 || NotificationStack.is_notification (window)
             ) {
-                actor.get_parent ().remove_child (actor);
-                shell_group.add_child (actor);
+                InternalUtils.clutter_actor_reparent (actor, shell_group);
             }
 
             if (NotificationStack.is_notification (window)) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -37,7 +37,13 @@ namespace Gala {
          */
         public Clutter.Actor top_window_group { get; protected set; }
 
-        public Clutter.Actor notification_group { get; protected set; }
+        /**
+         * The group that contains all WindowActors that make shell elements, that is all windows reported as
+         * ShellClientsManager.is_positioned_window and notifications, as well as manually added elements.
+         * It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
+         * responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).
+         */
+        public Clutter.Actor shell_group { get; private set; }
 
         /**
          * {@inheritDoc}
@@ -103,8 +109,6 @@ namespace Gala {
         private GestureTracker gesture_tracker;
         private bool animating_switch_workspace = false;
         private bool switch_workspace_with_gesture = false;
-
-        private signal void window_created (Meta.Window window);
 
         /**
          * Amount of pixels to move on the nudge animation.
@@ -253,14 +257,6 @@ namespace Gala {
             stage.remove_child (top_window_group);
             ui_group.add_child (top_window_group);
 
-#if HAS_MUTTER44
-            var feedback_group = display.get_compositor ().get_feedback_group ();
-#else
-            var feedback_group = display.get_feedback_group ();
-#endif
-            stage.remove_child (feedback_group);
-            ui_group.add_child (feedback_group);
-
             // Initialize plugins and add default components if no plugin overrides them
             unowned var plugin_manager = PluginManager.get_default ();
             plugin_manager.initialize (this);
@@ -293,8 +289,16 @@ namespace Gala {
             }
 
             // Add the remaining components that should be on top
-            notification_group = new Clutter.Actor ();
-            ui_group.add_child (notification_group);
+            shell_group = new Clutter.Actor ();
+            ui_group.add_child (shell_group);
+
+#if HAS_MUTTER44
+            var feedback_group = display.get_compositor ().get_feedback_group ();
+#else
+            var feedback_group = display.get_feedback_group ();
+#endif
+            stage.remove_child (feedback_group);
+            ui_group.add_child (feedback_group);
 
             pointer_locator = new PointerLocator (display);
             ui_group.add_child (pointer_locator);
@@ -381,11 +385,13 @@ namespace Gala {
 
             update_input_area ();
 
-            display.window_created.connect ((window) => window_created (window));
-
             var scroll_action = new SuperScrollAction (display);
             scroll_action.triggered.connect (handle_super_scroll);
             stage.add_action_full ("wm-super-scroll-action", CAPTURE, scroll_action);
+
+            display.window_created.connect ((window) =>
+                InternalUtils.wait_for_window_actor_visible (window, check_shell_window)
+            );
 
             stage.show ();
 
@@ -1162,6 +1168,20 @@ namespace Gala {
             show_window_menu (window, menu, rect.x, rect.y);
         }
 
+        private void check_shell_window (Meta.WindowActor actor) {
+            unowned var window = actor.get_meta_window ();
+            if (ShellClientsManager.get_instance ().is_positioned_window (window)
+                || NotificationStack.is_notification (window)
+            ) {
+                actor.get_parent ().remove_child (actor);
+                shell_group.add_child (actor);
+            }
+
+            if (NotificationStack.is_notification (window)) {
+                notification_stack.show_notification (actor);
+            }
+        }
+
         /*
          * effects
          */
@@ -1436,12 +1456,8 @@ namespace Gala {
             actor.remove_all_transitions ();
             actor.show ();
 
-            // Notifications are a special case and have to be always be handled
-            // (also regardless of the animation setting)
+            // Notifications initial animation is handled by the notification stack
             if (NotificationStack.is_notification (window)) {
-                InternalUtils.clutter_actor_reparent (actor, notification_group);
-                notification_stack.show_notification (actor);
-
                 map_completed (actor);
                 return;
             }
@@ -1843,7 +1859,6 @@ namespace Gala {
         private List<Clutter.Actor>? windows;
         private List<Clutter.Actor>? parents;
         private List<Clutter.Actor>? tmp_actors;
-        private ulong switch_workspace_window_created_id = 0;
         private Clutter.Actor? out_group;
         private Clutter.Actor? in_group;
         private Clutter.Actor? wallpaper;
@@ -1932,7 +1947,10 @@ namespace Gala {
                     continue;
                 }
 
-                if (!window.showing_on_its_workspace () || move_primary_only && !window.is_on_primary_monitor ()) {
+                if (!window.showing_on_its_workspace () ||
+                    move_primary_only && !window.is_on_primary_monitor () ||
+                    actor.get_parent () == shell_group
+                ) {
                     continue;
                 }
 
@@ -2045,17 +2063,6 @@ namespace Gala {
 
             prepare_workspace_switch (from, to, direction);
 
-            // while a workspace is being switched mutter doesn't map windows
-            // TODO: currently only notifications are handled here, other windows should be too
-            switch_workspace_window_created_id = window_created.connect ((window) => {
-                if (NotificationStack.is_notification (window)) {
-                    InternalUtils.wait_for_window_actor_visible (window, (actor) => {
-                        InternalUtils.clutter_actor_reparent (actor, notification_group);
-                        notification_stack.show_notification (actor);
-                    });
-                }
-            });
-
             var animation_mode = Clutter.AnimationMode.EASE_OUT_CUBIC;
 
             var x2 = -in_group.x;
@@ -2127,11 +2134,8 @@ namespace Gala {
                 return;
             }
 
-            if (switch_workspace_window_created_id > 0) {
-                disconnect (switch_workspace_window_created_id);
-                switch_workspace_window_created_id = 0;
-            }
             end_switch_workspace ();
+
             if (!is_nudge_animation) {
                 switch_workspace_completed ();
             }
@@ -2156,9 +2160,9 @@ namespace Gala {
             }
         }
 
-        private void end_switch_workspace () {
-            if (windows == null || parents == null)
-                return;
+        private bool end_switch_workspace () {
+            if ((windows == null || parents == null) && tmp_actors == null)
+                return false;
 
             unowned var display = get_display ();
             unowned var active_workspace = display.get_workspace_manager ().get_active_workspace ();
@@ -2222,10 +2226,14 @@ namespace Gala {
 
             switch_workspace_with_gesture = false;
             animating_switch_workspace = false;
+
+            return true;
         }
 
         public override void kill_switch_workspace () {
-            end_switch_workspace ();
+            if (end_switch_workspace ()) {
+                switch_workspace_completed ();
+            }
         }
 
         public override void locate_pointer () {


### PR DESCRIPTION
Since moving the panel hiding from the multitasking view completely to the shell clients and introducing a shell group are bigger changes, I think they probably should be separated which is what this PR does.

It still includes the new version of #2192 but now only introduces the shell group which is (taken from the code comment):

> The group that contains all WindowActors that make shell elements, that is all windows reported as 
ShellClientsManager.is_positioned_window and notifications, as well as manually added elements.
         It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
         responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).

This will allow us to fix https://github.com/elementary/gala/issues/2130, have wingpanel and dock interactable in the windowoverview (currently they show but you can't do anything with them) or eventually we can keep e.g. the dock visible and interactable in the multitasking view.

There are no functional changes apart from the side effect that we get a nice hide animation for the panels when entering fullscreen.

This will now be required for moving all hiding logic to shell clients from the multitasking view (#2193) which will allow us to do some nice consistency improvements :)