### PR TITLE
Add support for restoring previous region

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -27,6 +27,15 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.2.2" date="2025-05-16" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+          <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="8.2.1" date="2025-05-15" urgency="medium">
       <description>
         <p>Improvements:</p>
@@ -36,6 +45,8 @@
       </description>
       <issues>
         <issue url="https://github.com/elementary/gala/issues/2322">Workspace Switch</issue>
+        <issue url="https://github.com/elementary/gala/issues/2357">Very rough shadows around the workspace switcher in HiDPI mode.</issue>
+        <issue url="https://github.com/elementary/gala/issues/2380">ShadowEffect: corner radius doesn't use monitor scale</issue>
       </issues>
     </release>
 

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -404,13 +404,9 @@ namespace Gala {
             return texture;
         }
 
-        private static HashTable<Meta.Window, X.Rectangle?> regions = new HashTable<Meta.Window, X.Rectangle?> (null, null);
+        private static HashTable<Meta.Window, X.XserverRegion?> regions = new HashTable<Meta.Window, X.XserverRegion?> (null, null);
 
         public static void x11_set_window_pass_through (Meta.Window window) {
-            if (window in regions) {
-                return;
-            }
-
             unowned var x11_display = window.display.get_x11_display ();
 
 #if HAS_MUTTER46
@@ -420,8 +416,7 @@ namespace Gala {
 #endif
             unowned var xdisplay = x11_display.get_xdisplay ();
 
-            int count, ordering;
-            regions[window] = X.Shape.get_rectangles (xdisplay, x_window, 2, out count, out ordering)[0];
+            regions[window] = X.Fixes.create_region_from_window (xdisplay, x_window, 0);
 
             X.Xrectangle rect = {};
             var region = X.Fixes.create_region (xdisplay, {rect});
@@ -442,13 +437,13 @@ namespace Gala {
             unowned var xdisplay = x11_display.get_xdisplay ();
 
             if (restore_previous_region) {
-                var x_rect = regions[window];
-                if (x_rect == null) {
+                var region = regions[window];
+                if (region == null) {
                     debug ("Cannot unset pass through: window not found.");
                     return;
                 }
 
-                X.Shape.combine_rectangles (xdisplay, x_window, 2, 0, 0, { x_rect }, 0, 3);
+                X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, region);
             } else {
                 X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, (X.XserverRegion) 0);
             }

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -404,7 +404,7 @@ namespace Gala {
             return texture;
         }
 
-        private static HashTable<Meta.Window, X.XserverRegion?> regions = new HashTable<Meta.Window, X.XserverRegion?> (null, null);
+        private static HashTable<Meta.Window, X.Rectangle?> regions = new HashTable<Meta.Window, X.Rectangle?> (null, null);
 
         public static void x11_set_window_pass_through (Meta.Window window) {
             unowned var x11_display = window.display.get_x11_display ();
@@ -416,7 +416,8 @@ namespace Gala {
 #endif
             unowned var xdisplay = x11_display.get_xdisplay ();
 
-            regions[window] = X.Fixes.create_region_from_window (xdisplay, x_window, 0);
+            int count, ordering;
+            regions[window] = X.Shape.get_rectangles (xdisplay, x_window, 2, out count, out ordering)[0];
 
             X.Xrectangle rect = {};
             var region = X.Fixes.create_region (xdisplay, {rect});
@@ -443,7 +444,7 @@ namespace Gala {
                     return;
                 }
 
-                X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, region);
+                X.Shape.combine_rectangles (xdisplay, x_window, 2, 0, 0, { region }, 0, 3);
             } else {
                 X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, (X.XserverRegion) 0);
             }

--- a/lib/Utils.vala
+++ b/lib/Utils.vala
@@ -404,7 +404,13 @@ namespace Gala {
             return texture;
         }
 
+        private static HashTable<Meta.Window, X.Rectangle?> regions = new HashTable<Meta.Window, X.Rectangle?> (null, null);
+
         public static void x11_set_window_pass_through (Meta.Window window) {
+            if (window in regions) {
+                return;
+            }
+
             unowned var x11_display = window.display.get_x11_display ();
 
 #if HAS_MUTTER46
@@ -413,6 +419,9 @@ namespace Gala {
             var x_window = window.get_xwindow ();
 #endif
             unowned var xdisplay = x11_display.get_xdisplay ();
+
+            int count, ordering;
+            regions[window] = X.Shape.get_rectangles (xdisplay, x_window, 2, out count, out ordering)[0];
 
             X.Xrectangle rect = {};
             var region = X.Fixes.create_region (xdisplay, {rect});
@@ -422,7 +431,7 @@ namespace Gala {
             X.Fixes.destroy_region (xdisplay, region);
         }
 
-        public static void x11_unset_window_pass_through (Meta.Window window) {
+        public static void x11_unset_window_pass_through (Meta.Window window, bool restore_previous_region) {
             unowned var x11_display = window.display.get_x11_display ();
 
 #if HAS_MUTTER46
@@ -432,7 +441,19 @@ namespace Gala {
 #endif
             unowned var xdisplay = x11_display.get_xdisplay ();
 
-            X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, (X.XserverRegion) 0);
+            if (restore_previous_region) {
+                var x_rect = regions[window];
+                if (x_rect == null) {
+                    debug ("Cannot unset pass through: window not found.");
+                    return;
+                }
+
+                X.Shape.combine_rectangles (xdisplay, x_window, 2, 0, 0, { x_rect }, 0, 3);
+            } else {
+                X.Fixes.set_window_shape_region (xdisplay, x_window, 2, 0, 0, (X.XserverRegion) 0);
+            }
+
+            regions.remove (window);
         }
 
         /**

--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,6 @@ gnome_desktop_dep = dependency('gnome-desktop-3.0')
 m_dep = cc.find_library('m', required: false)
 posix_dep = vala.find_library('posix', required: false)
 sqlite3_dep = dependency('sqlite3')
-xext_dep = cc.find_library('Xext', required: true)
 if get_option('systemd')
     systemd_dep = dependency('libsystemd')
 endif
@@ -150,7 +149,7 @@ endif
 add_project_arguments(vala_flags, language: 'vala')
 add_project_link_arguments(['-Wl,-rpath,@0@'.format(mutter_typelib_dir)], language: 'c')
 
-gala_base_dep = [atk_bridge_dep, canberra_dep, glib_dep, gobject_dep, gio_dep, gio_unix_dep, gmodule_dep, gee_dep, gtk_dep, mutter_dep, gnome_desktop_dep, m_dep, posix_dep, sqlite3_dep, xext_dep, config_dep]
+gala_base_dep = [atk_bridge_dep, canberra_dep, glib_dep, gobject_dep, gio_dep, gio_unix_dep, gmodule_dep, gee_dep, gtk_dep, mutter_dep, gnome_desktop_dep, m_dep, posix_dep, sqlite3_dep, config_dep]
 
 if get_option('systemd')
     gala_base_dep += systemd_dep

--- a/meson.build
+++ b/meson.build
@@ -94,6 +94,7 @@ gnome_desktop_dep = dependency('gnome-desktop-3.0')
 m_dep = cc.find_library('m', required: false)
 posix_dep = vala.find_library('posix', required: false)
 sqlite3_dep = dependency('sqlite3')
+xext_dep = cc.find_library('Xext', required: true)
 if get_option('systemd')
     systemd_dep = dependency('libsystemd')
 endif
@@ -149,7 +150,7 @@ endif
 add_project_arguments(vala_flags, language: 'vala')
 add_project_link_arguments(['-Wl,-rpath,@0@'.format(mutter_typelib_dir)], language: 'c')
 
-gala_base_dep = [atk_bridge_dep, canberra_dep, glib_dep, gobject_dep, gio_dep, gio_unix_dep, gmodule_dep, gee_dep, gtk_dep, mutter_dep, gnome_desktop_dep, m_dep, posix_dep, sqlite3_dep, config_dep]
+gala_base_dep = [atk_bridge_dep, canberra_dep, glib_dep, gobject_dep, gio_dep, gio_unix_dep, gmodule_dep, gee_dep, gtk_dep, mutter_dep, gnome_desktop_dep, m_dep, posix_dep, sqlite3_dep, xext_dep, config_dep]
 
 if get_option('systemd')
     gala_base_dep += systemd_dep

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -293,7 +293,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
                 case "centered":
                     make_centered (window);
                     break;
-                
+
                 case "restore-previous-region":
                     set_restore_previous_x11_region (window);
                     break;

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -293,10 +293,20 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
                 case "centered":
                     make_centered (window);
                     break;
+                
+                case "restore-previous-region":
+                    set_restore_previous_x11_region (window);
+                    break;
 
                 default:
                     break;
             }
         }
+    }
+
+    private void set_restore_previous_x11_region (Meta.Window window)
+    requires (!Meta.Util.is_wayland_compositor ())
+    requires (window in panel_windows) {
+        panel_windows[window].restore_previous_x11_region = true;
     }
 }

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -7,6 +7,7 @@
 
 public class Gala.ShellWindow : PositionedWindow, GestureTarget {
     public Clutter.Actor? actor { get { return window_actor; } }
+    public bool restore_previous_x11_region { private get; set; default = false; }
 
     private Meta.WindowActor window_actor;
     private double custom_progress = 0;
@@ -89,7 +90,7 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
             if (!visible) {
                 Utils.x11_set_window_pass_through (window);
             } else {
-                Utils.x11_unset_window_pass_through (window);
+                Utils.x11_unset_window_pass_through (window, restore_previous_x11_region);
             }
         }
 

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -86,15 +86,15 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
         var visible = double.max (multitasking_view_progress, custom_progress) < 0.1;
         var animating = animations_ongoing > 0;
 
+        window_actor.visible = animating || visible;
+
         if (!Meta.Util.is_wayland_compositor ()) {
-            if (!visible) {
-                Utils.x11_set_window_pass_through (window);
-            } else {
+            if (window_actor.visible) {
                 Utils.x11_unset_window_pass_through (window, restore_previous_x11_region);
+            } else {
+                Utils.x11_set_window_pass_through (window);
             }
         }
-
-        window_actor.visible = animating || visible;
 
         unowned var manager = ShellClientsManager.get_instance ();
         window.foreach_transient ((transient) => {

--- a/vapi/xfixes-4.0.vapi
+++ b/vapi/xfixes-4.0.vapi
@@ -13,12 +13,6 @@ namespace X {
 		[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XFixesSetWindowShapeRegion")]
         public static void set_window_shape_region (X.Display display, X.Window win, int shape_kind, int x_off, int y_off, XserverRegion region);
 	}
-	namespace Shape {
-		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeGetRectangles")]
-		public static X.Rectangle* get_rectangles (X.Display display, X.Window win, int kind, out int count, out int ordering);
-		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeCombineRectangles")]
-		public static void combine_rectangles (X.Display display, X.Window win, int kind, int x, int y, [CCode (array_length_cname = "count", type = "XRectangle*")] X.Rectangle[] rectangles, int op, int ordering);
-	}
 	[SimpleType]
 	[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XserverRegion", has_type_id = false)]
 	public struct XserverRegion {

--- a/vapi/xfixes-4.0.vapi
+++ b/vapi/xfixes-4.0.vapi
@@ -13,6 +13,12 @@ namespace X {
 		[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XFixesSetWindowShapeRegion")]
         public static void set_window_shape_region (X.Display display, X.Window win, int shape_kind, int x_off, int y_off, XserverRegion region);
 	}
+		namespace Shape {
+		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeGetRectangles")]
+		public static X.Rectangle* get_rectangles (X.Display display, X.Window win, int kind, out int count, out int ordering);
+		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeCombineRectangles")]
+		public static void combine_rectangles (X.Display display, X.Window win, int kind, int x, int y, [CCode (array_length_cname = "count", type = "XRectangle*")] X.Rectangle[] rectangles, int op, int ordering);
+	}
 	[SimpleType]
 	[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XserverRegion", has_type_id = false)]
 	public struct XserverRegion {

--- a/vapi/xfixes-4.0.vapi
+++ b/vapi/xfixes-4.0.vapi
@@ -13,6 +13,12 @@ namespace X {
 		[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XFixesSetWindowShapeRegion")]
         public static void set_window_shape_region (X.Display display, X.Window win, int shape_kind, int x_off, int y_off, XserverRegion region);
 	}
+	namespace Shape {
+		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeGetRectangles")]
+		public static X.Rectangle* get_rectangles (X.Display display, X.Window win, int kind, out int count, out int ordering);
+		[CCode (cheader_filename = "X11/extensions/shape.h", cname = "XShapeCombineRectangles")]
+		public static void combine_rectangles (X.Display display, X.Window win, int kind, int x, int y, [CCode (array_length_cname = "count", type = "XRectangle*")] X.Rectangle[] rectangles, int op, int ordering);
+	}
 	[SimpleType]
 	[CCode (cheader_filename = "X11/extensions/Xfixes.h", cname = "XserverRegion", has_type_id = false)]
 	public struct XserverRegion {


### PR DESCRIPTION
Currently in gala 8.2.1, if you open multitasking view on X11 and close it, the dock clickable area will be a lot bigger then its visible part.

Unseting window shape region entirely doesn't work for our Dock since its window size is a lot bigger than its visible part. This branch introduces `restore-previous-region` argument for mutter hints. If it's set, we restore previous region (dock needs this), if not, unset region (wingpanel needs this).