### PR TITLE
Introduce and use GestureTrigger

### DIFF
--- a/lib/Gestures/GestureTrigger.vala
+++ b/lib/Gestures/GestureTrigger.vala
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+/**
+ * Decides whether a gesture should be recognized. It also automatically enables
+ * the necessary backends for the type of gesture.
+ */
+public interface Gala.GestureTrigger : Object {
+    internal abstract bool triggers (Gesture gesture);
+    internal abstract void enable_backends (GestureController controller);
+}

--- a/lib/Gestures/GlobalTrigger.vala
+++ b/lib/Gestures/GlobalTrigger.vala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+/**
+ * A trigger that triggers when a globally configured gesture has been recognized.
+ * These are the typical three or four finger multi touch gestures configurable in the settings.
+ * It enables touchpad and touchscreen backends for the whole stage.
+ */
+public class Gala.GlobalTrigger : Object, GestureTrigger {
+    public GestureAction action { get; construct; }
+    public WindowManager wm { get; construct; }
+
+    private Variant? _action_info;
+    public Variant? action_info { get { return _action_info; } }
+
+    public GlobalTrigger (GestureAction action, WindowManager wm) {
+        Object (action: action, wm: wm);
+    }
+
+    internal bool triggers (Gesture gesture) {
+        var action = GestureSettings.get_action (gesture, out _action_info);
+        return !wm.filter_action (action.to_modal_action ()) && this.action == action;
+    }
+
+    internal void enable_backends (GestureController controller) {
+        var group = action == MULTITASKING_VIEW || action == SWITCH_WORKSPACE ? TouchpadBackend.Group.MULTITASKING_VIEW : TouchpadBackend.Group.NONE;
+        controller.enable_backend (ToucheggBackend.get_default ());
+        controller.enable_backend (new TouchpadBackend (wm.stage, group));
+    }
+}

--- a/lib/Gestures/SwipeTrigger.vala
+++ b/lib/Gestures/SwipeTrigger.vala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+/**
+ * A trigger that triggers when a swipe gesture (2 fingers on touchpad, 1 finger on touchscreen)
+ * has been recognized on the given actor with the given orientation.
+ * It enables touchpad and (once supported) touchscreen backends for the given actor.
+ */
+public class Gala.SwipeTrigger : Object, GestureTrigger {
+    public Clutter.Actor actor { get; construct; }
+    public Clutter.Orientation orientation { get; construct; }
+
+    public SwipeTrigger (Clutter.Actor actor, Clutter.Orientation orientation) {
+        Object (actor: actor, orientation: orientation);
+    }
+
+    internal bool triggers (Gesture gesture) {
+        return (
+            gesture.fingers == 1 && gesture.performed_on_device_type == TOUCHSCREEN_DEVICE ||
+            gesture.fingers == 2 && gesture.performed_on_device_type == TOUCHPAD_DEVICE
+        );
+    }
+
+    internal void enable_backends (GestureController controller) {
+        controller.enable_backend (new ScrollBackend (actor, orientation, new GestureSettings ()));
+    }
+}

