### PR TITLE
HideTracker: Assume hovered when revealing via barrier

### DIFF
--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -222,6 +222,10 @@ public class Gala.HideTracker : Object {
             behavior_settings.get_boolean ("enable-hotcorners-in-fullscreen")
         ) {
             trigger_show ();
+            // This handles the case that the user triggered the barrier but never hovered
+            // the panel e.g. when triggering the barrier at a point where the dock doesnt
+            // reach. In that case once the pointer is moved it'll recheck the hovered state.
+            hovered = true;
         }
     }
 }


### PR DESCRIPTION
From the commit message:
> In the case that the user triggered the barrier at a point where the panel will actually reveal this is true anyways. And in the case that the user triggered the barrier at a point where the panel won't reveal because it's not wide enough it will make sure that we recheck and unreveal it
when the pointer is invalidated.

The cause was that triggering the barrier at a point where  the dock won't appear will never cause a recheck because we only recheck if the hovered state changed and it wouldn't in that case.

Fixes #2630 