### PR TITLE
Multitasking view fixes

### DIFF
--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -508,5 +508,19 @@ namespace Gala {
 
             return true;
         }
+
+        public override bool captured_event (Clutter.Event event) {
+            /* If we aren't open but receive events this means we are animating closed
+             * or we are finishing a workspace switch animation. In any case we want to
+             * prevent a drag and drop to start for the window clones which can happen
+             * pretty easily if you click on one while the animation finishes.
+             */
+            var type = event.get_type (); // LEAVE and ENTER have to be propagated
+            if (!opened && animating && type != ENTER && type != LEAVE) {
+                return Clutter.EVENT_STOP;
+            }
+
+            return Clutter.EVENT_PROPAGATE;
+        }
     }
 }

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -236,7 +236,7 @@ namespace Gala {
         }
 
         public override void start_progress (GestureAction action) {
-            if (!opened) {
+            if (!visible) {
                 opened = true;
 
                 wm.background_group.hide ();


### PR DESCRIPTION
Two fixes for the multitasking view.

The first commit fixes #2297 where we would push modal twice leading to one of the grabs never being released.

The second commit fixes an issue where you could initiate a drag and drop on window clones while
the workspace switch animation finished which looks very strange.