### PR TITLE
MultitaskingView: Fix escape after workspace switch

### DIFF
--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -278,6 +278,12 @@ public class Gala.MultitaskingView : Root, RootTarget, ActivatableComponent {
                 } else {
                     target_workspace.activate (display.get_current_time ());
                 }
+
+                /* Activating a workspace will set the input focus to the stage so recapture it
+                   (Gala.Root will automatically recapture it if we try to move the focus but we want
+                   it right away for escape to work) */
+                grab_key_focus ();
+
                 break;
 
             default:


### PR DESCRIPTION
After a workspace switch you currently have to press one of the arrow keys once so that the gala.root captures the input focus again and only then pressing esc will work.
This PR makes sure it will always work after switching workspaces.