### PR TITLE
WindowTracker: ignore windows from our Wayland clients

### DIFF
--- a/src/DesktopIntegration.vala
+++ b/src/DesktopIntegration.vala
@@ -78,7 +78,7 @@ public class Gala.DesktopIntegration : GLib.Object {
             return false;
         }
 
-        if (ShellClientsManager.get_instance ().is_positioned_window (window)) {
+        if (ShellClientsManager.get_instance ().is_shell_window (window)) {
             return false;
         }
 

--- a/src/Dialogs/InhibitShortcutsDialog.vala
+++ b/src/Dialogs/InhibitShortcutsDialog.vala
@@ -36,7 +36,7 @@ public class Gala.InhibitShortcutsDialog : AccessDialog, Meta.InhibitShortcutsDi
         }
 
         if (app.id == "io.elementary.settings.desktop" || // Naive check to always allow inhibiting by our settings app. This is needed for setting custom shortcuts
-            ShellClientsManager.get_instance ().is_positioned_window (window) // Certain windows (e.g. centered ones) may want to disable move via super + drag
+            ShellClientsManager.get_instance ().is_shell_window (window) // Certain windows (e.g. centered ones) may want to disable move via super + drag
         ) {
             on_response (0);
             return;

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -18,10 +18,16 @@ public class Gala.ManagedClient : Object {
 
     public Meta.WaylandClient? wayland_client { get; private set; }
 
+    private static GLib.List<unowned ManagedClient> instances = new GLib.List<unowned ManagedClient> ();
     private Subprocess? subprocess;
 
     public ManagedClient (Meta.Display display, string[] args) {
         Object (display: display, args: args);
+        instances.append (this);
+    }
+
+    ~ManagedClient () {
+        instances.remove (this);
     }
 
     construct {
@@ -45,6 +51,20 @@ public class Gala.ManagedClient : Object {
         } else {
             start_x.begin ();
         }
+    }
+
+    public static bool is_wayland_client (Meta.Window window) {
+        if (!Meta.Util.is_wayland_compositor ()) {
+            return false;
+        }
+
+        foreach (unowned var instance in instances) {
+            if (instance.wayland_client.owns_window (window)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async void start_wayland () {

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -203,10 +203,15 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
     }
 
     public bool is_itself_positioned (Meta.Window window) {
-        return (window in positioned_windows) || (window in panel_windows) || NotificationStack.is_notification (window);
+        return (
+            (window in positioned_windows) ||
+            (window in panel_windows) ||
+            NotificationStack.is_notification (window) ||
+            ManagedClient.is_wayland_client (window)
+        );
     }
 
-    public bool is_positioned_window (Meta.Window window) {
+    public bool is_shell_window (Meta.Window window) {
         bool positioned = is_itself_positioned (window);
         window.foreach_ancestor ((ancestor) => {
             if (is_itself_positioned (ancestor)) {

--- a/src/Widgets/MultitaskingView/StaticWindowContainer.vala
+++ b/src/Widgets/MultitaskingView/StaticWindowContainer.vala
@@ -71,7 +71,7 @@ public class Gala.StaticWindowContainer : ActorTarget {
     }
 
     private void check_window_changed (Meta.Window window) {
-        var is_static = is_static (window) && !ShellClientsManager.get_instance ().is_positioned_window (window);
+        var is_static = is_static (window) && !ShellClientsManager.get_instance ().is_shell_window (window);
 
         Clutter.Actor? clone = null;
         for (var child = get_first_child (); child != null; child = child.get_next_sibling ()) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -43,7 +43,7 @@ namespace Gala {
 
         /**
          * The group that contains all WindowActors that make shell elements, that is all windows reported as
-         * ShellClientsManager.is_positioned_window.
+         * ShellClientsManager.is_shell_window.
          * It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
          * responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).
          */
@@ -972,7 +972,7 @@ namespace Gala {
 
         private void check_shell_window (Meta.WindowActor actor) {
             unowned var window = actor.get_meta_window ();
-            if (ShellClientsManager.get_instance ().is_positioned_window (window)) {
+            if (ShellClientsManager.get_instance ().is_shell_window (window)) {
                 InternalUtils.clutter_actor_reparent (actor, shell_group);
             }
 

--- a/src/WindowStateSaver.vala
+++ b/src/WindowStateSaver.vala
@@ -87,7 +87,7 @@ public class Gala.WindowStateSaver : GLib.Object {
             return;
         }
 
-        if (ShellClientsManager.get_instance ().is_positioned_window (window)) {
+        if (ShellClientsManager.get_instance ().is_shell_window (window)) {
             return;
         }
 

--- a/src/WindowTracker.vala
+++ b/src/WindowTracker.vala
@@ -341,6 +341,10 @@ public class Gala.WindowTracker : GLib.Object {
     }
 
     private void track_window (Meta.Window window) {
+        if (ShellClientsManager.get_instance ().is_shell_window (window)) {
+            return;
+        }
+
         var app = get_app_for_window (window);
         if (app == null) {
             return;


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2079

Makes DaemonManager use ManagedClient instead of reimplementing it