### PR TITLE
ToucheggBackend: Use Priority.DEFAULT for sending events to the main thread

### DIFF
--- a/src/Gestures/ToucheggBackend.vala
+++ b/src/Gestures/ToucheggBackend.vala
@@ -200,19 +200,19 @@ public class Gala.ToucheggBackend : Object, GestureBackend {
                     on_gesture_detected (make_gesture (type, direction, fingers, performed_on_device_type), Meta.CURRENT_TIME);
                     on_begin (delta, elapsed_time);
                     return false;
-                });
+                }, Priority.DEFAULT);
                 break;
             case DBUS_ON_GESTURE_UPDATE:
                 Idle.add (() => {
                     on_update (delta, elapsed_time);
                     return false;
-                });
+                }, Priority.DEFAULT);
                 break;
             case DBUS_ON_GESTURE_END:
                 Idle.add (() => {
                     on_end (delta, elapsed_time);
                     return false;
-                });
+                }, Priority.DEFAULT);
                 break;
             default:
                 break;


### PR DESCRIPTION
Reason behind this (from #2258):

Ok I did some more investigation. Turns out that the reason is that in our toucheggbackend we receive events in a different thread and send them via idle to the main thread. So far so good. However we use Priority.DEFAULT_IDLE (we don't set anything) which might cause them to be stuck behind other more important events. This is the case when we do update_hover_widgets in the window clone because there they get animated via set_easing etc. which seemingly blocks lower priority events. This sometimes causes a delay which seems like a lag.