### PR TITLE
Move WorkspaceClone management to WorkspaceRow

### DIFF
--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -151,12 +151,6 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
 
         primary_monitor_container.set_position (primary_geometry.x, primary_geometry.y);
         primary_monitor_container.set_size (primary_geometry.width, primary_geometry.height);
-
-        foreach (unowned var child in workspaces.get_children ()) {
-            unowned var workspace_clone = (WorkspaceClone) child;
-            workspace_clone.monitor_scale = scale;
-            workspace_clone.update_size (primary_geometry);
-        }
     }
 
     private void update_brightness_effect () {
@@ -326,9 +320,8 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
 
     private void add_workspace (int num) {
         unowned var manager = display.get_workspace_manager ();
-        var scale = Utils.get_ui_scaling_factor (display, display.get_primary_monitor ());
 
-        var workspace = new WorkspaceClone (wm, manager.get_workspace_by_index (num), scale);
+        var workspace = new WorkspaceClone (wm, manager.get_workspace_by_index (num));
         workspaces.insert_child_at_index (workspace, num);
 
         workspace.window_selected.connect (window_selected);

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -68,7 +68,7 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
 
         add_target (ShellClientsManager.get_instance ()); // For hiding the panels
 
-        workspaces = new WorkspaceRow (display);
+        workspaces = new WorkspaceRow (wm);
 
         workspaces_trigger = new GlobalTrigger (SWITCH_WORKSPACE, wm);
 
@@ -92,9 +92,8 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         add_child (StaticWindowContainer.get_instance (display));
 
         unowned var manager = display.get_workspace_manager ();
-        manager.workspace_added.connect (add_workspace);
-        manager.workspace_removed.connect (remove_workspace);
-        manager.workspaces_reordered.connect (on_workspaces_reordered);
+        manager.workspace_removed.connect (sync_active_workspace);
+        manager.workspaces_reordered.connect (sync_active_workspace);
         manager.workspace_switched.connect (on_workspace_switched);
 
         workspaces_gesture_controller.overshoot_lower_clamp = -manager.n_workspaces - 0.1 + 1;
@@ -122,7 +121,6 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
      */
     private void update_monitors () {
         update_blurred_bg ();
-        update_workspaces ();
 
         foreach (var monitor_clone in window_containers_monitors) {
             monitor_clone.destroy ();
@@ -147,8 +145,6 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         }
 
         var primary_geometry = display.get_monitor_geometry (primary);
-        var scale = Utils.get_ui_scaling_factor (display, primary);
-
         primary_monitor_container.set_position (primary_geometry.x, primary_geometry.y);
         primary_monitor_container.set_size (primary_geometry.width, primary_geometry.height);
     }
@@ -174,18 +170,6 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         blurred_bg.add_effect (brightness_effect);
 
         insert_child_below (blurred_bg, null);
-    }
-
-    private void update_workspaces () {
-        foreach (unowned var child in workspaces.get_children ()) {
-            unowned var workspace_clone = (WorkspaceClone) child;
-            workspace_clone.destroy ();
-        }
-
-        unowned var manager = display.get_workspace_manager ();
-        for (int i = 0; i < manager.get_n_workspaces (); i++) {
-            add_workspace (i);
-        }
     }
 
     /**
@@ -318,44 +302,7 @@ public class Gala.MultitaskingView : ActorTarget, RootTarget, ActivatableCompone
         }
     }
 
-    private void add_workspace (int num) {
-        unowned var manager = display.get_workspace_manager ();
-
-        var workspace = new WorkspaceClone (wm, manager.get_workspace_by_index (num));
-        workspaces.insert_child_at_index (workspace, num);
-
-        workspace.window_selected.connect (window_selected);
-    }
-
-    private void remove_workspace (int num) {
-        WorkspaceClone? workspace = null;
-
-        // FIXME is there a better way to get the removed workspace?
-        unowned Meta.WorkspaceManager manager = display.get_workspace_manager ();
-        List<Meta.Workspace> existing_workspaces = null;
-        for (int i = 0; i < manager.get_n_workspaces (); i++) {
-            existing_workspaces.append (manager.get_workspace_by_index (i));
-        }
-
-        foreach (unowned var child in workspaces.get_children ()) {
-            unowned var clone = (WorkspaceClone) child;
-            if (existing_workspaces.index (clone.workspace) < 0) {
-                workspace = clone;
-                break;
-            }
-        }
-
-        if (workspace == null) {
-            return;
-        }
-
-        workspace.window_selected.disconnect (window_selected);
-        workspace.destroy ();
-
-        workspaces_gesture_controller.progress = -manager.get_active_workspace_index ();
-    }
-
-    private void on_workspaces_reordered () {
+    private void sync_active_workspace () {
         unowned var manager = display.get_workspace_manager ();
         workspaces_gesture_controller.progress = -manager.get_active_workspace_index ();
     }

--- a/src/Widgets/MultitaskingView/WorkspaceClone.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceClone.vala
@@ -124,12 +124,13 @@ public class Gala.WorkspaceClone : ActorTarget {
     private WindowListModel windows;
     private uint hover_activate_timeout = 0;
 
-    public WorkspaceClone (WindowManager wm, Meta.Workspace workspace, float monitor_scale) {
-        Object (wm: wm, workspace: workspace, monitor_scale: monitor_scale);
+    public WorkspaceClone (WindowManager wm, Meta.Workspace workspace) {
+        Object (wm: wm, workspace: workspace);
     }
 
     construct {
         unowned var display = workspace.get_display ();
+        monitor_scale = Utils.get_ui_scaling_factor (display, display.get_primary_monitor ());
         var monitor_geometry = display.get_monitor_geometry (display.get_primary_monitor ());
 
 #if HAS_MUTTER49
@@ -186,13 +187,6 @@ public class Gala.WorkspaceClone : ActorTarget {
         window_container.destroy ();
     }
 
-    public void update_size (Mtk.Rectangle monitor_geometry) {
-        if (window_container.width != monitor_geometry.width || window_container.height != monitor_geometry.height) {
-            window_container.set_size (monitor_geometry.width, monitor_geometry.height);
-            background.set_size (window_container.width, window_container.height);
-        }
-    }
-
     private void update_targets () {
         remove_all_targets ();
 
@@ -202,6 +196,11 @@ public class Gala.WorkspaceClone : ActorTarget {
         windows.monitor_filter = primary;
 
         var monitor = display.get_monitor_geometry (primary);
+
+        window_container.set_size (monitor.width, monitor.height);
+        background.set_size (monitor.width, monitor.height);
+
+        monitor_scale = Utils.get_ui_scaling_factor (display, primary);
 
         var scale = (float)(monitor.height - Utils.scale_to_int (TOP_OFFSET + BOTTOM_OFFSET, monitor_scale)) / monitor.height;
         var pivot_y = Utils.scale_to_int (TOP_OFFSET, monitor_scale) / (monitor.height - monitor.height * scale);

--- a/src/Widgets/MultitaskingView/WorkspaceClone.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceClone.vala
@@ -108,12 +108,6 @@ public class Gala.WorkspaceClone : ActorTarget {
      */
     private const int HOVER_ACTIVATE_DELAY = 400;
 
-    /**
-     * A window has been selected, the MultitaskingView should consider activating
-     * and closing the view.
-     */
-    public signal void window_selected (Meta.Window window);
-
     public WindowManager wm { get; construct; }
     public Meta.Workspace workspace { get; construct; }
     public float monitor_scale { get; construct set; }
@@ -149,7 +143,7 @@ public class Gala.WorkspaceClone : ActorTarget {
             width = monitor_geometry.width,
             height = monitor_geometry.height,
         };
-        window_container.window_selected.connect ((window) => window_selected (window));
+        window_container.window_selected.connect (on_window_selected);
         window_container.requested_close.connect (() => activate (true));
         bind_property ("monitor-scale", window_container, "monitor-scale");
 
@@ -223,6 +217,16 @@ public class Gala.WorkspaceClone : ActorTarget {
             wm.perform_action (SHOW_MULTITASKING_VIEW);
         } else {
             workspace.activate (Meta.CURRENT_TIME);
+        }
+    }
+
+    private void on_window_selected (Meta.Window window) {
+        if (workspace.active) {
+            /* First activate then close to make sure the stacking is correct while animating closed */
+            window.activate (wm.get_display ().get_current_time ());
+            wm.perform_action (SHOW_MULTITASKING_VIEW);
+        } else {
+            window.activate (wm.get_display ().get_current_time ());
         }
     }
 }

