### PR TITLE
ShellWindow: Clip window actor when applying translations

### DIFF
--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -147,18 +147,19 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
     }
 
     private void update_clip () {
-        switch (position) {
-            case TOP:
-                window_actor.set_clip (0, -window_actor.translation_y, window_actor.width, window_actor.height + window_actor.translation_y);
-                break;
+        if (position != TOP && position != BOTTOM) {
+            window_actor.remove_clip ();
+            return;
+        }
 
-            case BOTTOM:
-                window_actor.set_clip (0, 0, window_actor.width, window_actor.height - window_actor.translation_y);
-                break;
+        var monitor_geom = window.display.get_monitor_geometry (window.get_monitor ());
 
-            default:
-                window_actor.remove_clip ();
-                break;
+        var y = window_actor.y + window_actor.translation_y;
+
+        if (y + window_actor.height > monitor_geom.y + monitor_geom.height) {
+            window_actor.set_clip (0, 0, window_actor.width, monitor_geom.y + monitor_geom.height - y);
+        } else if (y < monitor_geom.y) {
+            window_actor.set_clip (0, monitor_geom.y - y, window_actor.width, window_actor.height);
         }
     }
 }

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -24,6 +24,11 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
     construct {
         window_actor = (Meta.WindowActor) window.get_compositor_private ();
 
+        window_actor.notify["width"].connect (update_clip);
+        window_actor.notify["height"].connect (update_clip);
+        window_actor.notify["translation-y"].connect (update_clip);
+        notify["position"].connect (update_clip);
+
         window_actor.notify["height"].connect (update_target);
         notify["position"].connect (update_target);
         update_target ();
@@ -138,6 +143,22 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
                 return hidden ? window_actor.height : 0f;
             default:
                 return hidden ? 0u : 255u;
+        }
+    }
+
+    private void update_clip () {
+        switch (position) {
+            case TOP:
+                window_actor.set_clip (0, -window_actor.translation_y, window_actor.width, window_actor.height + window_actor.translation_y);
+                break;
+
+            case BOTTOM:
+                window_actor.set_clip (0, 0, window_actor.width, window_actor.height - window_actor.translation_y);
+                break;
+
+            default:
+                window_actor.remove_clip ();
+                break;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elementary/dock/issues/425
Closes #2418 

There are things in the shell group that can be on secondary monitors (most notably freely movable transient windows like the connect to hidden network window). Also sometime soon the monitor labels should go there so they will need to be on secondary monitors. So instead of clipping the whole group only clip the respective actors.