### PR TITLE
WindowListModel: fix crash

### DIFF
--- a/src/WindowListModel.vala
+++ b/src/WindowListModel.vala
@@ -136,6 +136,10 @@ public class Gala.WindowListModel : Object, ListModel {
     }
 
     public Object? get_item (uint position) {
+        if (position >= get_n_items ()) {
+            return null;
+        }
+
         return windows[(int) position];
     }
 


### PR DESCRIPTION
From `GLib.ListModel.get_item ()`: 

> Get the item at position. If position is greater than the number of items in list, null is returned.