### PR TITLE
Rework workspace clone layouting

### DIFF
--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -149,7 +149,6 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         foreach (unowned var child in workspaces.get_children ()) {
             unowned var workspace_clone = (WorkspaceClone) child;
             workspace_clone.monitor_scale = scale;
-            workspace_clone.update_size (primary_geometry);
         }
     }
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -505,7 +505,7 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
                 did_move = true;
             }
 
-            var workspace = ((WorkspaceClone) destination.get_parent ()).workspace;
+            var workspace = ((WorkspaceClone) destination.get_parent ().get_parent ()).workspace;
             if (workspace != window.get_workspace ()) {
                 window.change_workspace (workspace);
                 did_move = true;

--- a/src/Widgets/MultitaskingView/WindowCloneContainer.vala
+++ b/src/Widgets/MultitaskingView/WindowCloneContainer.vala
@@ -11,10 +11,7 @@ public class Gala.WindowCloneContainer : ActorTarget {
     public signal void window_selected (Meta.Window window);
     public signal void requested_close ();
 
-    public int padding_top { get; set; default = 12; }
-    public int padding_left { get; set; default = 12; }
-    public int padding_right { get; set; default = 12; }
-    public int padding_bottom { get; set; default = 12; }
+    public Mtk.Rectangle area { get; set; }
 
     public WindowManager wm { get; construct; }
     public WindowListModel windows { get; construct; }
@@ -139,13 +136,6 @@ public class Gala.WindowCloneContainer : ActorTarget {
             var seq_b = ((WindowClone) b.clone).window.get_stable_sequence ();
             return (int) (seq_b - seq_a);
         });
-
-        Mtk.Rectangle area = {
-            padding_left,
-            padding_top,
-            (int) width - padding_left - padding_right,
-            (int) height - padding_top - padding_bottom
-        };
 
         foreach (var tilable in calculate_grid_placement (area, windows)) {
             tilable.clone.take_slot (tilable.rect, !view_toggle);

--- a/src/Widgets/MultitaskingView/WorkspaceRow.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceRow.vala
@@ -23,12 +23,13 @@ public class Gala.WorkspaceRow : ActorTarget {
         set_allocation (allocation);
 
         double progress = get_current_progress (SWITCH_WORKSPACE);
+        var monitor_width = display.get_monitor_geometry (display.get_primary_monitor ()).width;
         int index = 0;
         for (var child = get_first_child (); child != null; child = child.get_next_sibling ()) {
             float preferred_width;
             child.get_preferred_width (-1, null, out preferred_width);
 
-            var child_x = (float) Math.round ((progress + index) * (preferred_width + WORKSPACE_GAP));
+            var child_x = (float) Math.round ((progress + index) * (preferred_width + WORKSPACE_GAP) + (monitor_width - preferred_width) / 2);
 
             child.allocate_preferred_size (child_x, 0);
 

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -120,10 +120,7 @@ public class Gala.WindowOverview : ActorTarget, RootTarget, ActivatableComponent
             model.items_changed.connect (on_items_changed);
 
             window_clone_container = new WindowCloneContainer (wm, model, scale, true) {
-                padding_top = TOP_GAP,
-                padding_left = BORDER,
-                padding_right = BORDER,
-                padding_bottom = BOTTOM_GAP,
+                area = { BORDER, TOP_GAP, geometry.width - 2 * BORDER, geometry.height - TOP_GAP - BOTTOM_GAP },
                 width = geometry.width,
                 height = geometry.height,
                 x = geometry.x,


### PR DESCRIPTION
This PR adjusts how and where workspace clones are allocated to be where they are actually drawing to. This will allow the workspace clones to be clipped to their allocation which will make showing static windows easy.

A made a little drawing to show the difference:

<img width="1093" height="748" alt="grafik" src="https://github.com/user-attachments/assets/2d68dfb2-1a01-47c2-a159-dd7de31488bd" />
