### PR TITLE
gtk3/4-daemon: don't depend on libgala

### DIFF
--- a/daemon-gtk3/meson.build
+++ b/daemon-gtk3/meson.build
@@ -13,7 +13,8 @@ hdy_dep = dependency('libhandy-1')
 executable(
     'gala-daemon-gtk3',
     gala_daemon_sources,
+    gala_common_enums,
     config_header,
-    dependencies: [gala_base_dep, gala_dep, granite6_dep, hdy_dep],
+    dependencies: [granite6_dep, hdy_dep],
     install: true,
 )

--- a/daemon/DBus.vala
+++ b/daemon/DBus.vala
@@ -3,44 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-public enum Gala.ActionType {
-    NONE = 0,
-    SHOW_MULTITASKING_VIEW,
-    MAXIMIZE_CURRENT,
-    HIDE_CURRENT,
-    OPEN_LAUNCHER,
-    CUSTOM_COMMAND,
-    WINDOW_OVERVIEW,
-    WINDOW_OVERVIEW_ALL,
-    SWITCH_TO_WORKSPACE_PREVIOUS,
-    SWITCH_TO_WORKSPACE_NEXT,
-    SWITCH_TO_WORKSPACE_LAST,
-    START_MOVE_CURRENT,
-    START_RESIZE_CURRENT,
-    TOGGLE_ALWAYS_ON_TOP_CURRENT,
-    TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT,
-    MOVE_CURRENT_WORKSPACE_LEFT,
-    MOVE_CURRENT_WORKSPACE_RIGHT,
-    CLOSE_CURRENT,
-    SCREENSHOT_CURRENT
-}
-
-[Flags]
-public enum Gala.WindowFlags {
-    NONE = 0,
-    CAN_HIDE,
-    CAN_MAXIMIZE,
-    IS_MAXIMIZED,
-    ALLOWS_MOVE,
-    ALLOWS_RESIZE,
-    ALWAYS_ON_TOP,
-    ON_ALL_WORKSPACES,
-    CAN_CLOSE,
-    IS_TILED,
-    ALLOWS_MOVE_LEFT,
-    ALLOWS_MOVE_RIGHT
-}
-
 [DBus (name = "org.pantheon.gala")]
 public interface Gala.WMDBus : GLib.Object {
     public abstract void perform_action (Gala.ActionType type) throws DBusError, IOError;

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -13,6 +13,7 @@ granite7_dep = dependency('granite-7')
 executable(
     'gala-daemon',
     gala_daemon_sources,
+    gala_common_enums,
     config_header,
     gala_resources,
     dependencies: [gtk4_dep, granite7_dep],

--- a/lib/CommonEnums.vala
+++ b/lib/CommonEnums.vala
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ *                         2014 Tom Beckmann
+ *
+ * Note: These enums are shared with the daemon
+ */
+
+namespace Gala {
+    public enum ActionType {
+        NONE = 0,
+        SHOW_MULTITASKING_VIEW,
+        MAXIMIZE_CURRENT,
+        HIDE_CURRENT,
+        OPEN_LAUNCHER,
+        CUSTOM_COMMAND,
+        WINDOW_OVERVIEW,
+        WINDOW_OVERVIEW_ALL,
+        SWITCH_TO_WORKSPACE_PREVIOUS,
+        SWITCH_TO_WORKSPACE_NEXT,
+        SWITCH_TO_WORKSPACE_LAST,
+        START_MOVE_CURRENT,
+        START_RESIZE_CURRENT,
+        TOGGLE_ALWAYS_ON_TOP_CURRENT,
+        TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT,
+        MOVE_CURRENT_WORKSPACE_LEFT,
+        MOVE_CURRENT_WORKSPACE_RIGHT,
+        CLOSE_CURRENT,
+        SCREENSHOT_CURRENT
+    }
+
+    [Flags]
+    public enum WindowFlags {
+        NONE = 0,
+        CAN_HIDE,
+        CAN_MAXIMIZE,
+        IS_MAXIMIZED,
+        ALLOWS_MOVE,
+        ALLOWS_RESIZE,
+        ALWAYS_ON_TOP,
+        ON_ALL_WORKSPACES,
+        CAN_CLOSE,
+        IS_TILED,
+        ALLOWS_MOVE_LEFT,
+        ALLOWS_MOVE_RIGHT
+    }
+}

--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -23,44 +23,6 @@ namespace Gala {
         public const string TOGGLE_RECORDING_ACTION = "toggle-recording-action";
     }
 
-    public enum ActionType {
-        NONE = 0,
-        SHOW_MULTITASKING_VIEW,
-        MAXIMIZE_CURRENT,
-        HIDE_CURRENT,
-        OPEN_LAUNCHER,
-        CUSTOM_COMMAND,
-        WINDOW_OVERVIEW,
-        WINDOW_OVERVIEW_ALL,
-        SWITCH_TO_WORKSPACE_PREVIOUS,
-        SWITCH_TO_WORKSPACE_NEXT,
-        SWITCH_TO_WORKSPACE_LAST,
-        START_MOVE_CURRENT,
-        START_RESIZE_CURRENT,
-        TOGGLE_ALWAYS_ON_TOP_CURRENT,
-        TOGGLE_ALWAYS_ON_VISIBLE_WORKSPACE_CURRENT,
-        MOVE_CURRENT_WORKSPACE_LEFT,
-        MOVE_CURRENT_WORKSPACE_RIGHT,
-        CLOSE_CURRENT,
-        SCREENSHOT_CURRENT
-    }
-
-    [Flags]
-    public enum WindowFlags {
-        NONE = 0,
-        CAN_HIDE,
-        CAN_MAXIMIZE,
-        IS_MAXIMIZED,
-        ALLOWS_MOVE,
-        ALLOWS_RESIZE,
-        ALWAYS_ON_TOP,
-        ON_ALL_WORKSPACES,
-        CAN_CLOSE,
-        IS_TILED,
-        ALLOWS_MOVE_LEFT,
-        ALLOWS_MOVE_RIGHT
-    }
-
     /**
      * Function that should return true if the given shortcut should be blocked.
      */

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,3 +1,7 @@
+gala_common_enums = files(
+  'CommonEnums.vala',
+)
+
 gala_lib_sources = files(
     'ActivatableComponent.vala',
     'App.vala',
@@ -33,7 +37,7 @@ gala_lib_sources = files(
     'Gestures/SpringTimeline.vala',
     'Gestures/ToucheggBackend.vala',
     'Gestures/TouchpadBackend.vala'
-)
+) + gala_common_enums
 
 gala_resources = gnome.compile_resources(
     'gala-resources',


### PR DESCRIPTION
Move the enums to a shared file so that we can only keep the common part apart.