### PR TITLE
Draw rounded rectangles using shader

### DIFF
--- a/data/gala.gresource.xml
+++ b/data/gala.gresource.xml
@@ -23,6 +23,7 @@
   <gresource prefix="/io/elementary/desktop/gala">
     <file compressed="true">shaders/colorblindness-correction.vert</file>
     <file compressed="true">shaders/monochrome.vert</file>
+    <file compressed="true">shaders/rounded-corners.vert</file>
   </gresource>
   <gresource prefix="/io/elementary/desktop/gala-daemon">
     <file compressed="true">gala-daemon.css</file>

--- a/data/shaders/rounded-corners.vert
+++ b/data/shaders/rounded-corners.vert
@@ -6,24 +6,24 @@ uniform float clip_radius;
 uniform vec2 pixel_step;
 
 float rounded_rect_coverage (vec2 p) {
-  float center_left  = bounds.x + clip_radius;
-  float center_right = bounds.z - clip_radius;
+  float center_left  = bounds.x + clip_radius + 1.5;
+  float center_right = bounds.z - clip_radius - 1.5;
   float center_x;
 
   if (p.x < center_left)
     center_x = center_left;
-  else if (p.x > center_right)
+  else if (p.x >= center_right)
     center_x = center_right;
   else
     return 1.0; // The vast majority of pixels exit early here
 
-  float center_top    = bounds.y + clip_radius;
-  float center_bottom = bounds.w - clip_radius;
+  float center_top    = bounds.y + clip_radius + 1.5;
+  float center_bottom = bounds.w - clip_radius - 1.5;
   float center_y;
 
   if (p.y < center_top)
     center_y = center_top;
-  else if (p.y > center_bottom)
+  else if (p.y >= center_bottom)
     center_y = center_bottom;
   else
     return 1.0;
@@ -32,25 +32,26 @@ float rounded_rect_coverage (vec2 p) {
   float dist_squared = dot (delta, delta);
 
   // Fully outside the circle
-  float outer_radius = clip_radius + 0.5;
+  float outer_radius = clip_radius + 0.75;
   if (dist_squared >= (outer_radius * outer_radius))
     return 0.0;
 
   // Fully inside the circle
-  float inner_radius = clip_radius - 0.5;
+  float inner_radius = clip_radius - 0.75;
   if (dist_squared <= (inner_radius * inner_radius))
     return 1.0;
 
   // Only pixels on the edge of the curve need expensive antialiasing
   return outer_radius - sqrt (dist_squared);
+  // return smoothstep(outer_radius, inner_radius, length(delta));
 }
 
 void main () {
   vec4 sample = texture2D (tex, cogl_tex_coord0_in.xy);
 
   vec2 texture_coord = cogl_tex_coord0_in.xy / pixel_step;
-  // float res = rounded_rect_coverage (texture_coord);
-  float res = 1.0;
+  float res = rounded_rect_coverage (texture_coord);
 
-  cogl_color_out = cogl_color_in;
+  cogl_color_out = sample * cogl_color_in;
+  cogl_color_out.a *= res;
 }

--- a/data/shaders/rounded-corners.vert
+++ b/data/shaders/rounded-corners.vert
@@ -1,13 +1,12 @@
 // copied from mutter
 
 uniform sampler2D tex;
-uniform vec4 bounds; // x, y: top left; z, w: bottom right
 uniform float clip_radius;
-uniform vec2 pixel_step;
+uniform vec2 actor_size;
 
 float rounded_rect_coverage (vec2 p) {
-  float center_left  = bounds.x + clip_radius + 1.5;
-  float center_right = bounds.z - clip_radius - 1.5;
+  float center_left = clip_radius + 1.5;
+  float center_right = actor_size.x - clip_radius - 0.5;
   float center_x;
 
   if (p.x < center_left)
@@ -17,13 +16,13 @@ float rounded_rect_coverage (vec2 p) {
   else
     return 1.0; // The vast majority of pixels exit early here
 
-  float center_top    = bounds.y + clip_radius + 1.5;
-  float center_bottom = bounds.w - clip_radius - 1.5;
+  float center_top = clip_radius + 1.5;
+  float center_bottom = actor_size.y - clip_radius - 0.5;
   float center_y;
 
   if (p.y < center_top)
     center_y = center_top;
-  else if (p.y >= center_bottom)
+  else if (p.y > center_bottom)
     center_y = center_bottom;
   else
     return 1.0;
@@ -32,24 +31,23 @@ float rounded_rect_coverage (vec2 p) {
   float dist_squared = dot (delta, delta);
 
   // Fully outside the circle
-  float outer_radius = clip_radius + 0.75;
-  if (dist_squared >= (outer_radius * outer_radius))
+  float outer_radius = clip_radius + 0.5;
+  if (dist_squared > (outer_radius * outer_radius))
     return 0.0;
 
   // Fully inside the circle
-  float inner_radius = clip_radius - 0.75;
+  float inner_radius = clip_radius - 0.5;
   if (dist_squared <= (inner_radius * inner_radius))
     return 1.0;
 
   // Only pixels on the edge of the curve need expensive antialiasing
   return outer_radius - sqrt (dist_squared);
-  // return smoothstep(outer_radius, inner_radius, length(delta));
 }
 
 void main () {
   vec4 sample = texture2D (tex, cogl_tex_coord0_in.xy);
 
-  vec2 texture_coord = cogl_tex_coord0_in.xy / pixel_step;
+  vec2 texture_coord = cogl_tex_coord0_in.xy * actor_size;
   float res = rounded_rect_coverage (texture_coord);
 
   cogl_color_out = sample * cogl_color_in;

--- a/data/shaders/rounded-corners.vert
+++ b/data/shaders/rounded-corners.vert
@@ -1,4 +1,4 @@
-// copied from mutter
+// based on shader from mutter
 
 uniform sampler2D tex;
 uniform float clip_radius;
@@ -6,7 +6,7 @@ uniform vec2 actor_size;
 
 float rounded_rect_coverage (vec2 p) {
   float center_left = clip_radius + 1.5;
-  float center_right = actor_size.x - clip_radius - 0.5;
+  float center_right = actor_size.x - clip_radius - 0.55;
   float center_x;
 
   if (p.x < center_left)
@@ -14,10 +14,10 @@ float rounded_rect_coverage (vec2 p) {
   else if (p.x >= center_right)
     center_x = center_right;
   else
-    return 1.0; // The vast majority of pixels exit early here
+    return 1.0;
 
   float center_top = clip_radius + 1.5;
-  float center_bottom = actor_size.y - clip_radius - 0.5;
+  float center_bottom = actor_size.y - clip_radius - 0.55;
   float center_y;
 
   if (p.y < center_top)
@@ -41,7 +41,7 @@ float rounded_rect_coverage (vec2 p) {
     return 1.0;
 
   // Only pixels on the edge of the curve need expensive antialiasing
-  return outer_radius - sqrt (dist_squared);
+  return smoothstep (outer_radius, inner_radius, length (delta));
 }
 
 void main () {

--- a/data/shaders/rounded-corners.vert
+++ b/data/shaders/rounded-corners.vert
@@ -50,6 +50,5 @@ void main () {
   vec2 texture_coord = cogl_tex_coord0_in.xy * actor_size;
   float res = rounded_rect_coverage (texture_coord);
 
-  cogl_color_out = sample * cogl_color_in;
-  cogl_color_out.a *= res;
+  cogl_color_out = sample * cogl_color_in * res;
 }

--- a/data/shaders/rounded-corners.vert
+++ b/data/shaders/rounded-corners.vert
@@ -1,0 +1,56 @@
+// copied from mutter
+
+uniform sampler2D tex;
+uniform vec4 bounds; // x, y: top left; z, w: bottom right
+uniform float clip_radius;
+uniform vec2 pixel_step;
+
+float rounded_rect_coverage (vec2 p) {
+  float center_left  = bounds.x + clip_radius;
+  float center_right = bounds.z - clip_radius;
+  float center_x;
+
+  if (p.x < center_left)
+    center_x = center_left;
+  else if (p.x > center_right)
+    center_x = center_right;
+  else
+    return 1.0; // The vast majority of pixels exit early here
+
+  float center_top    = bounds.y + clip_radius;
+  float center_bottom = bounds.w - clip_radius;
+  float center_y;
+
+  if (p.y < center_top)
+    center_y = center_top;
+  else if (p.y > center_bottom)
+    center_y = center_bottom;
+  else
+    return 1.0;
+
+  vec2 delta = p - vec2 (center_x, center_y);
+  float dist_squared = dot (delta, delta);
+
+  // Fully outside the circle
+  float outer_radius = clip_radius + 0.5;
+  if (dist_squared >= (outer_radius * outer_radius))
+    return 0.0;
+
+  // Fully inside the circle
+  float inner_radius = clip_radius - 0.5;
+  if (dist_squared <= (inner_radius * inner_radius))
+    return 1.0;
+
+  // Only pixels on the edge of the curve need expensive antialiasing
+  return outer_radius - sqrt (dist_squared);
+}
+
+void main () {
+  vec4 sample = texture2D (tex, cogl_tex_coord0_in.xy);
+
+  vec2 texture_coord = cogl_tex_coord0_in.xy / pixel_step;
+  // float res = rounded_rect_coverage (texture_coord);
+  float res = 1.0;
+
+  cogl_color_out = cogl_color_in;
+}

--- a/lib/RoundedCornersEffect.vala
+++ b/lib/RoundedCornersEffect.vala
@@ -60,6 +60,8 @@ public class Gala.RoundedCornersEffect : Clutter.ShaderEffect {
             actor.height
         };
 
+        warning ("%f", actor.height);
+
         var bounds_value = GLib.Value (typeof (Clutter.ShaderFloat));
         Clutter.Value.set_shader_float (bounds_value, bounds);
         set_uniform_value ("bounds", bounds_value);

--- a/lib/RoundedCornersEffect.vala
+++ b/lib/RoundedCornersEffect.vala
@@ -4,7 +4,7 @@
  */
 
 public class Gala.RoundedCornersEffect : Clutter.ShaderEffect {
-    private const int CLIP_RADIUS_OFFSET = 5;
+    private const int CLIP_RADIUS_OFFSET = 3;
 
     public float clip_radius {
         construct set {

--- a/lib/RoundedCornersEffect.vala
+++ b/lib/RoundedCornersEffect.vala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 elementary, Inc. <https://elementary.io>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+public class Gala.RoundedCornersEffect : Clutter.ShaderEffect {
+    public float clip_radius {
+        construct set {
+            set_uniform_value ("clip_radius",  value);
+        }
+    }
+
+    private float _monitor_scale = 1.0f;
+    public float monitor_scale {
+        get {
+            return _monitor_scale;
+        }
+        construct set {
+            _monitor_scale = value;
+
+            if (actor != null) {
+                update_pixel_step ();
+            }
+        }
+    }
+
+    public RoundedCornersEffect (float clip_radius, float monitor_scale) {
+        Object (
+            shader_type: Clutter.ShaderType.FRAGMENT_SHADER,
+            clip_radius: clip_radius,
+            monitor_scale: monitor_scale
+        );
+    }
+
+    construct {
+        try {
+            var bytes = GLib.resources_lookup_data ("/io/elementary/desktop/gala/shaders/rounded-corners.vert", GLib.ResourceLookupFlags.NONE);
+            set_shader_source ((string) bytes.get_data ());
+        } catch (Error e) {
+            critical ("Unable to load rounded-corners.vert: %s", e.message);
+        }
+
+        notify["actor"].connect (() => {
+            if (actor == null) {
+                return;
+            }
+
+            actor.notify["width"].connect (update_bounds);
+            actor.notify["height"].connect (update_bounds);
+
+            update_bounds ();
+        });
+    }
+
+    private void update_bounds () requires (actor != null) {
+        float[] bounds = {
+            0.0f,
+            0.0f,
+            actor.width,
+            actor.height
+        };
+
+        var bounds_value = GLib.Value (typeof (Clutter.ShaderFloat));
+        Clutter.Value.set_shader_float (bounds_value, bounds);
+        set_uniform_value ("bounds", bounds_value);
+
+        update_pixel_step ();
+    }
+
+    private void update_pixel_step () requires (actor != null) {
+        float[] pixel_step = {
+            1.0f / (actor.width * monitor_scale),
+            1.0f / (actor.height * monitor_scale)
+        };
+
+        var pixel_step_value = GLib.Value (typeof (Clutter.ShaderFloat));
+        Clutter.Value.set_shader_float (pixel_step_value, pixel_step);
+        set_uniform_value ("pixel_step", pixel_step_value);
+    }
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -15,6 +15,7 @@ gala_lib_sources = files(
     'Drawing/Utilities.vala',
     'Image.vala',
     'Plugin.vala',
+    'RoundedCornersEffect.vala',
     'ShadowEffect.vala',
     'Utils.vala',
     'WindowIcon.vala',

--- a/src/Widgets/MultitaskingView/Tooltip.vala
+++ b/src/Widgets/MultitaskingView/Tooltip.vala
@@ -46,7 +46,7 @@ public class Gala.Tooltip : Clutter.Actor {
             (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.alpha * uint8.MAX)
         };
 
-        add_effect (new RoundedCornersEffect (4, 1.0f));
+        add_effect (new RoundedCornersEffect (3, 1.0f));
     }
 
     public void set_text (string new_text) {

--- a/src/Widgets/MultitaskingView/Tooltip.vala
+++ b/src/Widgets/MultitaskingView/Tooltip.vala
@@ -8,6 +8,8 @@
  * Clutter actor to display text in a tooltip-like component.
  */
 public class Gala.Tooltip : Clutter.Actor {
+    private const int BASE_HEIGHT = 32;
+
     /**
      * Actor to display the Tooltip text.
      */
@@ -44,7 +46,9 @@ public class Gala.Tooltip : Clutter.Actor {
             (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.alpha * uint8.MAX)
         };
 
-        add_effect (new RoundedCornersEffect (4, 1.0f));
+        height = BASE_HEIGHT * 1.0f;
+
+        add_effect (new RoundedCornersEffect (16, 1.0f));
     }
 
     public void set_text (string new_text) {

--- a/src/Widgets/MultitaskingView/Tooltip.vala
+++ b/src/Widgets/MultitaskingView/Tooltip.vala
@@ -7,7 +7,7 @@
 /**
  * Clutter actor to display text in a tooltip-like component.
  */
-public class Gala.Tooltip : CanvasActor {
+public class Gala.Tooltip : Clutter.Actor {
     /**
      * Actor to display the Tooltip text.
      */
@@ -37,31 +37,17 @@ public class Gala.Tooltip : CanvasActor {
         add_child (text_actor);
 
         layout_manager = new Clutter.BinLayout ();
+        background_color = {
+            (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.red * uint8.MAX),
+            (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.green * uint8.MAX),
+            (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.blue * uint8.MAX),
+            (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.alpha * uint8.MAX)
+        };
+
+        add_effect (new RoundedCornersEffect (4, 1.0f));
     }
 
     public void set_text (string new_text) {
         text_actor.text = new_text;
-    }
-
-    protected override void draw (Cairo.Context ctx, int width, int height) {
-        ctx.save ();
-        ctx.set_operator (Cairo.Operator.CLEAR);
-        ctx.paint ();
-        ctx.clip ();
-        ctx.reset_clip ();
-        ctx.set_operator (Cairo.Operator.OVER);
-
-        var background_color = Drawing.Color.TOOLTIP_BACKGROUND;
-        ctx.set_source_rgba (
-            background_color.red,
-            background_color.green,
-            background_color.blue,
-            background_color.alpha
-        );
-
-        Drawing.Utilities.cairo_rounded_rectangle (ctx, 0, 0, width, height, 4);
-        ctx.fill ();
-
-        ctx.restore ();
     }
 }

--- a/src/Widgets/MultitaskingView/Tooltip.vala
+++ b/src/Widgets/MultitaskingView/Tooltip.vala
@@ -46,9 +46,7 @@ public class Gala.Tooltip : Clutter.Actor {
             (uint8) (Drawing.Color.TOOLTIP_BACKGROUND.alpha * uint8.MAX)
         };
 
-        height = BASE_HEIGHT * 1.0f;
-
-        add_effect (new RoundedCornersEffect (16, 1.0f));
+        add_effect (new RoundedCornersEffect (4, 1.0f));
     }
 
     public void set_text (string new_text) {

--- a/src/Widgets/MultitaskingView/Tooltip.vala
+++ b/src/Widgets/MultitaskingView/Tooltip.vala
@@ -8,8 +8,6 @@
  * Clutter actor to display text in a tooltip-like component.
  */
 public class Gala.Tooltip : Clutter.Actor {
-    private const int BASE_HEIGHT = 32;
-
     /**
      * Actor to display the Tooltip text.
      */

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -356,7 +356,6 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
         float window_title_max_width = box.get_width () - Utils.scale_to_int (TITLE_MAX_WIDTH_MARGIN, monitor_scale);
         float window_title_height, window_title_nat_width;
         window_title.get_preferred_size (null, null, out window_title_nat_width, out window_title_height);
-        warning ("Got nat height %f", window_title_height);
 
         var window_title_width = window_title_nat_width.clamp (0, window_title_max_width);
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -41,6 +41,8 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
      */
     public bool active {
         set {
+            active_shape.update_color ();
+
             active_shape.save_easing_state ();
             active_shape.set_easing_duration (Utils.get_animation_duration (FADE_ANIMATION_DURATION));
             active_shape.opacity = value ? 255 : 0;
@@ -122,8 +124,9 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
             add_action (drag_action);
         }
 
-        active_shape = new ActiveShape ();
-        active_shape.opacity = 0;
+        active_shape = new ActiveShape () {
+            opacity = 0
+        };
 
         clone_container = new Clutter.Actor () {
             pivot_point = { 0.5f, 0.5f }
@@ -687,33 +690,22 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
     /**
      * Border to show around the selected window when using keyboard navigation.
      */
-    private class ActiveShape : CanvasActor {
+    private class ActiveShape : Clutter.Actor {
         private const int BORDER_RADIUS = 16;
         private const double COLOR_OPACITY = 0.8;
 
         construct {
-            notify["opacity"].connect (invalidate);
+            add_effect (new RoundedCornersEffect (BORDER_RADIUS, 1.0f));
         }
 
-        public void invalidate () {
-            content.invalidate ();
-        }
-
-        protected override void draw (Cairo.Context cr, int width, int height) {
-            if (!visible || opacity == 0) {
-                return;
-            }
-
-            var color = Drawing.StyleManager.get_instance ().theme_accent_color;
-
-            cr.save ();
-            cr.set_operator (Cairo.Operator.CLEAR);
-            cr.paint ();
-            cr.restore ();
-
-            Drawing.Utilities.cairo_rounded_rectangle (cr, 0, 0, width, height, BORDER_RADIUS);
-            cr.set_source_rgba (color.red, color.green, color.blue, COLOR_OPACITY);
-            cr.fill ();
+        public void update_color () {
+            var accent_color = Drawing.StyleManager.get_instance ().theme_accent_color;
+            background_color = {
+                (uint8) (accent_color.red * uint8.MAX),
+                (uint8) (accent_color.green * uint8.MAX),
+                (uint8) (accent_color.blue * uint8.MAX),
+                (uint8) (COLOR_OPACITY * uint8.MAX)
+            };
         }
     }
 }

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -356,6 +356,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
         float window_title_max_width = box.get_width () - Utils.scale_to_int (TITLE_MAX_WIDTH_MARGIN, monitor_scale);
         float window_title_height, window_title_nat_width;
         window_title.get_preferred_size (null, null, out window_title_nat_width, out window_title_height);
+        warning ("Got nat height %f", window_title_height);
 
         var window_title_width = window_title_nat_width.clamp (0, window_title_max_width);
 


### PR DESCRIPTION
Significantly optimizes our drawing code by using shader to draw rounded rectangles. Multitasking view gets a huge performance boost by not manually checking/drawing ActiveShape since it's now done on GPU.

The shaders code looks weird but I just couldn't make it produce consistent results. I played with offsets and this configuration gives the most symmetrical and sharp results