### PR TITLE
ShellWindow: Disable unredirection when visible

### DIFF
--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -93,6 +93,12 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
 
         window_actor.visible = animating || visible;
 
+        if (window_actor.visible) {
+            window.display.disable_unredirect ();
+        } else {
+            window.display.enable_unredirect ();
+        }
+
         if (!Meta.Util.is_wayland_compositor ()) {
             if (window_actor.visible) {
                 Utils.x11_unset_window_pass_through (window, restore_previous_x11_region);

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -94,9 +94,17 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
         window_actor.visible = animating || visible;
 
         if (window_actor.visible) {
+#if HAS_MUTTER48
+            window.display.get_compositor ().disable_unredirect ();
+#else
             window.display.disable_unredirect ();
+#endif
         } else {
+#if HAS_MUTTER48
+            window.display.get_compositor ().enable_unredirect ();
+#else
             window.display.enable_unredirect ();
+#endif
         }
 
         if (!Meta.Util.is_wayland_compositor ()) {


### PR DESCRIPTION
Shell windows are in the shell group and are therefore above fullscreen windows. They can also be visible when a window is fullscreen via the new reveal feature. Also the animation plays when a window is already full screen. So we want to make sure to disable unredirection when we are visible so that we are actually visible.

Fixes an issue where when you are in a fullscreen firefox playing a video or in videos playing a video you wouldn't be able to reveal the wingpanel.