### PR TITLE
DesktopIntegration: new method to close window used by dock

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -183,4 +183,28 @@ public class Gala.DesktopIntegration : GLib.Object {
 
         wm.window_overview.open (hints);
     }
+
+    public void close_window (uint64 uid) throws GLib.DBusError, GLib.IOError {
+
+        var apps = Gala.AppSystem.get_default().get_running_apps();
+
+        foreach (unowned var app in apps) {
+
+            foreach (weak Meta.Window window in app.get_windows()) {
+
+                if (window.get_id() == uid) {
+
+                    window.delete(0);
+
+                    return;
+
+                }
+
+            }
+
+        }
+
+        throw new GLib.IOError.NOT_FOUND("Window not found");
+
+    }
 }


### PR DESCRIPTION
Implementation of close_window method on Gala.DesktopIntegration to solve the issue: https://github.com/elementary/dock/issues/278 
https://github.com/elementary/dock/pull/344