### PR TITLE
ShadowEffect: cleanup scale factor

### DIFF
--- a/lib/ShadowEffect.vala
+++ b/lib/ShadowEffect.vala
@@ -50,7 +50,8 @@ public class Gala.ShadowEffect : Clutter.Effect {
         }
     }
 
-    public float scale_factor { get; set; default = 1; }
+    public float monitor_scale { get; construct set; }
+
     public uint8 shadow_opacity { get; set; default = 255; }
     public int border_radius { get; set; default = 9;}
 
@@ -58,8 +59,8 @@ public class Gala.ShadowEffect : Clutter.Effect {
     private Cogl.Pipeline? pipeline;
     private string? current_key = null;
 
-    public ShadowEffect (string css_class = "") {
-        Object (css_class: css_class);
+    public ShadowEffect (string css_class, float monitor_scale) {
+        Object (css_class: css_class, monitor_scale: monitor_scale);
     }
 
     ~ShadowEffect () {
@@ -122,7 +123,7 @@ public class Gala.ShadowEffect : Clutter.Effect {
 
         cr.save ();
         cr.set_operator (Cairo.Operator.CLEAR);
-        var size = shadow_size * scale_factor;
+        var size = shadow_size * monitor_scale;
         Drawing.Utilities.cairo_rounded_rectangle (cr, size, size, actor.width, actor.height, border_radius);
         cr.fill ();
         cr.restore ();
@@ -161,7 +162,7 @@ public class Gala.ShadowEffect : Clutter.Effect {
     }
 
     private Clutter.ActorBox get_bounding_box () {
-        var size = shadow_size * scale_factor;
+        var size = shadow_size * monitor_scale;
         var bounding_box = Clutter.ActorBox ();
 
         bounding_box.set_origin (-size, -size);

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -78,7 +78,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
             reactive = true
         };
         container.add_child (clone_container);
-        container.add_effect (new ShadowEffect ("window"));
+        container.add_effect (new ShadowEffect ("window", scale));
 
         move_action = new DragDropAction (DragDropActionType.SOURCE, "pip");
         move_action.drag_begin.connect (on_move_begin);

--- a/src/Widgets/MultitaskingView/IconGroup.vala
+++ b/src/Widgets/MultitaskingView/IconGroup.vala
@@ -235,9 +235,8 @@ public class Gala.IconGroup : CanvasActor {
             InternalUtils.scale_to_int (5, scale_factor)
         );
 
-        var shadow_effect = new ShadowEffect () {
-            border_radius = InternalUtils.scale_to_int (5, scale_factor),
-            scale_factor = scale_factor
+        var shadow_effect = new ShadowEffect ("", scale_factor) {
+            border_radius = InternalUtils.scale_to_int (5, scale_factor)
         };
 
         var style_manager = Drawing.StyleManager.get_instance ();

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -206,7 +206,7 @@ public class Gala.WindowClone : ActorTarget {
 
         if (window.fullscreen || window.maximized_horizontally && window.maximized_vertically) {
             if (shadow_effect == null) {
-                shadow_effect = new ShadowEffect ("window");
+                shadow_effect = new ShadowEffect ("window", monitor_scale_factor);
                 shadow_opacity = 0;
                 clone.add_effect_with_name ("shadow", shadow_effect);
             }

--- a/src/Widgets/MultitaskingView/WorkspaceClone.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceClone.vala
@@ -42,11 +42,8 @@ private class Gala.FramedBackground : BackgroundManager {
         unowned var ctx = Clutter.get_default_backend ().get_cogl_context ();
 #endif
         pipeline = new Cogl.Pipeline (ctx);
-        var primary = display.get_primary_monitor ();
-        var monitor_geom = display.get_monitor_geometry (primary);
 
-        var effect = new ShadowEffect ("workspace");
-        add_effect (effect);
+        add_effect (new ShadowEffect ("workspace", display.get_monitor_scale (display.get_primary_monitor ())));
 
         reactive = true;
     }

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -96,7 +96,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
             orientation = VERTICAL
         };
 
-        shadow_effect = new ShadowEffect ("window-switcher") {
+        shadow_effect = new ShadowEffect ("window-switcher", scaling_factor) {
             border_radius = InternalUtils.scale_to_int (9, scaling_factor),
             shadow_opacity = 100
         };
@@ -118,7 +118,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
     private void scale () {
         scaling_factor = wm.get_display ().get_monitor_scale (wm.get_display ().get_current_monitor ());
 
-        shadow_effect.scale_factor = scaling_factor;
+        shadow_effect.monitor_scale = scaling_factor;
 
         var margin = InternalUtils.scale_to_int (WRAPPER_PADDING, scaling_factor);
 


### PR DESCRIPTION
No functional changes

1. Rename `scale_factor` into `monitor_scale` since it better represents what this field really means
2. Require to set `monitor_scale` on construct