### PR TITLE
Show git commit hash in `gala --version`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       env:
         DESTDIR: out
       run: |
+        git config --global --add safe.directory "$(pwd)"
         meson build -Ddocumentation=true -Dtests=true
         ninja -C build
         ninja -C build install
@@ -78,6 +79,7 @@ jobs:
         env:
           DESTDIR: out
         run: |
+          git config --global --add safe.directory "$(pwd)"
           meson build
           ninja -C build install
 

--- a/config.vala.in
+++ b/config.vala.in
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2025 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2025-2026 elementary, Inc. (https://elementary.io)
  *                         2011 Robert Dyer
  *                         2011 Rico Tzschichholz
  */
@@ -10,4 +10,5 @@ namespace Config {
 	public const string LOCALEDIR = "@LOCALEDIR@";
 	public const string VERSION = "@VERSION@";
 	public const string PLUGINDIR = "@PLUGINDIR@";
+	public const string GIT_HASH = "@GIT_HASH@";
 }

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,14 @@ conf.set('GETTEXT_PACKAGE', meson.project_name())
 conf.set('LOCALEDIR', locale_dir)
 conf.set('PLUGINDIR', plugins_dir)
 conf.set('VERSION', meson.project_version())
+
+git = find_program('git', required: false)
+git_hash = 'unknown'
+if git.found()
+	git_hash = run_command(['git', 'rev-parse', '--short', 'HEAD'], capture : true, check : true).stdout().strip()
+endif
+conf.set('GIT_HASH', git_hash)
+
 config_header = configure_file (
     input: 'config.vala.in',
     output: 'config.vala',

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -1,5 +1,6 @@
 //
 //  Copyright (C) 2012 Tom Beckmann, Rico Tzschichholz
+//  Copyright (C) 2026 elementary, Inc.
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -22,7 +23,7 @@ namespace Gala {
     };
 
     private void print_version () {
-        stdout.printf ("Gala %s\n", Config.VERSION);
+        stdout.printf ("Gala %s (%s)\n", Config.VERSION, Config.GIT_HASH);
         Meta.exit (Meta.ExitCode.SUCCESS);
     }
 


### PR DESCRIPTION
Should make it easier for early access users to get the accurate version information