### PR TITLE
Respect orientation in scroll backend

### DIFF
--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -85,6 +85,14 @@ public class Gala.ScrollBackend : Object, GestureBackend {
 
         if (!started) {
             if (delta_x != 0 || delta_y != 0) {
+                if (delta_x.abs () > delta_y.abs () && orientation != HORIZONTAL ||
+                    delta_y.abs () > delta_x.abs () && orientation != VERTICAL
+                ) {
+                    ignoring = true;
+                    reset ();
+                    return Clutter.EVENT_PROPAGATE;
+                }
+
                 float origin_x, origin_y;
                 event.get_coords (out origin_x, out origin_y);
                 Gesture gesture = build_gesture (origin_x, origin_y, delta_x, delta_y, orientation, time);
@@ -105,7 +113,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
             }
         }
 
-        return Clutter.EVENT_PROPAGATE;
+        return Clutter.EVENT_STOP;
     }
 
     private bool on_leave_event (Clutter.Event event) requires (event.get_type () == LEAVE) {

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -48,7 +48,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
     public ScrollBackend (Clutter.Actor actor, Clutter.Orientation orientation, GestureSettings settings) {
         Object (actor: actor, orientation: orientation, settings: settings);
 
-        actor.scroll_event.connect (on_scroll_event);
+        actor.captured_event.connect (on_scroll_event);
         actor.leave_event.connect (on_leave_event);
         // When the actor is turned invisible, we don't receive a scroll finish event which would cause
         // us to ignore the first new scroll event if we're currently ignoring.

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -271,13 +271,11 @@ public class Gala.WindowClone : ActorTarget {
     }
 
     public override void start_progress (GestureAction action) {
-        if (action == MULTITASKING_VIEW) {
-            update_hover_widgets (true);
-        }
+        update_hover_widgets (true);
     }
 
     public override void update_progress (Gala.GestureAction action, double progress) {
-        if (action != CLOSE_WINDOW || !Meta.Prefs.get_gnome_animations ()) {
+        if (action != CLOSE_WINDOW || slot == null) {
             return;
         }
 
@@ -295,30 +293,13 @@ public class Gala.WindowClone : ActorTarget {
 
         close_button.translation_y = target_translation_y;
         close_button.opacity = target_opacity;
-
-        if (progress == 1.0 && get_current_commit (CLOSE_WINDOW) == 1.0) {
-            close_window (Meta.CURRENT_TIME);
-        }
-    }
-
-    public override void commit_progress (Gala.GestureAction action, double to) {
-        if (action != CLOSE_WINDOW || !Meta.Prefs.get_gnome_animations ()) {
-            return;
-        }
-
-        if (to == 1.0 && get_current_progress (SWITCH_WORKSPACE) != 0) {
-            Idle.add (() => {
-                gesture_controller.goto (0.0);
-                return Source.REMOVE;
-            });
-        } else if (get_current_progress (CLOSE_WINDOW) == 1.0 && to == 1.0) {
-            close_window (Meta.CURRENT_TIME);
-        }
     }
 
     public override void end_progress (GestureAction action) {
-        if (action == MULTITASKING_VIEW) {
-            update_hover_widgets (false);
+        update_hover_widgets (false);
+
+        if (action == CLOSE_WINDOW && get_current_commit (CLOSE_WINDOW) > 0.5) {
+            close_window (Meta.CURRENT_TIME);
         }
     }
 


### PR DESCRIPTION
Get rid of the weirdness in commit_progress and the required additional check in update_progress.
A scroll action will now only trigger if the scroll direction matches its orientation.
This now in theory also supports disabled animations but if multiple windows are open it will pretty much close all since they probably rearrange before you stop scrolling. Currently it's still enabled but we can disable it.
Also fixes runtime warnings about non existing objects.

Also the additional check around update_hover_widgets was removed. Idk why it was added but if we need it we should also update on switching workspaces because the close button and windowtitle appear when switching workspaces on the desktop which looks weird.