### PR TITLE
WorkspaceManager: Fix crash on workspace removed

### DIFF
--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -229,6 +229,10 @@ public class Gala.WorkspaceManager : Object {
 
         workspaces_marked_removed.add (workspace);
 
+        // We might be here because of a signal emition from the ws machinery (e.g. workspace.window_removed).
+        // Often the function emitting the signal doesn't take a ref on the ws so if we remove it right
+        // away it will be freed. But because the function often accesses it after the singal emition this leads
+        // to warnings and in some cases a crash.
         Idle.add (() => remove_workspace (workspace));
     }
 


### PR DESCRIPTION
Tries to do the same as #2243.
It also fixes some warnings `g_object_notify: assertion 'G_IS_OBJECT (object)' failed`.

The reason from the code comment:

> We might be here because of a signal emition from the ws machinery (e.g. workspace.window_removed).
> Often the function emitting the signal doesn't take a ref on the ws so if we remove it right
> away it will be freed. But because the function often accesses it after the singal emition this leads
> to warnings and in some cases a crash.

Might fix https://github.com/elementary/gala/issues/2242, https://github.com/elementary/gala/issues/2227, https://github.com/elementary/gala/issues/2232.
Fixes the crash described in #2258 


