### PR TITLE
Reorder workspaces

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -244,4 +244,15 @@ public class Gala.DesktopIntegration : GLib.Object {
 
         wm.window_overview.open (hints);
     }
+
+    public void reorder_workspace (int index, int new_index) throws DBusError, IOError {
+        unowned var workspace_manager = wm.get_display ().get_workspace_manager ();
+        unowned var workspace = workspace_manager.get_workspace_by_index (index);
+
+        if (workspace == null) {
+            throw new IOError.NOT_FOUND ("Invalid index, workspace not found");
+        }
+
+        workspace_manager.reorder_workspace (workspace, new_index);
+    }
 }

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -94,7 +94,7 @@ public class Gala.MultitaskingView : ActorTarget, ActivatableComponent {
         unowned var manager = display.get_workspace_manager ();
         manager.workspace_added.connect (add_workspace);
         manager.workspace_removed.connect (remove_workspace);
-        manager.workspaces_reordered.connect (() => reposition_icon_groups (false));
+        manager.workspaces_reordered.connect (on_workspaces_reordered);
         manager.workspace_switched.connect (on_workspace_switched);
 
         manager.bind_property (
@@ -395,6 +395,15 @@ public class Gala.MultitaskingView : ActorTarget, ActivatableComponent {
         reposition_icon_groups (opened);
 
         workspaces_gesture_controller.progress = -manager.get_active_workspace_index ();
+    }
+
+    private void on_workspaces_reordered () {
+        if (!visible) {
+            unowned var manager = display.get_workspace_manager ();
+            workspaces_gesture_controller.progress = -manager.get_active_workspace_index ();
+        }
+
+        reposition_icon_groups (false);
     }
 
     private void on_workspace_switched (int from, int to) {


### PR DESCRIPTION
First commit adds a dbus method to reorder workspaces required for elementary/dock#392

Second commit fixes a small issue where if the active workspace was reordered the multitasking view was still at the outdated active index which now is a different workspace.