### PR TITLE
TouchpadBackend: Fix missing reset once gesture ends

### DIFF
--- a/lib/Gestures/TouchpadBackend.vala
+++ b/lib/Gestures/TouchpadBackend.vala
@@ -56,11 +56,12 @@ private class Gala.TouchpadBackend : Object, GestureBackend {
             return Clutter.EVENT_PROPAGATE;
         }
 
-        if (state == IGNORED) {
-            if (event.get_gesture_phase () == END || event.get_gesture_phase () == CANCEL) {
-                reset ();
-            }
+        if (state != ONGOING && (event.get_gesture_phase () == END || event.get_gesture_phase () == CANCEL)) {
+            reset ();
+            return Clutter.EVENT_PROPAGATE;
+        }
 
+        if (state == IGNORED) {
             return Clutter.EVENT_PROPAGATE;
         }
 


### PR DESCRIPTION
The touchpad backend wouldn't reset when the gesture ends if it didn't handle it.

Fixes #2633 