### PR TITLE
Simplify multitasking view type

### DIFF
--- a/daemon/DBus.vala
+++ b/daemon/DBus.vala
@@ -5,7 +5,7 @@
 
 public enum Gala.ActionType {
     NONE = 0,
-    SHOW_WORKSPACE_VIEW,
+    SHOW_MULTITASKING_VIEW,
     MAXIMIZE_CURRENT,
     HIDE_CURRENT,
     OPEN_LAUNCHER,

--- a/lib/Plugin.vala
+++ b/lib/Plugin.vala
@@ -19,7 +19,6 @@ namespace Gala {
     public enum PluginFunction {
         ADDITION,
         WINDOW_SWITCHER,
-        WORKSPACE_VIEW,
         WINDOW_OVERVIEW
     }
 

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -18,7 +18,7 @@
 namespace Gala {
     public enum ActionType {
         NONE = 0,
-        SHOW_WORKSPACE_VIEW,
+        SHOW_MULTITASKING_VIEW,
         MAXIMIZE_CURRENT,
         HIDE_CURRENT,
         OPEN_LAUNCHER,
@@ -117,11 +117,6 @@ namespace Gala {
          * The background group is a container for the background actors forming the wallpaper
          */
         public abstract Meta.BackgroundGroup background_group { get; protected set; }
-
-        /**
-         * View that allows to see and manage all your windows and desktops.
-         */
-        public abstract Gala.ActivatableComponent workspace_view { get; protected set; }
 
         /**
          * Enters the modal mode, which means that all events are directed to the stage instead

--- a/src/PluginManager.vala
+++ b/src/PluginManager.vala
@@ -26,7 +26,6 @@ public class Gala.PluginManager : Object {
 
     public string? window_switcher_provider { get; private set; default = null; }
     public string? window_overview_provider { get; private set; default = null; }
-    public string? workspace_view_provider { get; private set; default = null; }
 
     private HashTable<string,Plugin> plugins;
     private File plugin_dir;
@@ -129,13 +128,6 @@ public class Gala.PluginManager : Object {
     private bool check_provides (string name, PluginFunction provides) {
         var message = "Plugins %s and %s both provide %s functionality, using first one only";
         switch (provides) {
-            case PluginFunction.WORKSPACE_VIEW:
-                if (workspace_view_provider != null) {
-                    warning (message, workspace_view_provider, name, "workspace view");
-                    return false;
-                }
-                workspace_view_provider = name;
-                return true;
             case PluginFunction.WINDOW_OVERVIEW:
                 if (window_overview_provider != null) {
                     warning (message, window_overview_provider, name, "window overview");

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -52,9 +52,9 @@ namespace Gala {
         public Meta.BackgroundGroup background_group { get; protected set; }
 
         /**
-         * {@inheritDoc}
+         * View that allows to see and manage all your windows and desktops.
          */
-        public Gala.ActivatableComponent workspace_view { get; protected set; }
+        public MultitaskingView multitasking_view { get; protected set; }
 
         public PointerLocator pointer_locator { get; private set; }
 
@@ -243,12 +243,8 @@ namespace Gala {
             plugin_manager.initialize (this);
             plugin_manager.regions_changed.connect (update_input_area);
 
-            if (plugin_manager.workspace_view_provider == null
-                || (workspace_view = (plugin_manager.get_plugin (plugin_manager.workspace_view_provider) as ActivatableComponent)) == null
-            ) {
-                workspace_view = new MultitaskingView (this);
-                ui_group.add_child ((Clutter.Actor) workspace_view);
-            }
+            multitasking_view = new MultitaskingView (this);
+            ui_group.add_child (multitasking_view);
 
             if (plugin_manager.window_switcher_provider == null) {
                 window_switcher = new WindowSwitcher (this);
@@ -334,10 +330,10 @@ namespace Gala {
             });
 
             Meta.KeyBinding.set_custom_handler ("show-desktop", () => {
-                if (workspace_view.is_opened ()) {
-                    workspace_view.close ();
+                if (multitasking_view.is_opened ()) {
+                    multitasking_view.close ();
                 } else {
-                    workspace_view.open ();
+                    multitasking_view.open ();
                 }
             });
 
@@ -565,7 +561,7 @@ namespace Gala {
          * {@inheritDoc}
          */
         public void switch_to_next_workspace (Meta.MotionDirection direction, uint32 timestamp) {
-            ((MultitaskingView) workspace_view).switch_to_next_workspace (direction);
+            multitasking_view.switch_to_next_workspace (direction);
         }
 
         private void update_input_area () {
@@ -698,7 +694,7 @@ namespace Gala {
                 return;
             }
 
-            ((MultitaskingView) workspace_view).move_window (window, workspace);
+            multitasking_view.move_window (window, workspace);
         }
 
         /**
@@ -820,14 +816,11 @@ namespace Gala {
             unowned var current = display.get_focus_window ();
 
             switch (type) {
-                case ActionType.SHOW_WORKSPACE_VIEW:
-                    if (workspace_view == null)
-                        break;
-
-                    if (workspace_view.is_opened ())
-                        workspace_view.close ();
+                case ActionType.SHOW_MULTITASKING_VIEW:
+                    if (multitasking_view.is_opened ())
+                        multitasking_view.close ();
                     else
-                        workspace_view.open ();
+                        multitasking_view.open ();
                     break;
                 case ActionType.MAXIMIZE_CURRENT:
                     if (current == null || current.window_type != Meta.WindowType.NORMAL || !current.can_maximize ())
@@ -1743,7 +1736,7 @@ namespace Gala {
         }
 
         public override void kill_switch_workspace () {
-            ((MultitaskingView) workspace_view).kill_switch_workspace ();
+            multitasking_view.kill_switch_workspace ();
         }
 
         public override void locate_pointer () {


### PR DESCRIPTION
- Don't expose multitasking view to the library as no one uses it
- Don't support overriding multitasking view via plugin because we rely on it for desktop switch now
- 'Workspace view' -> 'Multitasking view'