### PR TITLE
BackgroundBlurEffect: fix for libmutter15+

### DIFF
--- a/src/BackgroundBlurEffect.vala
+++ b/src/BackgroundBlurEffect.vala
@@ -39,11 +39,7 @@ public class Gala.BackgroundBlurEffect : Clutter.Effect {
     }
 
     construct {
-#if HAS_MUTTER47
-        unowned var ctx = actor.context.get_backend ().get_cogl_context ();
-#else
         unowned var ctx = Clutter.get_default_backend ().get_cogl_context ();
-#endif
 
         actor_pipeline = new Cogl.Pipeline (ctx);
         actor_pipeline.set_layer_null_texture (0);


### PR DESCRIPTION
While mutter and gnome-shell devs are phasing out `Clutter.get_default_backend ()`, [it's still there](https://mutter.gnome.org/clutter/func.get_default_backend.html). Getting context through the actor isn't working because there isn't any assigned actor, so the whole thing just crashes.  Gnome-shell [exposes global stage and gets context from there](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/b3f5f9601b1584a3b9b3360d21239762e42bc941#f20947633d2bdbae926d8768c3bfb38fd7c12482), but this solution would require to re-engineer `WindowManagerGala` to be a singleton. Another solution is to pass context directly to the effect. Both options are out of scope for me because I'm not very familiar with the codebase.

<details><summary>Backtrace without this patch</summary>
<p>

```
Thread 1 "gala" received signal SIGSEGV, Segmentation fault.
clutter_actor_get_context (actor=0x0) at ../clutter/clutter/clutter-actor.c:12720
12720	  return actor->priv->context;
Missing rpms, try: dnf --enablerepo='*debug*' install wingpanel-debuginfo-8.0.4-1.fc43.x86_64
#0  clutter_actor_get_context (actor=0x0) at ../clutter/clutter/clutter-actor.c:12720
#1  0x000055555555ddde in gala_background_blur_effect_constructor (type=<optimized out>, n_construct_properties=<optimized out>, construct_properties=<optimized out>) at ../src/BackgroundBlurEffect.vala:43
#2  0x00007ffff7eb2362 in g_object_new_with_custom_constructor (class=class@entry=0x5555576a05d0, params=params@entry=0x7fffffffd0c0, n_params=n_params@entry=3) at ../gobject/gobject.c:2585
#3  0x00007ffff7eb4603 in g_object_new_internal (class=0x5555576a05d0, params=0x7fffffffd0c0, n_params=3) at ../gobject/gobject.c:2663
#4  g_object_new_valist (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e5b9f "blur-radius", var_args=var_args@entry=0x7fffffffd390) at ../gobject/gobject.c:3003
#5  0x00007ffff7eb4e7f in g_object_new (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e5b9f "blur-radius") at ../gobject/gobject.c:2479
#6  0x00005555555c7209 in gala_background_blur_effect_construct (object_type=<optimized out>, blur_radius=40, clip_radius=9, monitor_scale=1) at ../src/BackgroundBlurEffect.vala:38
#7  gala_background_blur_effect_new (blur_radius=40, clip_radius=9, monitor_scale=1) at ../src/BackgroundBlurEffect.vala:37
#8  gala_window_switcher_constructor (type=<optimized out>, n_construct_properties=<optimized out>, construct_properties=<optimized out>) at ../src/Widgets/WindowSwitcher/WindowSwitcher.vala:107
#9  0x00007ffff7eb2362 in g_object_new_with_custom_constructor (class=class@entry=0x5555576afaf0, params=params@entry=0x7fffffffd730, n_params=n_params@entry=1) at ../gobject/gobject.c:2585
#10 0x00007ffff7eb4603 in g_object_new_internal (class=0x5555576afaf0, params=0x7fffffffd730, n_params=1) at ../gobject/gobject.c:2663
#11 g_object_new_valist (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e5f71 "wm", var_args=var_args@entry=0x7fffffffda00) at ../gobject/gobject.c:3003
#12 0x00007ffff7eb4e7f in g_object_new (object_type=<optimized out>, first_property_name=first_property_name@entry=0x5555555e5f71 "wm") at ../gobject/gobject.c:2479
#13 0x0000555555584ae0 in gala_window_switcher_construct (object_type=<optimized out>, wm=0x5555576124a0) at ../src/Widgets/WindowSwitcher/WindowSwitcher.vala:54
#14 gala_window_switcher_new (wm=0x5555576124a0) at ../src/Widgets/WindowSwitcher/WindowSwitcher.vala:53
#15 gala_window_manager_gala_show_stage (self=0x5555576124a0) at ../src/WindowManager.vala:280
#16 gala_window_manager_gala_real_start (base=0x5555576124a0) at ../src/WindowManager.vala:139
#17 0x00007ffff6aa2cd3 in meta_plugin_manager_start (plugin_mgr=0x55555761d830) at ../src/compositor/meta-plugin-manager.c:165
#18 meta_compositor_manage (compositor=<optimized out>, plugin_options=0x0, error=<optimized out>) at ../src/compositor/compositor.c:311
#19 meta_display_new (context=<optimized out>, plugin_options=0x0, error=<optimized out>) at ../src/core/display.c:1067
#20 0x00007ffff6aaa1dc in meta_context_start (context=<optimized out>, error=error@entry=0x7fffffffdde8) at /usr/include/glib-2.0/glib/gmem.h:245
#21 0x0000555555571d41 in gala_main (args=<optimized out>, args_length1=<optimized out>) at ../src/Main.vala:78
#22 0x00007ffff63f15b5 in __libc_start_call_main (main=main@entry=0x55555555c260 <main>, argc=argc@entry=2, argv=argv@entry=0x7fffffffe248) at ../sysdeps/nptl/libc_start_call_main.h:58
#23 0x00007ffff63f1668 in __libc_start_main_impl (main=0x55555555c260 <main>, argc=2, argv=0x7fffffffe248, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe238) at ../csu/libc-start.c:360
#24 0x000055555555c2a5 in _start ()

``` 

</p>
</details> 