### PR TITLE
Introduce GestureAction.CUSTOM

### DIFF
--- a/lib/Gestures/Gesture.vala
+++ b/lib/Gestures/Gesture.vala
@@ -39,9 +39,8 @@ namespace Gala {
         SWITCH_WORKSPACE,
         SWITCH_WINDOWS,
         MULTITASKING_VIEW,
-        DOCK,
         ZOOM,
-        CLOSE_WINDOW,
+        CUSTOM,
         N_ACTIONS
     }
 

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -6,8 +6,6 @@
  */
 
 public class Gala.PanelWindow : ShellWindow, RootTarget {
-    private const int ANIMATION_DURATION = 250;
-
     private static HashTable<Meta.Window, Meta.Strut?> window_struts = new HashTable<Meta.Window, Meta.Strut?> (null, null);
 
     public WindowManager wm { get; construct; }
@@ -53,7 +51,7 @@ public class Gala.PanelWindow : ShellWindow, RootTarget {
         notify["width"].connect (update_strut);
         notify["height"].connect (update_strut);
 
-        gesture_controller = new GestureController (DOCK, wm);
+        gesture_controller = new GestureController (CUSTOM, wm);
         add_gesture_controller (gesture_controller);
 
         hide_tracker = new HideTracker (wm.get_display (), this);

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -37,7 +37,7 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
 
     private void update_target () {
         property_target = new PropertyTarget (
-            DOCK, window_actor,
+            CUSTOM, window_actor,
             get_animation_property (),
             get_property_type (),
             calculate_value (false),
@@ -54,7 +54,7 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
     }
 
     private void update_property () {
-        property_target.propagate (UPDATE, DOCK, get_hidden_progress ());
+        property_target.propagate (UPDATE, CUSTOM, get_hidden_progress ());
     }
 
     public override void propagate (UpdateType update_type, GestureAction action, double progress) {
@@ -84,7 +84,7 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
                 multitasking_view_progress = progress;
                 break;
 
-            case DOCK:
+            case CUSTOM:
                 custom_progress = progress;
                 break;
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -95,7 +95,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
     construct {
         reactive = true;
 
-        gesture_controller = new GestureController (CLOSE_WINDOW, wm);
+        gesture_controller = new GestureController (CUSTOM, wm);
         gesture_controller.enable_scroll (this, VERTICAL);
         add_gesture_controller (gesture_controller);
 
@@ -272,7 +272,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
     }
 
     public override void update_progress (Gala.GestureAction action, double progress) {
-        if (action != CLOSE_WINDOW || slot == null || !Meta.Prefs.get_gnome_animations ()) {
+        if (action != CUSTOM || slot == null || !Meta.Prefs.get_gnome_animations ()) {
             return;
         }
 
@@ -295,7 +295,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
     public override void end_progress (GestureAction action) {
         update_hover_widgets (false);
 
-        if (action == CLOSE_WINDOW && get_current_commit (CLOSE_WINDOW) > 0.5 && Meta.Prefs.get_gnome_animations ()) {
+        if (action == CUSTOM && get_current_commit (CUSTOM) > 0.5 && Meta.Prefs.get_gnome_animations ()) {
             close_window (Meta.CURRENT_TIME);
         }
     }


### PR DESCRIPTION
Replaces our DOCK and CLOSE_WINDOW gesture actions with CUSTOM. This allows us to use this action in plugins (e.g. for hiding PiP). This change shouldn't affect anything since users of DOCK and CLOSE_WINDOW are self-contained and don't have complicated target hierarchy. 