### PR TITLE
Add support for permanent workspaces

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -107,6 +107,11 @@
       <summary>What action should be performed on Super + Scroll</summary>
       <description></description>
     </key>
+    <key type="i" name="permanent-workspaces">
+      <default>0</default>
+      <summary>How many workspaces should be permanent</summary>
+      <description></description>
+    </key>
   </schema>
 
   <schema path="/io/elementary/desktop/wm/keybindings/" id="io.elementary.desktop.wm.keybindings">

--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -183,4 +183,24 @@ public class Gala.DesktopIntegration : GLib.Object {
 
         wm.window_overview.open (hints);
     }
+
+    public void set_workspace_permanent (int index, bool permanent) throws DBusError, IOError {
+        unowned var manager = wm.get_display ().get_workspace_manager ();
+
+        if (index < 0 || index >= manager.n_workspaces) {
+            throw new IOError.FAILED ("Invalid workspace index");
+        }
+
+        WorkspaceManager.get_default ().set_permanent (manager.get_workspace_by_index (index), permanent);
+    }
+
+    public bool is_workspace_permanent (int index) throws DBusError, IOError {
+        unowned var manager = wm.get_display ().get_workspace_manager ();
+
+        if (index < 0 || index >= manager.n_workspaces) {
+            throw new IOError.FAILED ("Invalid workspace index");
+        }
+
+        return WorkspaceManager.get_default ().is_permanent (manager.get_workspace_by_index (index));
+    }
 }


### PR DESCRIPTION
I've thought of this a while ago but wasn't sure how the UI would look like. Now I think it might be best as a context menu for the dock workspaces.

What this allows is to mark certain workspaces as "permanent". This means they wont be removed once there are no more windows on them. They will also already be available when starting.
This allows for a kind of hybrid between static and dynamic workspaces. If you don't mark anything as permanent behavior doesn't change compared to main.

The reason for this is that I found having static workspaces more useful for certain situations. For example currently when studying I like to have my first workspace for a browser window with misc stuff and my second workspace for the stuff that I need for my next exam and my third workspace for the stuff that I need for the exam after that. But sometimes I just want to start with the last one but after 5 minutes I want to google some unrelated stuff which I usually do on the first workspace. But now I have to open the browser on the second workspace and reorder. Building muscle memory like that (e.g. super + number for the workspace) doesn't work either. And when I close the browser because I've opened 100 tabs and my memory is getting full I will have to do the same thing again because the workspace got removed again.
On the other hand I don't want full static workspaces because e.g. inserting a new workspace when going fullscreen or adding new "temporary" workspaces for some fun stuff i want to do now when taking a break is really useful.

I'm not sure this is in line with the elementary multitasking model (though I don't see why not but might be missing something) so this is just a proposal :)

To test this I'd recommend setting the dconf key to the number of workspaces that should be permanent and logging out and in again. Alternatively you can use dspy and set any workspace that you want as permanent.

Let me know your thoughts, suggestions and improvements :)