### PR TITLE
PiP: set correct clone size with csd shadows

### DIFF
--- a/plugins/pip/PopupWindow.vala
+++ b/plugins/pip/PopupWindow.vala
@@ -118,7 +118,7 @@ public class Gala.Plugins.PIP.PopupWindow : Clutter.Actor {
 
         window_actor.notify["allocation"].connect (on_allocation_changed);
         container.set_position (container_margin, container_margin);
-        update_clone_clip ();
+        on_allocation_changed ();
 
         unowned var window = window_actor.get_meta_window ();
         window.unmanaged.connect (on_close_click_clicked);


### PR DESCRIPTION
Fixes a bug where if you try to make a PiP from a window with CSD shadows, the clone has incorrect size.