### PR TITLE
Remove destroy effect for menus

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -47,12 +47,14 @@
         <issue url="https://github.com/elementary/gala/issues/1235">Overview window title should follow keyboard focus</issue>
         <issue url="https://github.com/elementary/gala/issues/1661">Better post-screenshot animation</issue>
         <issue url="https://github.com/elementary/gala/issues/2114">Wrong context menu placement</issue>
+        <issue url="https://github.com/elementary/gala/issues/2172">Override redirect Popup menu type window under Xwayland can not be displayed on the second XMapWindow</issue>
         <issue url="https://github.com/elementary/gala/issues/2199">Swiping in the multitasking view can close applications</issue>
         <issue url="https://github.com/elementary/gala/issues/2260">Ghost of window on another workspace appears when cancelling workspace swipe</issue>
         <issue url="https://github.com/elementary/gala/issues/2267">Dock crash may crash Gala</issue>
         <issue url="https://github.com/elementary/gala/issues/2279">Can't reveal dock when animations are disabled</issue>
         <issue url="https://github.com/elementary/gala/issues/2294">Unlocking firewall settings leads to crash</issue>
         <issue url="https://github.com/elementary/gala/issues/2341">Lutris Flatpak crashes gala with GE setup</issue>
+        <issue url="https://github.com/elementary/gala/issues/2366">Menus only show once</issue>
         <issue url="https://github.com/elementary/portals/issues/97">False detection of "background activity" for some Flatpak apps</issue>
       </issues>
     </release>

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1483,31 +1483,6 @@ namespace Gala {
                         destroying.remove (actor);
                         destroy_completed (actor);
                     });
-
-                    break;
-                case Meta.WindowType.MENU:
-                case Meta.WindowType.DROPDOWN_MENU:
-                case Meta.WindowType.POPUP_MENU:
-                    var duration = AnimationDuration.MENU_MAP;
-                    if (duration == 0) {
-                        destroy_completed (actor);
-                        return;
-                    }
-
-                    destroying.add (actor);
-                    actor.save_easing_state ();
-                    actor.set_easing_mode (Clutter.AnimationMode.EASE_OUT_QUAD);
-                    actor.set_easing_duration (duration);
-                    actor.set_scale (0.8f, 0.8f);
-                    actor.opacity = 0U;
-                    actor.restore_easing_state ();
-
-                    ulong destroy_handler_id = 0UL;
-                    destroy_handler_id = actor.transitions_completed.connect (() => {
-                        actor.disconnect (destroy_handler_id);
-                        destroying.remove (actor);
-                        destroy_completed (actor);
-                    });
                     break;
                 default:
                     destroy_completed (actor);


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2172
Fixes https://github.com/elementary/gala/issues/2366

Some windows don't expect there to be a destroy effect for menus and they close their windows before the we call `destroy_completed`. I suppose if we still need this effect, we should implement it in Granite.