--- a/src/Widgets/MultitaskingView/WorkspaceRow.vala
+++ b/src/Widgets/MultitaskingView/WorkspaceRow.vala
@@ -8,15 +8,21 @@
 public class Gala.WorkspaceRow : ActorTarget {
     public const int WORKSPACE_GAP = 24;
 
-    public Meta.Display display { get; construct; }
+    public WindowManager wm { get; construct; }
 
-    public WorkspaceRow (Meta.Display display) {
-        Object (display: display);
+    public WorkspaceRow (WindowManager wm) {
+        Object (wm: wm);
     }
 
     construct {
-        unowned var manager = display.get_workspace_manager ();
+        unowned var manager = wm.get_display ().get_workspace_manager ();
+        manager.workspace_added.connect (add_workspace);
+        manager.workspace_removed.connect (remove_workspace);
         manager.workspaces_reordered.connect (update_order);
+
+        for (int i = 0; i < manager.n_workspaces; i++) {
+            add_workspace (i);
+        }
     }
 
     public override void allocate (Clutter.ActorBox allocation) {
@@ -40,6 +46,15 @@ public class Gala.WorkspaceRow : ActorTarget {
         if (action == SWITCH_WORKSPACE) {
             queue_relayout ();
         }
+    }
+
+    private void add_workspace (int index) {
+        var workspace = wm.get_display ().get_workspace_manager ().get_workspace_by_index (index);
+        insert_child_at_index (new WorkspaceClone (wm, workspace), index);
+    }
+
+    private void remove_workspace (int index) {
+        remove_child (get_child_at_index (index));
     }
 
     private void update_order () {


### PR DESCRIPTION
First handle size and monitor scale internally in the workspaceclone since we handle some monitor geometry here already anyways.

Then move the creation and deletion of workspace clones from the multitaskingview to the workspacerow. This allows for a bunch of cleanup.