--- a/lib/Gestures/TouchpadBackend.vala
+++ b/lib/Gestures/TouchpadBackend.vala
@@ -6,6 +6,11 @@
  */
 
 private class Gala.TouchpadBackend : Object, GestureBackend {
+    public enum Group {
+        NONE,
+        MULTITASKING_VIEW,
+    }
+
     private const int TOUCHPAD_BASE_HEIGHT = 300;
     private const int TOUCHPAD_BASE_WIDTH = 400;
     private const int DRAG_THRESHOLD_DISTANCE = 16;
@@ -19,7 +24,7 @@ private class Gala.TouchpadBackend : Object, GestureBackend {
     }
 
     public Clutter.Actor actor { get; construct; }
-    public GestureController.Group group { get; construct; }
+    public Group group { get; construct; }
 
     private static List<TouchpadBackend> instances = new List<TouchpadBackend> ();
 
@@ -29,7 +34,7 @@ private class Gala.TouchpadBackend : Object, GestureBackend {
     private double distance_y = 0;
     private double distance = 0;
 
-    public TouchpadBackend (Clutter.Actor actor, GestureController.Group group) {
+    public TouchpadBackend (Clutter.Actor actor, Group group) {
         Object (actor: actor, group: group);
     }
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -32,10 +32,13 @@ gala_lib_sources = files(
     'Gestures/GestureController.vala',
     'Gestures/GestureSettings.vala',
     'Gestures/GestureTarget.vala',
+    'Gestures/GestureTrigger.vala',
+    'Gestures/GlobalTrigger.vala',
     'Gestures/PropertyTarget.vala',
     'Gestures/RootTarget.vala',
     'Gestures/ScrollBackend.vala',
     'Gestures/SpringTimeline.vala',
+    'Gestures/SwipeTrigger.vala',
     'Gestures/ToucheggBackend.vala',
     'Gestures/TouchpadBackend.vala',
     'Gestures/WorkspaceHideTracker.vala'

--- a/src/ShellClients/PanelWindow.vala
+++ b/src/ShellClients/PanelWindow.vala
@@ -61,7 +61,7 @@ public class Gala.PanelWindow : ShellWindow, RootTarget {
         notify["width"].connect (update_strut);
         notify["height"].connect (update_strut);
 
-        user_gesture_controller = new GestureController (CUSTOM, wm) {
+        user_gesture_controller = new GestureController (CUSTOM) {
             progress = 1.0
         };
 
@@ -69,7 +69,7 @@ public class Gala.PanelWindow : ShellWindow, RootTarget {
         hide_tracker.hide.connect (hide);
         hide_tracker.show.connect (show);
 
-        workspace_gesture_controller = new GestureController (CUSTOM, wm) {
+        workspace_gesture_controller = new GestureController (CUSTOM) {
             progress = 1.0
         };
 

--- a/src/Widgets/MultitaskingView/WindowClone.vala
+++ b/src/Widgets/MultitaskingView/WindowClone.vala
@@ -99,8 +99,8 @@ public class Gala.WindowClone : ActorTarget, RootTarget {
     construct {
         reactive = true;
 
-        gesture_controller = new GestureController (CUSTOM, wm);
-        gesture_controller.enable_scroll (this, VERTICAL);
+        gesture_controller = new GestureController (CUSTOM);
+        gesture_controller.add_trigger (new SwipeTrigger (this, VERTICAL));
         add_gesture_controller (gesture_controller);
 
         window.unmanaged.connect (unmanaged);

--- a/src/Widgets/WindowOverview.vala
+++ b/src/Widgets/WindowOverview.vala
@@ -29,7 +29,7 @@ public class Gala.WindowOverview : ActorTarget, RootTarget, ActivatableComponent
     construct {
         visible = false;
         reactive = true;
-        gesture_controller = new GestureController (MULTITASKING_VIEW, wm) {
+        gesture_controller = new GestureController (MULTITASKING_VIEW) {
             enabled = false
         };
         add_gesture_controller (gesture_controller);

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -56,12 +56,12 @@ public class Gala.WindowSwitcher : CanvasActor, GestureTarget, RootTarget {
     construct {
         style_manager = Drawing.StyleManager.get_instance ();
 
-        gesture_controller = new GestureController (SWITCH_WINDOWS, wm) {
+        gesture_controller = new GestureController (SWITCH_WINDOWS) {
             overshoot_upper_clamp = int.MAX,
             overshoot_lower_clamp = int.MIN,
             snap = false
         };
-        gesture_controller.enable_touchpad (wm.stage);
+        gesture_controller.add_trigger (new GlobalTrigger (SWITCH_WINDOWS, wm));
         gesture_controller.notify["recognizing"].connect (recognizing_changed);
         add_gesture_controller (gesture_controller);
 

--- a/src/Zoom.vala
+++ b/src/Zoom.vala
@@ -33,10 +33,10 @@ public class Gala.Zoom : Object, GestureTarget, RootTarget {
         display.add_keybinding ("zoom-in", schema, NONE, zoom_in);
         display.add_keybinding ("zoom-out", schema, NONE, zoom_out);
 
-        gesture_controller = new GestureController (ZOOM, wm) {
+        gesture_controller = new GestureController (ZOOM) {
             snap = false
         };
-        gesture_controller.enable_touchpad (wm.stage);
+        gesture_controller.add_trigger (new GlobalTrigger (ZOOM, wm));
         add_gesture_controller (gesture_controller);
 
         behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");


### PR DESCRIPTION
GestureTrigger provides a configurable way to specify what should trigger a gesture. It also automatically enables the correct backends needed to recognize the handled gestures. Currently two triggers are provided. SwipeTrigger recognizing swipes on a provided actor and GlobalTrigger recognizing global touch gestures.

This makes it easier for users of gesturecontroller by being declarative instead of imperative. They can now simply specify what gesture should be recognized and not how it is recognized.
It also moves very global gesture specific stuff from the gesturecontroller to the globaltrigger.
It also allows more flexibility which allows us to remove a workaround where we always allow gestures from the scroll backend and will provide more freedom in the future (e.g. allowing gestures to only start within a certain area e.g. for dock swipe up).