### PR TITLE
ScreenshotManager: Fix invalid syntax

### DIFF
--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -155,7 +155,7 @@ namespace Gala {
             var rect = window.get_frame_rect ();
 #if HAS_MUTTER45
             if (!include_frame) {
-#if else
+#else
             if ((include_frame && window.is_client_decorated ()) ||
                 (!include_frame && !window.is_client_decorated ())) {
 #endif


### PR DESCRIPTION
This invalid syntax does not seem to be affected for our build but could be a problem when `HAS_MUTTER45` is not met.