### PR TITLE
WorkspaceManager/cleanup: Fix crash

### DIFF
--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -262,9 +262,17 @@ public class Gala.WorkspaceManager : Object {
     private void cleanup () {
         unowned Meta.WorkspaceManager manager = wm.get_display ().get_workspace_manager ();
 
-        foreach (var workspace in manager.get_workspaces ()) {
-            if (!workspace.active && Utils.get_n_windows (workspace, true) == 0 && workspace.index () != manager.n_workspaces - 1) {
-                queue_remove_workspace (workspace);
+        bool remove_last = false;
+        foreach (var workspace in manager.get_workspaces ().copy ()) {
+            if (Utils.get_n_windows (workspace, true) != 0) {
+                remove_last = false;
+                continue;
+            }
+
+            if (workspace.active) {
+                remove_last = true;
+            } else if (workspace.index () != manager.n_workspaces - 1 || remove_last) {
+                remove_workspace (workspace);
             }
         }
     }

--- a/src/WorkspaceManager.vala
+++ b/src/WorkspaceManager.vala
@@ -263,7 +263,9 @@ public class Gala.WorkspaceManager : Object {
         unowned Meta.WorkspaceManager manager = wm.get_display ().get_workspace_manager ();
 
         foreach (var workspace in manager.get_workspaces ()) {
-            maybe_remove_workspace (workspace, null);
+            if (!workspace.active && Utils.get_n_windows (workspace, true) == 0 && workspace.index () != manager.n_workspaces - 1) {
+                queue_remove_workspace (workspace);
+            }
         }
     }
 }


### PR DESCRIPTION
Another day another fix for the workspace manager. Here's to hoping that it doesn't make it worse once again.

When cleaning we only want to remove workspaces that we aren't on. Currently we can end up with no empty workspace at the end and sometimes crashes.
Cherry picked from #2291.