### PR TITLE
HideTracker: Fix not hiding when barrier triggered without hovering

### DIFF
--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -302,7 +302,7 @@ public class Gala.HideTracker : Object {
             int.MAX
         );
 
-        barrier.trigger.connect (trigger_show);
+        barrier.trigger.connect (on_barrier_triggered);
     }
 
     private void setup_barrier_bottom (Mtk.Rectangle monitor_geom, int offset) {
@@ -319,6 +319,11 @@ public class Gala.HideTracker : Object {
             int.MAX
         );
 
-        barrier.trigger.connect (trigger_show);
+        barrier.trigger.connect (on_barrier_triggered);
+    }
+
+    private void on_barrier_triggered () {
+        trigger_show ();
+        schedule_update ();
     }
 }


### PR DESCRIPTION
When the barrier was triggered and you wouldn't ever hover the dock there wouldn't be a new update so the dock would stay visible. So make sure to schedule an update on barrier trigger.

Fixes #2276
Fixes elementary/dock#357