### PR TITLE
Cleanup WindowManager

### DIFF
--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -34,7 +34,7 @@ public class Gala.DBus {
             (connection) => {
                 try {
                     connection.register_object ("/org/gnome/Shell", DBusAccelerator.init (wm.get_display ()));
-                    connection.register_object ("/org/gnome/Shell/Screenshot", ScreenshotManager.init (wm));
+                    connection.register_object ("/org/gnome/Shell/Screenshot", ScreenshotManager.get_default ());
                 } catch (Error e) { warning (e.message); }
             },
             () => {},

--- a/src/InternalUtils.vala
+++ b/src/InternalUtils.vala
@@ -369,5 +369,16 @@ namespace Gala {
                 }
             });
         }
+
+        public static void clutter_actor_reparent (Clutter.Actor actor, Clutter.Actor new_parent) {
+            if (actor == new_parent) {
+                return;
+            }
+
+            actor.ref ();
+            actor.get_parent ().remove_child (actor);
+            new_parent.add_child (actor);
+            actor.unref ();
+        }
     }
 }

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -57,7 +57,7 @@ namespace Gala {
             );
             display.add_keybinding (
                 "area-screenshot-clip", keybinding_settings, IGNORE_AUTOREPEAT, () => instance.handle_screenshot_area_shortcut.begin (true)
-            );  
+            );
         }
 
         private static ScreenshotManager? instance;

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1441,7 +1441,7 @@ namespace Gala {
             // Notifications are a special case and have to be always be handled
             // (also regardless of the animation setting)
             if (NotificationStack.is_notification (window)) {
-                clutter_actor_reparent (actor, notification_group);
+                InternalUtils.clutter_actor_reparent (actor, notification_group);
                 notification_stack.show_notification (actor);
 
                 map_completed (actor);
@@ -1947,7 +1947,7 @@ namespace Gala {
                     windows.append (actor);
                     parents.append (actor.get_parent ());
 
-                    clutter_actor_reparent (actor, static_windows);
+                    InternalUtils.clutter_actor_reparent (actor, static_windows);
                     actor.set_translation (-clone_offset_x, -clone_offset_y, 0);
 
                     // Don't fade docks and moving/grabbed windows they just stay where they are
@@ -1968,7 +1968,7 @@ namespace Gala {
                     windows.append (actor);
                     parents.append (actor.get_parent ());
                     actor.set_translation (-clone_offset_x, -clone_offset_y, 0);
-                    clutter_actor_reparent (actor, out_group);
+                    InternalUtils.clutter_actor_reparent (actor, out_group);
 
                     if (window.fullscreen)
                         from_has_fullscreened = true;
@@ -1977,7 +1977,7 @@ namespace Gala {
                     windows.append (actor);
                     parents.append (actor.get_parent ());
                     actor.set_translation (-clone_offset_x, -clone_offset_y, 0);
-                    clutter_actor_reparent (actor, in_group);
+                    InternalUtils.clutter_actor_reparent (actor, in_group);
 
                     if (window.fullscreen)
                         to_has_fullscreened = true;
@@ -2052,7 +2052,7 @@ namespace Gala {
             switch_workspace_window_created_id = window_created.connect ((window) => {
                 if (NotificationStack.is_notification (window)) {
                     InternalUtils.wait_for_window_actor_visible (window, (actor) => {
-                        clutter_actor_reparent (actor, notification_group);
+                        InternalUtils.clutter_actor_reparent (actor, notification_group);
                         notification_stack.show_notification (actor);
                     });
                 }
@@ -2175,13 +2175,13 @@ namespace Gala {
 
                 unowned Meta.WindowActor? window = actor as Meta.WindowActor;
                 if (window == null) {
-                    clutter_actor_reparent (actor, parents.nth_data (i));
+                    InternalUtils.clutter_actor_reparent (actor, parents.nth_data (i));
                     continue;
                 }
 
                 unowned Meta.Window? meta_window = window.get_meta_window ();
                 if (!window.is_destroyed ()) {
-                    clutter_actor_reparent (actor, parents.nth_data (i));
+                    InternalUtils.clutter_actor_reparent (actor, parents.nth_data (i));
                 }
 
                 kill_window_effects (window);
@@ -2346,18 +2346,5 @@ namespace Gala {
                 // Ignore this error
             }
         }
-
-        private static void clutter_actor_reparent (Clutter.Actor actor, Clutter.Actor new_parent) {
-            if (actor == new_parent)
-                return;
-
-            actor.ref ();
-            actor.get_parent ().remove_child (actor);
-            new_parent.add_child (actor);
-            actor.unref ();
-        }
     }
-
-    [CCode (cname="clutter_x11_get_stage_window")]
-    public extern X.Window x_get_stage_window (Clutter.Actor stage);
 }


### PR DESCRIPTION
1. Move `clutter_actor_reparent` into InternalUtils
2. Move handling screenshot shortcuts into ScreenshotManager

Don't merge until 8.1.0 is released