### PR TITLE
Gestures: Keep smooth progress even with disabled animations

### DIFF
--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -64,7 +64,6 @@ public class Gala.GestureController : Object {
 
     /**
      * When disabled gesture progress will stay where the gesture ended and not snap to full integers values.
-     * This will also cause the controller to emit smooth progress information even if animations are disabled.
      */
     public bool snap { get; construct set; default = true; }
 
@@ -171,12 +170,6 @@ public class Gala.GestureController : Object {
                 !GestureSettings.is_natural_scroll_enabled (gesture.performed_on_device_type)
             ) {
                 direction_multiplier *= -1;
-            }
-
-            if (snap && !Meta.Prefs.get_gnome_animations ()) {
-                recognizing = false;
-                prepare ();
-                finish (0, progress + direction_multiplier);
             }
 
             recognizing_backend = backend;


### PR DESCRIPTION
Fixes #2620 

Keep smooth progress during the gesture but still skip the finishing animation. This is also how adwaita does it for e.g. navigation view, carousel, etc.