### PR TITLE
WindowSwitcher: Fix crash

### DIFF
--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -42,10 +42,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
             _current_icon = value;
             if (_current_icon != null) {
                 _current_icon.selected = true;
-
-                // _current_icon.grab_key_focus () sometimes results in a crash
-                // https://github.com/elementary/gala/issues/2308
-                get_stage ().set_key_focus (_current_icon);
+                _current_icon.grab_key_focus ();
             }
 
             update_caption_text ();
@@ -334,14 +331,13 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
     }
 
     private bool collect_all_windows (Meta.Display display, Meta.Workspace? workspace) {
+        container.remove_all_children ();
         select_icon (null);
 
         var windows = display.get_tab_list (Meta.TabList.NORMAL, workspace);
         if (windows == null) {
             return false;
         }
-
-        container.remove_all_children ();
 
         unowned var current_window = display.get_tab_current (Meta.TabList.NORMAL, workspace);
         foreach (unowned var window in windows) {
@@ -357,6 +353,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
     }
 
     private bool collect_current_windows (Meta.Display display, Meta.Workspace? workspace) {
+        container.remove_all_children ();
         select_icon (null);
 
         var windows = display.get_tab_list (Meta.TabList.NORMAL, workspace);
@@ -368,8 +365,6 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget {
         if (current_window == null) {
             return false;
         }
-
-        container.remove_all_children ();
 
         unowned var window_tracker = ((WindowManagerGala) wm).window_tracker;
         var app = window_tracker.get_app_for_window (current_window);


### PR DESCRIPTION
Should fix #2308 
Closes #2360 

Explanation (kinda long im sorry):
The clutter stage holds an unowned reference on the actor that has key focus. That actor is responsible for unsetting the key focus if it has it and 
- is unmapped or
- is disposed

For that it has to be in the actor hierarchy in order to reach the stage via its parents which is usually a given because the actor is unmapped if it would be removed from the scene and unsets the keyfocus then.

However in our case the actor has already been unmapped when the switcher closed. When we now open it again and call `select_icon (null)` we first set the gesture controller progress to 0 which might end up setting the first icon as the current icon if it's not currently the current icon. This will also set it as the key focus actor for the stage. Next we set null as the current icon but we don't unset the key focus because in theory it's not needed.
Next we call `container.remove_all` which causes the icon that we temporarily selected to be removed. Because it's already unmapped it doesn't try to unset its keyfocus again. The icon will now be freed and tries to unset its keyfocus in the dispose virtual but because it doesn't have a parent anymore it can't get to the stage and can't unset the keyfocus. So we now have a pointer to freed memory.
When we set a new actor as key focus the stage accesses that pointer for some checks which crashes us.

We fix this by making sure the gesture controller doesn't accidentally select an unmapped icon by removing them before doing anything else.