### PR TITLE
WindowManager: Fix cancelling window move gesture

### DIFF
--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -2145,7 +2145,14 @@ namespace Gala {
                 unowned Meta.Display display = get_display ();
                 unowned var active_workspace = display.get_workspace_manager ().get_active_workspace ();
                 unowned var neighbor = active_workspace.get_neighbor (cancel_direction);
-                neighbor.activate (display.get_current_time ());
+
+                if (moving != null) {
+                    move_window (moving, neighbor, Meta.CURRENT_TIME);
+                } else {
+                    neighbor.activate (display.get_current_time ());
+                }
+            } else {
+                moving = null;
             }
         }
 
@@ -2207,7 +2214,6 @@ namespace Gala {
 
             windows = null;
             parents = null;
-            moving = null;
 
             out_group = null;
             in_group = null;


### PR DESCRIPTION
Currently when cancelling the move gesture, the window stays on the new workspace, leading to some glitches because we show it on the active one anyways because of some manual reparenting. Now we move it back to our original (active) workspace when cancelled.