### PR TITLE
Gala.Text: Don't extend Clutter.Text

### DIFF
--- a/lib/Text.vala
+++ b/lib/Text.vala
@@ -6,14 +6,34 @@
 /*
  * Clutter.Text that automatically changes font-name to the system one
  */
-public class Gala.Text : Clutter.Text {
+public class Gala.Text : Clutter.Actor {
     private static GLib.Settings gnome_interface_settings;
+
+#if HAS_MUTTER47
+    public Cogl.Color color { get { return text_actor.color; } set { text_actor.color = value; } }
+#else
+    public Clutter.Color color { get { return text_actor.color; } set { text_actor.color = value; } }
+#endif
+    public Pango.EllipsizeMode ellipsize { get { return text_actor.ellipsize; } set { text_actor.ellipsize = value; } }
+    public Pango.Alignment line_alignment {
+        get { return text_actor.line_alignment; } set { text_actor.line_alignment = value; }
+    }
+    public string text { get { return text_actor.text; } set { text_actor.text = value; } }
+
+    private Clutter.Text text_actor;
 
     static construct {
         gnome_interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
     }
 
+    class construct {
+        set_layout_manager_type (typeof (Clutter.BinLayout));
+    }
+
     construct {
+        text_actor = new Clutter.Text ();
+        add_child (text_actor);
+
         set_system_font_name ();
         gnome_interface_settings.changed["font-name"].connect (set_system_font_name);
     }
@@ -28,6 +48,6 @@ public class Gala.Text : Clutter.Text {
             name += "12";
         }
 
-        font_name = string.joinv (" ", name);
+        text_actor.font_name = string.joinv (" ", name);
     }
 }


### PR DESCRIPTION
This seems to mess with... something. At least the picking (or at least something with the event delivery) was wrong.
That was noticeable in the multitasking view where the window clones have tooltips. Sometimes these tooltips (that use gala text) caused the window clones to not receive events most notably enter and leave as well as button press events.

I think this is the same issues that caused the hover widgets to sometimes not appear (see #2641) at least this PR now also fixes the enter/leave events.

Fixes https://github.com/elementary/gala/issues/2676