### PR TITLE
Remodel GestureController lifetimes

### DIFF
--- a/src/Gestures/GestureController.vala
+++ b/src/Gestures/GestureController.vala
@@ -94,7 +94,9 @@ public class Gala.GestureController : Object {
         Object (action: action, wm: wm);
     }
 
-    // Do not call this directly, use {@link RooTarget.add_controller} instead.
+    /**
+     * Do not call this directly, use {@link RooTarget.add_controller} instead.
+     */
     public void attached (RootTarget target) {
         ref ();
         this.target = target;

--- a/src/Gestures/GestureController.vala
+++ b/src/Gestures/GestureController.vala
@@ -35,10 +35,10 @@ public class Gala.GestureController : Object {
     public GestureAction action { get; construct; }
     public WindowManager wm { get; construct; }
 
-    private GestureTarget? _target;
-    public GestureTarget target {
+    private unowned RootTarget? _target;
+    public RootTarget target {
         get { return _target; }
-        set {
+        private set {
             _target = value;
             target.propagate (UPDATE, action, progress);
         }
@@ -90,8 +90,13 @@ public class Gala.GestureController : Object {
 
     private SpringTimeline? timeline;
 
-    public GestureController (GestureAction action, GestureTarget target, WindowManager wm) {
-        Object (action: action, target: target, wm: wm);
+    public GestureController (GestureAction action, WindowManager wm) {
+        Object (action: action, wm: wm);
+    }
+
+    // Do not call this directly, use {@link RooTarget.add_controller} instead.
+    public void attached (RootTarget target) {
+        this.target = target;
     }
 
     public void enable_touchpad () {

--- a/src/Gestures/GestureController.vala
+++ b/src/Gestures/GestureController.vala
@@ -40,7 +40,7 @@ public class Gala.GestureController : Object {
         get { return _target; }
         private set {
             _target = value;
-            target.propagate (UPDATE, action, progress);
+            _target.propagate (UPDATE, action, progress);
         }
     }
 
@@ -96,7 +96,13 @@ public class Gala.GestureController : Object {
 
     // Do not call this directly, use {@link RooTarget.add_controller} instead.
     public void attached (RootTarget target) {
+        ref ();
         this.target = target;
+    }
+
+    public void detached () {
+        _target = null;
+        unref ();
     }
 
     public void enable_touchpad () {

--- a/src/Gestures/RootTarget.vala
+++ b/src/Gestures/RootTarget.vala
@@ -6,11 +6,10 @@
  */
 
 public interface Gala.RootTarget : Object, GestureTarget {
-    public void add_controller (GestureController controller) requires (controller.target == null) {
+    public void add_gesture_controller (GestureController controller) requires (controller.target == null) {
         controller.attached (this);
 
         // Bind the controller lifetime to #this lifetime
-        controller.ref ();
-        weak_ref (controller.unref);
+        weak_ref (controller.detached);
     }
 }

--- a/src/Gestures/RootTarget.vala
+++ b/src/Gestures/RootTarget.vala
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+public interface Gala.RootTarget : Object, GestureTarget {
+    public void add_controller (GestureController controller) requires (controller.target == null) {
+        controller.attached (this);
+
+        // Bind the controller lifetime to #this lifetime
+        controller.ref ();
+        weak_ref (controller.unref);
+    }
+}

--- a/src/Gestures/RootTarget.vala
+++ b/src/Gestures/RootTarget.vala
@@ -8,8 +8,6 @@
 public interface Gala.RootTarget : Object, GestureTarget {
     public void add_gesture_controller (GestureController controller) requires (controller.target == null) {
         controller.attached (this);
-
-        // Bind the controller lifetime to #this lifetime
         weak_ref (controller.detached);
     }
 }

--- a/src/Gestures/ScrollBackend.vala
+++ b/src/Gestures/ScrollBackend.vala
@@ -26,7 +26,6 @@ public class Gala.ScrollBackend : Object, GestureBackend {
     private const double FINISH_DELTA_HORIZONTAL = 40;
     private const double FINISH_DELTA_VERTICAL = 30;
 
-    public Clutter.Actor actor { get; construct; }
     public Clutter.Orientation orientation { get; construct; }
     public GestureSettings settings { get; construct; }
 
@@ -46,7 +45,7 @@ public class Gala.ScrollBackend : Object, GestureBackend {
     }
 
     public ScrollBackend (Clutter.Actor actor, Clutter.Orientation orientation, GestureSettings settings) {
-        Object (actor: actor, orientation: orientation, settings: settings);
+        Object (orientation: orientation, settings: settings);
 
         actor.captured_event.connect (on_scroll_event);
         actor.leave_event.connect (on_leave_event);

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -62,7 +62,7 @@ public class Gala.PanelWindow : ShellWindow, RootTarget {
         window.position_changed.connect (update_strut);
 
         gesture_controller = new GestureController (DOCK, wm);
-        add_controller (gesture_controller);
+        add_gesture_controller (gesture_controller);
 
         window.display.in_fullscreen_changed.connect (() => {
             if (wm.get_display ().get_monitor_in_fullscreen (window.get_monitor ())) {

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -5,7 +5,7 @@
  * Authored by: Leonhard Kargl <leo.kargl@proton.me>
  */
 
-public class Gala.PanelWindow : ShellWindow {
+public class Gala.PanelWindow : ShellWindow, RootTarget {
     private const int ANIMATION_DURATION = 250;
 
     private static HashTable<Meta.Window, Meta.Strut?> window_struts = new HashTable<Meta.Window, Meta.Strut?> (null, null);
@@ -50,8 +50,6 @@ public class Gala.PanelWindow : ShellWindow {
             if (window_struts.remove (window)) {
                 update_struts ();
             }
-
-            gesture_controller = null; // make it release its reference on us
         });
 
         notify["anchor"].connect (() => position = Position.from_anchor (anchor));
@@ -63,7 +61,8 @@ public class Gala.PanelWindow : ShellWindow {
         window.size_changed.connect (update_strut);
         window.position_changed.connect (update_strut);
 
-        gesture_controller = new GestureController (DOCK, this, wm);
+        gesture_controller = new GestureController (DOCK, wm);
+        add_controller (gesture_controller);
 
         window.display.in_fullscreen_changed.connect (() => {
             if (wm.get_display ().get_monitor_in_fullscreen (window.get_monitor ())) {

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -59,7 +59,7 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
 
         multitasking_gesture_controller = new GestureController (MULTITASKING_VIEW, wm);
         multitasking_gesture_controller.enable_touchpad ();
-        add_controller (multitasking_gesture_controller);
+        add_gesture_controller (multitasking_gesture_controller);
 
         add_target (ShellClientsManager.get_instance ()); // For hiding the panels
 
@@ -70,7 +70,7 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         };
         workspaces_gesture_controller.enable_touchpad ();
         workspaces_gesture_controller.enable_scroll (this, HORIZONTAL);
-        add_controller (workspaces_gesture_controller);
+        add_gesture_controller (workspaces_gesture_controller);
 
         icon_groups = new IconGroupContainer (display.get_monitor_scale (display.get_primary_monitor ()));
 

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -20,7 +20,7 @@
  * preparing the wm, opening the components and holds containers for
  * the icon groups, the WorkspaceClones and the MonitorClones.
  */
-public class Gala.MultitaskingView : ActorTarget, ActivatableComponent {
+public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableComponent {
     public const int ANIMATION_DURATION = 250;
 
     private GestureController workspaces_gesture_controller;
@@ -57,18 +57,20 @@ public class Gala.MultitaskingView : ActorTarget, ActivatableComponent {
         opened = false;
         display = wm.get_display ();
 
-        multitasking_gesture_controller = new GestureController (MULTITASKING_VIEW, this, wm);
+        multitasking_gesture_controller = new GestureController (MULTITASKING_VIEW, wm);
         multitasking_gesture_controller.enable_touchpad ();
+        add_controller (multitasking_gesture_controller);
 
         add_target (ShellClientsManager.get_instance ()); // For hiding the panels
 
         workspaces = new WorkspaceRow (display);
 
-        workspaces_gesture_controller = new GestureController (SWITCH_WORKSPACE, this, wm) {
+        workspaces_gesture_controller = new GestureController (SWITCH_WORKSPACE, wm) {
             overshoot_upper_clamp = 0.1
         };
         workspaces_gesture_controller.enable_touchpad ();
         workspaces_gesture_controller.enable_scroll (this, HORIZONTAL);
+        add_controller (workspaces_gesture_controller);
 
         icon_groups = new IconGroupContainer (display.get_monitor_scale (display.get_primary_monitor ()));
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -106,7 +106,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
 
         gesture_controller = new GestureController (CLOSE_WINDOW, wm);
         gesture_controller.enable_scroll (this, VERTICAL);
-        add_controller (gesture_controller);
+        add_gesture_controller (gesture_controller);
 
         window.unmanaged.connect (unmanaged);
         window.notify["fullscreen"].connect (check_shadow_requirements);

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -8,7 +8,7 @@
  * A container for a clone of the texture of a MetaWindow, a WindowIcon, a Tooltip with the title,
  * a close button and a shadow. Used together with the WindowCloneContainer.
  */
-public class Gala.WindowClone : ActorTarget {
+public class Gala.WindowClone : ActorTarget, RootTarget {
     private const int WINDOW_ICON_SIZE = 64;
     private const int ACTIVE_SHAPE_SIZE = 12;
     private const int FADE_ANIMATION_DURATION = 200;
@@ -104,8 +104,9 @@ public class Gala.WindowClone : ActorTarget {
     construct {
         reactive = true;
 
-        gesture_controller = new GestureController (CLOSE_WINDOW, this, wm);
+        gesture_controller = new GestureController (CLOSE_WINDOW, wm);
         gesture_controller.enable_scroll (this, VERTICAL);
+        add_controller (gesture_controller);
 
         window.unmanaged.connect (unmanaged);
         window.notify["fullscreen"].connect (check_shadow_requirements);

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public class Gala.WindowOverview : ActorTarget, ActivatableComponent {
+public class Gala.WindowOverview : ActorTarget, RootTarget, ActivatableComponent {
     private const int BORDER = 10;
     private const int TOP_GAP = 30;
     private const int BOTTOM_GAP = 100;
@@ -26,9 +26,10 @@ public class Gala.WindowOverview : ActorTarget, ActivatableComponent {
     construct {
         visible = false;
         reactive = true;
-        gesture_controller = new GestureController (MULTITASKING_VIEW, this, wm) {
+        gesture_controller = new GestureController (MULTITASKING_VIEW, wm) {
             enabled = false
         };
+        add_controller (gesture_controller);
     }
 
 

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -29,7 +29,7 @@ public class Gala.WindowOverview : ActorTarget, RootTarget, ActivatableComponent
         gesture_controller = new GestureController (MULTITASKING_VIEW, wm) {
             enabled = false
         };
-        add_controller (gesture_controller);
+        add_gesture_controller (gesture_controller);
     }
 
 

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
+public class Gala.WindowSwitcher : CanvasActor, RootTarget, GestureTarget {
     public const int ICON_SIZE = 64;
     public const int WRAPPER_PADDING = 12;
 
@@ -63,13 +63,14 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
     construct {
         style_manager = Drawing.StyleManager.get_instance ();
 
-        gesture_controller = new GestureController (SWITCH_WINDOWS, this, wm) {
+        gesture_controller = new GestureController (SWITCH_WINDOWS, wm) {
             overshoot_upper_clamp = int.MAX,
             overshoot_lower_clamp = int.MIN,
             snap = false
         };
         gesture_controller.enable_touchpad ();
         gesture_controller.notify["recognizing"].connect (recognizing_changed);
+        add_controller (gesture_controller);
 
         container = new Clutter.Actor () {
             reactive = true,

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -70,7 +70,7 @@ public class Gala.WindowSwitcher : CanvasActor, RootTarget, GestureTarget {
         };
         gesture_controller.enable_touchpad ();
         gesture_controller.notify["recognizing"].connect (recognizing_changed);
-        add_controller (gesture_controller);
+        add_gesture_controller (gesture_controller);
 
         container = new Clutter.Actor () {
             reactive = true,

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public class Gala.WindowSwitcher : CanvasActor, RootTarget, GestureTarget {
+public class Gala.WindowSwitcher : CanvasActor, GestureTarget, RootTarget {
     public const int ICON_SIZE = 64;
     public const int WRAPPER_PADDING = 12;
 

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public class Gala.Zoom : Object, RootTarget, GestureTarget {
+public class Gala.Zoom : Object, GestureTarget, RootTarget {
     private const float MIN_ZOOM = 1.0f;
     private const float MAX_ZOOM = 10.0f;
     private const float SHORTCUT_DELTA = 0.5f;

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public class Gala.Zoom : Object, GestureTarget {
+public class Gala.Zoom : Object, RootTarget, GestureTarget {
     private const float MIN_ZOOM = 1.0f;
     private const float MAX_ZOOM = 10.0f;
     private const float SHORTCUT_DELTA = 0.5f;
@@ -34,10 +34,11 @@ public class Gala.Zoom : Object, GestureTarget {
         display.add_keybinding ("zoom-in", schema, Meta.KeyBindingFlags.NONE, (Meta.KeyHandlerFunc) zoom_in);
         display.add_keybinding ("zoom-out", schema, Meta.KeyBindingFlags.NONE, (Meta.KeyHandlerFunc) zoom_out);
 
-        gesture_controller = new GestureController (ZOOM, this, wm) {
+        gesture_controller = new GestureController (ZOOM, wm) {
             snap = false
         };
         gesture_controller.enable_touchpad ();
+        add_controller (gesture_controller);
 
         behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
 

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -38,7 +38,7 @@ public class Gala.Zoom : Object, RootTarget, GestureTarget {
             snap = false
         };
         gesture_controller.enable_touchpad ();
-        add_controller (gesture_controller);
+        add_gesture_controller (gesture_controller);
 
         behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,7 @@ gala_bin_sources = files(
     'Gestures/GestureSettings.vala',
     'Gestures/GestureTarget.vala',
     'Gestures/PropertyTarget.vala',
+    'Gestures/RootTarget.vala',
     'Gestures/ScrollBackend.vala',
     'Gestures/SpringTimeline.vala',
     'Gestures/ToucheggBackend.vala',


### PR DESCRIPTION
We are leaking WindowClones since #2327. This is because the GestureController holds a strong reference on the target which means in our case that the windowclone holds a strong ref on the controller which holds a strong ref on the window clone => ref cycle. That is for example also why we set it to null in the panelwindow once it unmanages https://github.com/elementary/gala/blob/a9868810ffacb35001647e63eafc4091cabd6329/src/ShellClients/PanelWindow.vala#L54

While we could easily work around this I admit for how we currently use it the ownership model of gesturecontrollers is not really intuitive.

There are multiple solutions to this problem:
- We could just do the same as in panel window but we don't exactly know the lifetime of a windowclone (it can move to other ws, unmanage, etc.) and destroy doesn't work either because that relies on actually destroying it instead of e.g. just removing it which would be very easy to miss (that would be the workaround).
- Make the gesture controller just hold an unowned ref to target. Very error prone because you definitely don't expect that. (Even less intuitive)
- Be inspired by Clutter, GTK, etc. (think EventControllers, Constraints, Actions) and have a RootTarget where you can add controllers which will automatically attach them to that target and bind their lifetime to it. (Hopefully more intuitive :))

I went with the last one because IMO it's the least error prone and thus safest :)

Also don't hold a ref on the actor in the ScrollBackend because it's unneeded and would cause another ref cycle.