### PR TITLE
SwipeTrigger: trigger only on scroll events on touchpad

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -27,6 +27,18 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.4.2" date="2026-02-116" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+          <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/gala/issues/2767">Pinch gestures are switching between workspaces instead of zooming</issue>
+      </issues>
+    </release>
+
     <release version="8.4.1" date="2026-02-10" urgency="medium">
       <description>
         <p>Improvements:</p>

--- a/lib/Gestures/SwipeTrigger.vala
+++ b/lib/Gestures/SwipeTrigger.vala
@@ -20,8 +20,8 @@ public class Gala.SwipeTrigger : Object, GestureTrigger {
 
     internal bool triggers (Gesture gesture) {
         return (
-            gesture.fingers == 1 && gesture.performed_on_device_type == TOUCHSCREEN_DEVICE ||
-            gesture.fingers == 2 && gesture.performed_on_device_type == TOUCHPAD_DEVICE
+            gesture.fingers == 1 && gesture.performed_on_device_type == TOUCHSCREEN_DEVICE && gesture.type == TOUCHPAD_SWIPE ||
+            gesture.fingers == 2 && gesture.performed_on_device_type == TOUCHPAD_DEVICE && gesture.type == SCROLL
         );
     }
 


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2767

ToucheggBackend sends pinch events and SwipeTrigger doesn't filter them.