### PR TITLE
 MultitaskingView: Fix occassions where the active workspace could be wrong

### DIFF
--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -319,6 +319,18 @@ public class Gala.GestureController : Object {
         finish ((to > progress ? 1 : -1) * 1, to);
     }
 
+    public void jump (double to) {
+        if (running && !recognizing) {
+            /* We are animating to a snap point so stop the animation */
+            finished ();
+        }
+
+        var clamped_to = to.clamp ((int) overshoot_lower_clamp, (int) overshoot_upper_clamp);
+
+        target?.propagate (COMMIT, action, clamped_to);
+        progress = clamped_to;
+    }
+
     public void cancel_gesture () {
         if (recognizing) {
             recognizing_backend.cancel_gesture ();

--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -287,9 +287,9 @@ public class Gala.GestureController : Object {
 
     private void finished () {
         assert (running);
-        target.propagate (END, action, progress);
         running = false;
         remove_timeline ();
+        target.propagate (END, action, progress);
     }
 
     private void remove_timeline () {

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -92,6 +92,7 @@ public class Gala.MultitaskingView : Root, RootTarget, ActivatableComponent {
         add_child (StaticWindowContainer.get_instance (display));
 
         unowned var manager = display.get_workspace_manager ();
+        manager.workspace_added.connect (sync_active_workspace);
         manager.workspace_removed.connect (sync_active_workspace);
         manager.workspaces_reordered.connect (sync_active_workspace);
         manager.workspace_switched.connect (on_workspace_switched);
@@ -302,8 +303,12 @@ public class Gala.MultitaskingView : Root, RootTarget, ActivatableComponent {
     }
 
     private void sync_active_workspace () {
-        unowned var manager = display.get_workspace_manager ();
-        workspaces_gesture_controller.progress = -manager.get_active_workspace_index ();
+        if (workspaces_gesture_controller.recognizing) {
+            return;
+        }
+
+        var target = -display.get_workspace_manager ().get_active_workspace_index ();
+        workspaces_gesture_controller.jump (target);
     }
 
     private void on_workspace_switched (int from, int to) {


### PR DESCRIPTION
Fixes #2701 

I've introduced a jump method for the gesturecontroller here which also makes sure we send a commit and reset any running timeline whereas setting the progress wouldn't do that. I eventually want to make progress private set and move to this new method because having wrong commits is not really great but I'd leave that to a future PR.

I've also fixed goto comparing progress == to which could be the case - even if we won't stay at that `to` - when a goto was called before but the timeline hasn't started yet. This would cause an early return even though the second goto should overwrite the first.