### PR TITLE
GestureTarget: make propagate abstract

### DIFF
--- a/lib/Gestures/ActorTarget.vala
+++ b/lib/Gestures/ActorTarget.vala
@@ -64,7 +64,7 @@ public class Gala.ActorTarget : Clutter.Actor, GestureTarget {
     public virtual void commit_progress (GestureAction action, double to) {}
     public virtual void end_progress (GestureAction action) {}
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         if (update_type == COMMIT) {
             current_commit[action] = progress;
         } else {

--- a/lib/Gestures/GestureTarget.vala
+++ b/lib/Gestures/GestureTarget.vala
@@ -13,5 +13,5 @@ public interface Gala.GestureTarget : Object {
         END
     }
 
-    public virtual void propagate (UpdateType update_type, GestureAction action, double progress) { }
+    public abstract void propagate (UpdateType update_type, GestureAction action, double progress);
 }

--- a/lib/Gestures/PropertyTarget.vala
+++ b/lib/Gestures/PropertyTarget.vala
@@ -30,7 +30,7 @@ public class Gala.PropertyTarget : Object, GestureTarget {
         target = null;
     }
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         if (target == null || update_type != UPDATE || action != this.action) {
             return;
         }

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -205,7 +205,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         window.unmanaging.connect_after ((_window) => positioned_windows.remove (_window));
     }
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         foreach (var window in positioned_windows.get_values ()) {
             window.propagate (update_type, action, progress);
         }

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -41,7 +41,7 @@ public class Gala.ShellWindow : PositionedWindow, GestureTarget {
         );
     }
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         switch (update_type) {
             case START:
                 animations_ongoing++;

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -230,7 +230,7 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget, RootTarget {
         ctx.restore ();
     }
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         if (update_type != UPDATE || container.get_n_children () == 0) {
             return;
         }

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -103,7 +103,7 @@ public class Gala.Zoom : Object, GestureTarget, RootTarget {
         gesture_controller.goto (current_commit + (delta / 10));
     }
 
-    public override void propagate (UpdateType update_type, GestureAction action, double progress) {
+    public void propagate (UpdateType update_type, GestureAction action, double progress) {
         switch (update_type) {
             case COMMIT:
                 current_commit = progress;


### PR DESCRIPTION
There're no reasons why it shouldn't be abstract