### PR TITLE
Move windows to shell group when window type changes

### DIFF
--- a/src/WindowListener.vala
+++ b/src/WindowListener.vala
@@ -55,6 +55,7 @@ public class Gala.WindowListener : Object {
 
     public signal void window_workspace_changed (Meta.Window window);
     public signal void window_on_all_workspaces_changed (Meta.Window window);
+    public signal void window_type_changed (Meta.Window window);
 
     private Gee.HashMap<Meta.Window, WindowGeometry?> unmaximized_state_geometry;
 
@@ -80,6 +81,9 @@ public class Gala.WindowListener : Object {
                 break;
             case "on-all-workspaces":
                 window_on_all_workspaces_changed (window);
+                break;
+            case "window-type":
+                window_type_changed (window);
                 break;
         }
     }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -47,7 +47,7 @@ namespace Gala {
          * It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
          * responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).
          */
-        public Clutter.Actor shell_group { get; private set; }
+        private Clutter.Actor shell_group { get; private set; }
 
         private Clutter.Actor menu_group { get; set; }
 
@@ -398,6 +398,13 @@ namespace Gala {
             display.window_created.connect ((window) =>
                 InternalUtils.wait_for_window_actor_visible (window, check_shell_window)
             );
+
+            WindowListener.get_default ().window_type_changed.connect ((window) => {
+                unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
+                if (window_actor != null) {
+                    check_shell_window (window_actor);
+                }
+            });
 
             stage.show ();
 


### PR DESCRIPTION
Sometimes Wingpanel sets dock window type after the window was shown which leads to it being invisible in the multitasking view