### PR TITLE
PanelWindow/Gestures: Fix a few warnings

### DIFF
--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -73,7 +73,7 @@ public class Gala.GestureController : Object {
         get { return _progress; }
         set {
             _progress = value;
-            target.propagate (UPDATE, action, value);
+            target?.propagate (UPDATE, action, value);
         }
     }
 

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -60,18 +60,19 @@ public class Gala.PanelWindow : ShellWindow, RootTarget {
         user_gesture_controller = new GestureController (CUSTOM, wm) {
             progress = 1.0
         };
-        add_gesture_controller (user_gesture_controller);
 
         hide_tracker = new HideTracker (wm.get_display (), this);
         hide_tracker.hide.connect (hide);
         hide_tracker.show.connect (show);
 
         workspace_gesture_controller = new GestureController (CUSTOM, wm);
-        add_gesture_controller (workspace_gesture_controller);
 
         workspace_hide_tracker = new WorkspaceHideTracker (window.display, update_overlap);
         workspace_hide_tracker.switching_workspace_progress_updated.connect ((value) => workspace_gesture_controller.progress = value);
         workspace_hide_tracker.window_state_changed_progress_updated.connect (workspace_gesture_controller.goto);
+
+        add_gesture_controller (user_gesture_controller);
+        add_gesture_controller (workspace_gesture_controller);
     }
 
     public void request_visible_in_multitasking_view () {


### PR DESCRIPTION
Fixes a few `self != null` warnings introduced in #2568. These happen because adding a controller will propagate an update and that leads to calculating progress without all fields having been set.

There is still another warning but that is fixed in #2575 