### PR TITLE
Mutter47+: use hex colors when calling Cogl.Color.from_string ()

### DIFF
--- a/src/Background/Background.vala
+++ b/src/Background/Background.vala
@@ -103,7 +103,7 @@ public class Gala.Background : Object {
 #endif
         if (color == null) {
 #if HAS_MUTTER47
-            color = Cogl.Color.from_string ("black");
+            color = Cogl.Color.from_string ("#000000");
 #else
             color = Clutter.Color.from_string ("black");
 #endif
@@ -122,7 +122,7 @@ public class Gala.Background : Object {
 #endif
             if (second_color == null) {
 #if HAS_MUTTER47
-                second_color = Cogl.Color.from_string ("black");
+                second_color = Cogl.Color.from_string ("#000000");
 #else
                 second_color = Clutter.Color.from_string ("black");
 #endif

--- a/src/Background/BackgroundContainer.vala
+++ b/src/Background/BackgroundContainer.vala
@@ -29,7 +29,7 @@ public class Gala.BackgroundContainer : Meta.BackgroundGroup {
         });
 
 #if HAS_MUTTER47
-        background_color = Cogl.Color.from_string ("Black");
+        background_color = Cogl.Color.from_string ("#000000");
 #else
         background_color = Clutter.Color.from_string ("Black");
 #endif

--- a/src/ScreenshotManager.vala
+++ b/src/ScreenshotManager.vala
@@ -244,7 +244,7 @@ public class Gala.ScreenshotManager : Object {
         flash_actor.set_size (width, height);
         flash_actor.set_position (x, y);
 #if HAS_MUTTER47
-        flash_actor.set_background_color (Cogl.Color.from_string ("white"));
+        flash_actor.set_background_color (Cogl.Color.from_string ("#FFFFFF"));
 #elif HAS_MUTTER46
         flash_actor.set_background_color (Clutter.Color.from_pixel (0xffffffffu));
 #else

--- a/src/Widgets/SessionLocker.vala
+++ b/src/Widgets/SessionLocker.vala
@@ -121,7 +121,7 @@ public class Gala.SessionLocker : Clutter.Actor {
         });
 
 #if HAS_MUTTER47
-        background_color = Cogl.Color.from_string ("black");
+        background_color = Cogl.Color.from_string ("#000000");
 #else
         background_color = Clutter.Color.from_string ("black");
 #endif


### PR DESCRIPTION
[`Cogl.Color.from_string ()`](https://gjs-docs.gnome.org/cogl15~15/cogl.color#function-from_string) in limutter15+ doesn't support defining colors by their name, like [`Clutter.Color.from_string ()`](https://gjs-docs.gnome.org/clutter14~14/clutter.color#function-from_string) did before. This results in a segfault when compiled with mutter47+.

<details><summary>Backtrace without this patch</summary>
<p>

```
Thread 1 "gala" received signal SIGSEGV, Segmentation fault.
gala_background_container_constructor (type=<optimized out>, n_construct_properties=<optimized out>, construct_properties=<optimized out>) at ../src/Background/BackgroundContainer.vala:32
32	        background_color = Cogl.Color.from_string ("Black");
#0  gala_background_container_constructor (type=<optimized out>, n_construct_properties=<optimized out>, construct_properties=<optimized out>) at ../src/Background/BackgroundContainer.vala:32
#1  0x00007ffff7eb0362 in g_object_new_with_custom_constructor (class=class@entry=0x555557640330, params=params@entry=0x7fffffffd690, n_params=n_params@entry=1) at ../gobject/gobject.c:2585
#2  0x00007ffff7eb2603 in g_object_new_internal (class=0x555557640330, params=0x7fffffffd690, n_params=1) at ../gobject/gobject.c:2663
#3  g_object_new_valist (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e7d21 "display", var_args=var_args@entry=0x7fffffffd960) at ../gobject/gobject.c:3003
#4  0x00007ffff7eb2e7f in g_object_new (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e7d21 "display") at ../gobject/gobject.c:2479
#5  0x0000555555583a4e in gala_background_container_construct (object_type=<optimized out>, display=0x5555575fb460) at ../src/Background/BackgroundContainer.vala:15
#6  gala_background_container_new (display=0x5555575fb460) at ../src/Background/BackgroundContainer.vala:14
#7  gala_window_manager_gala_show_stage (self=0x555557610aa0) at ../src/WindowManager.vala:258
#8  gala_window_manager_gala_real_start (base=0x555557610aa0) at ../src/WindowManager.vala:139
#9  0x00007ffff6a96a02 in meta_plugin_manager_start (plugin_mgr=0x555557620810) at ../src/compositor/meta-plugin-manager.c:165
#10 meta_compositor_manage (compositor=<optimized out>, plugin_options=0x0, error=<optimized out>) at ../src/compositor/compositor.c:311
#11 meta_display_new (context=<optimized out>, plugin_options=0x0, error=<optimized out>) at ../src/core/display.c:1066
#12 0x00007ffff6aa7ac9 in meta_context_start (context=<optimized out>, error=error@entry=0x7fffffffdd48) at /usr/include/glib-2.0/glib/gmem.h:245
#13 0x0000555555572381 in gala_main (args=<optimized out>, args_length1=<optimized out>) at ../src/Main.vala:78
#14 0x00007ffff629f5b5 in __libc_start_call_main (main=main@entry=0x55555555c220 <main>, argc=argc@entry=2, argv=argv@entry=0x7fffffffe1a8) at ../sysdeps/nptl/libc_start_call_main.h:58
#15 0x00007ffff629f668 in __libc_start_main_impl (main=0x55555555c220 <main>, argc=2, argv=0x7fffffffe1a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe198) at ../csu/libc-start.c:360
#16 0x000055555555c265 in _start ()
```

</p>
</details> 