### PR TITLE
Add an option to disable focusing windows then they demand attention

### DIFF
--- a/data/gala.gschema.xml
+++ b/data/gala.gschema.xml
@@ -102,6 +102,11 @@
       <summary>Whether hotcorners should be enabled when fullscreen window is opened</summary>
       <description></description>
     </key>
+    <key type="b" name="focus-on-demands-attention">
+      <default>true</default>
+      <summary>Whether windows should automatically be focused when they demand attention</summary>
+      <description></description>
+    </key>
     <key enum="SuperScrollAction" name="super-scroll-action">
       <default>"none"</default>
       <summary>What action should be performed on Super + Scroll</summary>

--- a/src/WindowAttentionTracker.vala
+++ b/src/WindowAttentionTracker.vala
@@ -4,13 +4,19 @@
  */
 
 public class Gala.WindowAttentionTracker : GLib.Object {
+    private static GLib.Settings behavior_settings;
+
     public static void init (Meta.Display display) {
+        behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
+
         display.window_demands_attention.connect (on_window_demands_attention);
         display.window_marked_urgent.connect (on_window_demands_attention);
     }
 
     private static void on_window_demands_attention (Meta.Window window) {
-        window.raise ();
-        window.get_workspace ().activate_with_focus (window, window.display.get_current_time ());
+        if (behavior_settings.get_boolean ("focus-on-demands-attention")) {
+            window.raise ();
+            window.get_workspace ().activate_with_focus (window, window.display.get_current_time ());
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/orgs/elementary/discussions/769 and https://github.com/elementary/gala/issues/2263

Usually apps expect that demanding attention just adds some badge or indicator to the dock/taskbar, not that it focuses the window. Initially I added focusing window because gnome-settings-daemon's application shortcuts uses this mechanism to 'focus' windows. To fix this issue properly we should probably implement our own application shortcuts backend for settings-daemon. That's too hard for now, so let's add an option to disable this mechanism entirely