### PR TITLE
WindowManager/ShellClients: Explicitly override window group

### DIFF
--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -8,7 +8,7 @@
 public class Gala.ShellClientsManager : Object, GestureTarget {
     private static ShellClientsManager instance;
 
-    public static void init (WindowManager wm) {
+    public static void init (WindowManagerGala wm) {
         if (instance != null) {
             return;
         }
@@ -20,7 +20,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         return instance;
     }
 
-    public WindowManager wm { get; construct; }
+    public WindowManagerGala wm { get; construct; }
 
     private NotificationsClient notifications_client;
     private ManagedClient[] protocol_clients = {};
@@ -31,7 +31,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
     private GLib.HashTable<Meta.Window, ExtendedBehaviorWindow> positioned_windows = new GLib.HashTable<Meta.Window, ExtendedBehaviorWindow> (null, null);
     private GLib.HashTable<Meta.Window, MonitorLabelWindow> monitor_label_windows = new GLib.HashTable<Meta.Window, MonitorLabelWindow> (null, null);
 
-    private ShellClientsManager (WindowManager wm) {
+    private ShellClientsManager (WindowManagerGala wm) {
         Object (wm: wm);
     }
 
@@ -178,6 +178,8 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
 
         panel_windows[window] = new PanelWindow (wm, window, anchor);
 
+        wm.override_window_group (window, DESKTOP_SHELL);
+
         InternalUtils.wait_for_window_actor_visible (window, on_panel_ready);
 
         // connect_after so we make sure the PanelWindow can destroy its barriers and struts
@@ -243,6 +245,8 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
 
     public void make_modal (Meta.Window window, bool dim) requires (window in positioned_windows) {
         positioned_windows[window].make_modal (dim);
+
+        wm.override_window_group (window, MODAL);
     }
 
     public void make_monitor_label (Meta.Window window, int monitor_index) requires (!is_itself_shell_window (window)) {
@@ -252,6 +256,8 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         }
 
         monitor_label_windows[window] = new MonitorLabelWindow (window, monitor_index);
+
+        wm.override_window_group (window, DESKTOP_SHELL);
 
         // connect_after so we make sure that any queued move is unqueued
         window.unmanaging.connect_after ((_window) => monitor_label_windows.remove (_window));
@@ -297,25 +303,10 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         return positioned;
     }
 
-    private bool is_itself_system_modal (Meta.Window window) {
-        return (window in positioned_windows) && positioned_windows[window].modal;
-    }
-
-    public bool is_system_modal_window (Meta.Window window) {
-        var modal = is_itself_system_modal (window);
-        window.foreach_ancestor ((ancestor) => {
-            if (is_itself_system_modal (ancestor)) {
-                modal = true;
-            }
-
-            return !modal;
-        });
-
-        return modal;
-    }
-
-    public bool is_system_modal_dimmed (Meta.Window window) {
-        return is_itself_system_modal (window) && positioned_windows[window].dim;
+    public bool is_system_modal_dimmed (Meta.Window window) requires (
+        window in positioned_windows && positioned_windows[window].modal
+    ) {
+        return positioned_windows[window].dim;
     }
 
     //X11 only

--- a/src/WindowListener.vala
+++ b/src/WindowListener.vala
@@ -55,7 +55,6 @@ public class Gala.WindowListener : Object {
 
     public signal void window_workspace_changed (Meta.Window window);
     public signal void window_on_all_workspaces_changed (Meta.Window window);
-    public signal void window_type_changed (Meta.Window window);
     public signal void window_maximized_changed (Meta.Window window) {
         WindowGeometry window_geometry = {};
         window_geometry.inner = window.get_frame_rect ();
@@ -90,9 +89,6 @@ public class Gala.WindowListener : Object {
                 break;
             case "on-all-workspaces":
                 window_on_all_workspaces_changed (window);
-                break;
-            case "window-type":
-                window_type_changed (window);
                 break;
             case "fullscreen":
                 window_fullscreen_changed (window);

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -401,13 +401,13 @@ namespace Gala {
             stage.add_action_full ("wm-super-scroll-action", CAPTURE, scroll_action);
 
             display.window_created.connect ((window) =>
-                InternalUtils.wait_for_window_actor_visible (window, check_shell_window)
+                InternalUtils.wait_for_window_actor_visible (window, check_window_group)
             );
 
             WindowListener.get_default ().window_type_changed.connect ((window) => {
                 unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
                 if (window_actor != null) {
-                    check_shell_window (window_actor);
+                    check_window_group (window_actor);
                 }
             });
 
@@ -1073,7 +1073,7 @@ namespace Gala {
             }
         }
 
-        private void check_shell_window (Meta.WindowActor actor) {
+        private void check_window_group (Meta.WindowActor actor) {
             unowned var window = actor.get_meta_window ();
 
             if (overridden_window_group.has_key (window)) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -18,6 +18,11 @@
 
 namespace Gala {
     public class WindowManagerGala : Meta.Plugin, WindowManager {
+        public enum WindowGroup {
+            DESKTOP_SHELL,
+            MODAL,
+        }
+
         private const string OPEN_MULTITASKING_VIEW = "dbus-send --session --dest=org.pantheon.gala --print-reply /org/pantheon/gala org.pantheon.gala.PerformAction int32:1";
         private const string OPEN_APPLICATIONS_MENU = "io.elementary.wingpanel --toggle-indicator=app-launcher";
 
@@ -119,6 +124,8 @@ namespace Gala {
         private Clutter.Actor? latest_window_snapshot;
 
         private GLib.Settings behavior_settings;
+
+        private Gee.Map<Meta.Window, WindowGroup> overridden_window_group = new Gee.HashMap<Meta.Window, WindowGroup> ();
 
         construct {
 #if !HAS_MUTTER48
@@ -1040,23 +1047,57 @@ namespace Gala {
             show_window_menu (window, menu, rect.x, rect.y);
         }
 
-        private void check_shell_window (Meta.WindowActor actor) {
-            unowned var window = actor.get_meta_window ();
+        /**
+         * Tells the wm to place the {@link window} in the given {@link new_group} instead of the default
+         * window group as determined by the wm.
+         * The wm will also automatically place transient windows of {@link window} in the same group.
+         */
+        public void override_window_group (Meta.Window window, WindowGroup new_group) {
+            overridden_window_group[window] = new_group;
+            window.unmanaged.connect ((_window) => overridden_window_group.unset (_window));
 
-            if (ShellClientsManager.get_instance ().is_system_modal_window (window)) {
-                InternalUtils.clutter_actor_reparent (actor, modal_group.window_group);
-                return;
-            }
-
-            if (ShellClientsManager.get_instance ().is_shell_window (window)) {
-                InternalUtils.clutter_actor_reparent (actor, shell_group);
+            InternalUtils.wait_for_window_actor_visible (window, (actor) => {
+                InternalUtils.clutter_actor_reparent (actor, get_window_group_actor (new_group));
 
                 // FIXME: workaround for https://github.com/elementary/dock/issues/537
                 actor.set_scale (1.0, 1.0);
                 actor.opacity = 255;
+            });
+        }
+
+        private Clutter.Actor get_window_group_actor (WindowGroup group) {
+            switch (group) {
+                case DESKTOP_SHELL: return shell_group;
+                case MODAL: return modal_group.window_group;
+                default: assert_not_reached ();
+            }
+        }
+
+        private void check_shell_window (Meta.WindowActor actor) {
+            unowned var window = actor.get_meta_window ();
+
+            if (overridden_window_group.has_key (window)) {
+                /* We are already overridden so make sure to ignore it */
+                return;
+            }
+
+            /* Check if we're a transient of a window with an overridden group and if so place there */
+            window.foreach_ancestor ((ancestor) => {
+                if (overridden_window_group.has_key (ancestor)) {
+                    override_window_group (window, overridden_window_group[ancestor]);
+                    return false;
+                }
+
+                return true;
+            });
+
+            if (overridden_window_group.has_key (window)) {
+                /* We found an ancestor with an overridden group so we are now being placed in the same group */
+                return;
             }
 
             if (NotificationStack.is_notification (window)) {
+                override_window_group (window, DESKTOP_SHELL);
                 notification_stack.show_notification (actor);
             }
 

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -404,13 +404,6 @@ namespace Gala {
                 InternalUtils.wait_for_window_actor_visible (window, check_window_group)
             );
 
-            WindowListener.get_default ().window_type_changed.connect ((window) => {
-                unowned var window_actor = (Meta.WindowActor) window.get_compositor_private ();
-                if (window_actor != null) {
-                    check_window_group (window_actor);
-                }
-            });
-
             stage.show ();
 
             plugin_manager.load_waiting_plugins ();


### PR DESCRIPTION
To select the correct group for shell windows the window manager currently has to know what the possibilities are and then query the shell clients manager to see if the windows are one of that.
It also only works if we know the correct info about the windows before their window actor is turning visible.

Instead of this hacky solution we introduce a `override_window_group` in the wm. This is then called by the shellclientsmanager at that moment when it knows what the window will be.

This has a few advantages:
- We have a clear interface for how to handle changing the group of a window that also makes sure the wm knows about it and doesn't try to mess with it.
- It scales a lot better by allowing the actual places that know that the window should be somewhere else to change its group instead of the wm having to query everywhere. This will be useful for example with the osk which will also need its own group.
- It reduces the public api the shellclientsmanager has to expose
- It should finally fix the wingpanel sometimes being invisible in the multitasking view which for me still happens even after #2646
- The second commit can remove some now unecessary code