### PR TITLE
ShadowEffect: require border_radius

### DIFF
--- a/lib/ShadowEffect.vala
+++ b/lib/ShadowEffect.vala
@@ -51,16 +51,16 @@ public class Gala.ShadowEffect : Clutter.Effect {
     }
 
     public float monitor_scale { get; construct set; }
+    public int border_radius { get; construct; }
 
     public uint8 shadow_opacity { get; set; default = 255; }
-    public int border_radius { get; set; default = 9;}
 
     private int shadow_size;
     private Cogl.Pipeline? pipeline;
     private string? current_key = null;
 
-    public ShadowEffect (string css_class, float monitor_scale) {
-        Object (css_class: css_class, monitor_scale: monitor_scale);
+    public ShadowEffect (string css_class, int border_radius, float monitor_scale) {
+        Object (css_class: css_class, border_radius: border_radius, monitor_scale: monitor_scale);
     }
 
     ~ShadowEffect () {

--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -78,7 +78,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
             reactive = true
         };
         container.add_child (clone_container);
-        container.add_effect (new ShadowEffect ("window", scale));
+        container.add_effect (new ShadowEffect ("window", 9, scale));
 
         move_action = new DragDropAction (DragDropActionType.SOURCE, "pip");
         move_action.drag_begin.connect (on_move_begin);

--- a/src/Widgets/MultitaskingView/IconGroup.vala
+++ b/src/Widgets/MultitaskingView/IconGroup.vala
@@ -235,9 +235,7 @@ public class Gala.IconGroup : CanvasActor {
             InternalUtils.scale_to_int (5, scale_factor)
         );
 
-        var shadow_effect = new ShadowEffect ("", scale_factor) {
-            border_radius = InternalUtils.scale_to_int (5, scale_factor)
-        };
+        var shadow_effect = new ShadowEffect ("", InternalUtils.scale_to_int (5, scale_factor), scale_factor);
 
         var style_manager = Drawing.StyleManager.get_instance ();
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -206,7 +206,7 @@ public class Gala.WindowClone : ActorTarget {
 
         if (window.fullscreen || window.maximized_horizontally && window.maximized_vertically) {
             if (shadow_effect == null) {
-                shadow_effect = new ShadowEffect ("window", monitor_scale_factor);
+                shadow_effect = new ShadowEffect ("window", 9, monitor_scale_factor);
                 shadow_opacity = 0;
                 clone.add_effect_with_name ("shadow", shadow_effect);
             }

--- a/src/Widgets/MultitaskingView/WorkspaceClone.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceClone.vala
@@ -43,7 +43,7 @@ private class Gala.FramedBackground : BackgroundManager {
 #endif
         pipeline = new Cogl.Pipeline (ctx);
 
-        add_effect (new ShadowEffect ("workspace", display.get_monitor_scale (display.get_primary_monitor ())));
+        add_effect (new ShadowEffect ("workspace", 9, display.get_monitor_scale (display.get_primary_monitor ())));
 
         reactive = true;
     }

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -99,8 +99,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
             orientation = VERTICAL
         };
 
-        shadow_effect = new ShadowEffect ("window-switcher", scaling_factor) {
-            border_radius = InternalUtils.scale_to_int (9, scaling_factor),
+        shadow_effect = new ShadowEffect ("window-switcher", InternalUtils.scale_to_int (9, scaling_factor), scaling_factor) {
             shadow_opacity = 100
         };
         add_effect (shadow_effect);


### PR DESCRIPTION
We don't save border_radius in current_key so if we update border_radius the texture will not update immediately. I think it's fair to just disallow changing border radius altogether to avoid this bug.