### PR TITLE
GestureController.goto (): fix progress check

### DIFF
--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -291,7 +291,8 @@ public class Gala.GestureController : Object {
      */
     public void goto (double to) {
         var clamped_to = to.clamp ((int) overshoot_lower_clamp, (int) overshoot_upper_clamp);
-        if (progress == to || recognizing ||
+        if (progress == to && (timeline == null || timeline.value_to == to) ||
+            recognizing ||
             timeline != null && clamped_to == timeline.value_to // Only allow overshoot if there's no ongoing overshoot animation to prevent stacking
         ) {
             return;


### PR DESCRIPTION
Fixes https://github.com/elementary/gala/issues/2724 for me

I think what's happening here is:
1. We're calling goto multiple times per frame with 0 (show) then 1 (hide)
2. Sometimes when the switch from 0 to 1 happens, current progress is 1 (because the dock is hidden), but the timeline exists and it's changing the progress to 0