### PR TITLE
control: Replace transitional package name

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,7 +59,7 @@ Package: libgala-dev
 Architecture: any
 Section: libdevel
 Depends: libgala0 (= ${binary:Version}),
-         libgdk-pixbuf2.0-dev,
+         libgdk-pixbuf-2.0-dev,
          libglib2.0-dev (>= 2.44),
          libmutter-17-dev | libmutter-16-dev | libmutter-15-dev | libmutter-14-dev | libmutter-13-dev,
          ${misc:Depends}


### PR DESCRIPTION
`libgdk-pixbuf2.0-dev` is a transitional package that will be removed in Resolute:

https://packages.ubuntu.com/search?lang=en&keywords=libgdk-pixbuf2.0-dev&searchon=names

We can safely replace `libgdk-pixbuf2.0-dev` to `libgdk-pixbuf-2.0-dev` because the later package name is available on Noble too:

https://packages.ubuntu.com/search?lang=en&keywords=libgdk-pixbuf-2.0-dev&searchon=names
