### PR TITLE
ShellClients: Don't declare centered windows as shell windows

### DIFF
--- a/src/Dialogs/InhibitShortcutsDialog.vala
+++ b/src/Dialogs/InhibitShortcutsDialog.vala
@@ -36,7 +36,7 @@ public class Gala.InhibitShortcutsDialog : AccessDialog, Meta.InhibitShortcutsDi
         }
 
         if (app.id == "io.elementary.settings.desktop" || // Naive check to always allow inhibiting by our settings app. This is needed for setting custom shortcuts
-            ShellClientsManager.get_instance ().is_positioned_window (window) // Certain windows (e.g. centered ones) may want to disable move via super + drag
+            ShellClientsManager.get_instance ().is_shell_window (window) // Certain windows (e.g. centered ones) may want to disable move via super + drag
         ) {
             on_response (0);
             return;

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -233,7 +233,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         panel_windows[window].request_visible_in_multitasking_view ();
     }
 
-    public void make_centered (Meta.Window window) requires (!is_itself_positioned (window)) {
+    public void make_centered (Meta.Window window) requires (!is_itself_shell_window (window)) {
         positioned_windows[window] = new ExtendedBehaviorWindow (window);
 
         // connect_after so we make sure that any queued move is unqueued
@@ -254,7 +254,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         }
     }
 
-    public bool is_itself_positioned (Meta.Window window) {
+    public bool is_itself_shell_window (Meta.Window window) {
         return (
             (window in positioned_windows && positioned_windows[window].modal) ||
             (window in panel_windows) ||
@@ -262,10 +262,18 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         );
     }
 
-    public bool is_positioned_window (Meta.Window window) {
-        bool positioned = is_itself_positioned (window);
+    /**
+     * Whether the given window is a shell window. A shell window is a window that's
+     * part of the desktop shell itself and should be completely ignored by other components.
+     * It is entirely managed by Gala, always above everything else, and manages hiding
+     * in e.g. multitasking view itself. This also applies to transient windows of shell windows.
+     * Note that even if `false` is returned the window might still be in part managed by gala
+     * e.g. for centered windows.
+     */
+    public bool is_shell_window (Meta.Window window) {
+        bool positioned = is_itself_shell_window (window);
         window.foreach_ancestor ((ancestor) => {
-            if (is_itself_positioned (ancestor)) {
+            if (is_itself_shell_window (ancestor)) {
                 positioned = true;
             }
 

--- a/src/ShellClients/ShellWindow.vala
+++ b/src/ShellClients/ShellWindow.vala
@@ -85,7 +85,7 @@ public abstract class Gala.ShellWindow : PositionedWindow, GestureTarget {
 
         unowned var manager = ShellClientsManager.get_instance ();
         window.foreach_transient ((transient) => {
-            if (manager.is_itself_positioned (transient)) {
+            if (manager.is_itself_shell_window (transient)) {
                 return true;
             }
 

--- a/src/Widgets/MultitaskingView/StaticWindowContainer.vala
+++ b/src/Widgets/MultitaskingView/StaticWindowContainer.vala
@@ -71,7 +71,7 @@ public class Gala.StaticWindowContainer : ActorTarget {
     }
 
     private void check_window_changed (Meta.Window window) {
-        var is_static = is_static (window) && !ShellClientsManager.get_instance ().is_positioned_window (window);
+        var is_static = is_static (window) && !ShellClientsManager.get_instance ().is_shell_window (window);
 
         Clutter.Actor? clone = null;
         for (var child = get_first_child (); child != null; child = child.get_next_sibling ()) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -43,7 +43,7 @@ namespace Gala {
 
         /**
          * The group that contains all WindowActors that make shell elements, that is all windows reported as
-         * ShellClientsManager.is_positioned_window.
+         * ShellClientsManager.is_shell_window.
          * It will (eventually) never be hidden by other components and is always on top of everything. Therefore elements are
          * responsible themselves for hiding depending on the state we are currently in (e.g. normal desktop, open multitasking view, fullscreen, etc.).
          */
@@ -714,7 +714,7 @@ namespace Gala {
             unowned var display = get_display ();
 
             if (!is_modal () || modal_stack.peek_head ().grab != null || display.focus_window == null ||
-                ShellClientsManager.get_instance ().is_positioned_window (display.focus_window)
+                ShellClientsManager.get_instance ().is_shell_window (display.focus_window)
             ) {
                 return;
             }
@@ -1032,7 +1032,7 @@ namespace Gala {
                 return;
             }
 
-            if (ShellClientsManager.get_instance ().is_positioned_window (window)) {
+            if (ShellClientsManager.get_instance ().is_shell_window (window)) {
                 InternalUtils.clutter_actor_reparent (actor, shell_group);
             }
 


### PR DESCRIPTION
While I still strongly disagree that non modal windows can be fixed at the center of the screen this fixes elementary/onboarding#272. See also elementary/installer#917 the same fix as here will probably work in the greeter compositor as well.

Note that this will cause all centered windows that do not call make_modal to be treated like normal windows. I.e. no special hiding when going to multitasking view (although since they are on all workspaces they will have the same animation as static windows which currently is no animation at all but I'd like to fix that somewhat soon).