### PR TITLE
Packaging: Disable old icon groups

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,9 +3,6 @@
 %:
 	dh $@ --buildsystem=meson
 
-override_dh_auto_configure:
-	dh_auto_configure -- -Dold-icon-groups=true
-
 override_dh_missing:
 	dh_missing --fail-missing
 


### PR DESCRIPTION
The old icon groups are seemingly useless right now: #2668 and also have other bugs: #2669

And since the dock workspace switcher is now IMO good enough to replace the old icon groups, I think it's not worth the effort to fix something that will be removed very soon anyways and better to just enable the workspace switcher in the multitasking view.