### PR TITLE
WindowSwitcher: don't force visibility and allocate manually

### DIFF
--- a/lib/Widgets/AbstractSwitcher.vala
+++ b/lib/Widgets/AbstractSwitcher.vala
@@ -31,7 +31,6 @@ public abstract class Gala.AbstractSwitcher : CanvasActor {
         style_manager = Drawing.StyleManager.get_instance ();
 
         container = new Clutter.Actor () {
-            reactive = true,
 #if HAS_MUTTER46
             layout_manager = new Clutter.FlowLayout (Clutter.Orientation.HORIZONTAL)
 #else
@@ -89,24 +88,35 @@ public abstract class Gala.AbstractSwitcher : CanvasActor {
         caption.margin_bottom = margin;
     }
 
-    protected override void get_preferred_width (float for_height, out float min_width, out float natural_width) {
-        min_width = 0;
-
-        float preferred_nat_width;
-        base.get_preferred_width (for_height, null, out preferred_nat_width);
-
+    public override void allocate (Clutter.ActorBox box) {
         unowned var display = wm.get_display ();
         var geom = display.get_monitor_geometry (display.get_current_monitor ());
 
-        float container_nat_width;
-        container.get_preferred_size (null, null, out container_nat_width, null);
+        float nat_container_width;
+        container.get_preferred_width (-1, null, out nat_container_width);
 
-        var max_width = float.min (
-            geom.width - Utils.scale_to_int (MIN_OFFSET * 2, monitor_scale), // Don't overflow the monitor
-            container_nat_width // Ellipsize the label if it's longer than the icons
-        );
+        var max_width = geom.width - Utils.scale_to_int (MIN_OFFSET * 2, monitor_scale);
+        var real_width = (int) float.min (nat_container_width, max_width);
 
-        natural_width = float.min (max_width, preferred_nat_width);
+        float nat_container_height;
+        container.get_preferred_height (real_width, null, out nat_container_height);
+
+        float nat_caption_height;
+        caption.get_preferred_height (real_width, null, out nat_caption_height);
+
+        var horizontal_margin = (geom.width - real_width) / 2;
+
+        var children_height = nat_container_height + nat_caption_height;
+        var vertical_margin = (geom.height - children_height) / 2;
+
+        box = {
+            geom.x + horizontal_margin,
+            geom.y + vertical_margin,
+            geom.width - horizontal_margin,
+            geom.height - vertical_margin
+        };
+
+        base.allocate (box);
     }
 
     protected override void draw (Cairo.Context ctx, int width, int height) {

--- a/src/Widgets/WindowSwitcher/WindowSwitcher.vala
+++ b/src/Widgets/WindowSwitcher/WindowSwitcher.vala
@@ -243,10 +243,6 @@ public class Gala.WindowSwitcher : AbstractSwitcher, GestureTarget, RootTarget {
             return;
         }
 
-        //Although we are setting visible via the opacity notify handler anyway
-        //we have to set it here manually otherwise the size gotten via get_preferred_size is wrong
-        visible = true;
-
         float width, height;
         get_preferred_size (null, null, out width, out height);
 


### PR DESCRIPTION
Should fix https://github.com/elementary/gala/issues/2696

When forcing visible = true, the actor starts receiving events and I suppose there may appear some race condition or some other bug that doesn't reset it. But overall we shouldn't force visibility to get correct size so I implemented a custom allocate function which fixes that