### PR TITLE
Support running as greeter

### DIFF
--- a/data/io.elementary.desktop.wm.shell
+++ b/data/io.elementary.desktop.wm.shell
@@ -7,3 +7,19 @@ session-type=desktop
 launch-on-x=true
 args=io.elementary.dock
 session-type=desktop
+
+[Greeter wingpanel]
+args=io.elementary.wingpanel;-g
+session-type=greeter
+
+[Greeter Session Manager]
+args=io.elementary.greeter-session-manager
+session-type=greeter
+
+[Greeter]
+args=io.elementary.greeter
+session-type=greeter
+
+[Greeter Settings Daemon]
+args=io.elementary.settings-daemon
+session-type=greeter

--- a/data/io.elementary.desktop.wm.shell
+++ b/data/io.elementary.desktop.wm.shell
@@ -1,7 +1,9 @@
 [io.elementary.wingpanel]
 launch-on-x=true
 args=io.elementary.wingpanel
+session-type=desktop
 
 [io.elementary.dock]
 launch-on-x=true
 args=io.elementary.dock
+session-type=desktop

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -62,4 +62,8 @@ namespace Gala.SessionSettings {
     public bool should_blur_background () {
         return get_session_type () != DESKTOP;
     }
+
+    public bool should_fade_in () {
+        return get_session_type () != DESKTOP;
+    }
 }

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -49,4 +49,8 @@ namespace Gala.SessionSettings {
 
         return "desktop";
     }
+
+    public bool should_set_xdg_current_desktop () {
+        return get_session_type () != DESKTOP;
+    }
 }

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -36,4 +36,17 @@ namespace Gala.SessionSettings {
 
         return session_type;
     }
+
+    public string get_shell_clients_type () {
+        switch (get_session_type ()) {
+            case DESKTOP:
+                return "desktop";
+            case GREETER:
+                return "greeter";
+            case INSTALLER:
+                return "installer";
+        }
+
+        return "desktop";
+    }
 }

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -58,4 +58,8 @@ namespace Gala.SessionSettings {
         /* In the other types we fade in anyways */
         return get_session_type () == DESKTOP;
     }
+
+    public bool should_blur_background () {
+        return get_session_type () != DESKTOP;
+    }
 }

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+namespace Gala.SessionSettings {
+    private enum SessionType {
+        DESKTOP,
+        GREETER,
+        INSTALLER;
+    }
+
+    private static SessionType? session_type = null;
+
+    private static SessionType get_session_type () {
+        if (session_type == null) {
+            var session_type_str = Environment.get_variable ("GALA_SESSION_TYPE") ?? "desktop";
+            switch (session_type_str) {
+                case "desktop":
+                    session_type = DESKTOP;
+                    break;
+                case "greeter":
+                    session_type = GREETER;
+                    break;
+                case "installer":
+                    session_type = INSTALLER;
+                    break;
+                default:
+                    warning ("Unknown session type: %s", session_type_str);
+                    session_type = DESKTOP;
+                    break;
+            }
+        }
+
+        return session_type;
+    }
+}

--- a/lib/SessionSettings.vala
+++ b/lib/SessionSettings.vala
@@ -53,4 +53,9 @@ namespace Gala.SessionSettings {
     public bool should_set_xdg_current_desktop () {
         return get_session_type () != DESKTOP;
     }
+
+    public bool should_animate_panels () {
+        /* In the other types we fade in anyways */
+        return get_session_type () == DESKTOP;
+    }
 }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -8,6 +8,7 @@ gala_lib_sources = files(
     'Constants.vala',
     'DragDropAction.vala',
     'Plugin.vala',
+    'SessionSettings.vala',
     'Utils.vala',
     'WindowManager.vala',
     'AppSystem/App.vala',

--- a/src/Background/BackgroundContainer.vala
+++ b/src/Background/BackgroundContainer.vala
@@ -54,6 +54,10 @@ public class Gala.BackgroundContainer : Meta.BackgroundGroup {
         for (var i = 0; i < display.get_n_monitors (); i++) {
             var background = new BackgroundManager (display, i);
 
+            if (SessionSettings.should_blur_background ()) {
+                background.add_effect (new BlurEffect (background, 18));
+            }
+
             add_child (background);
 
             if (i == 0)

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -27,6 +27,12 @@ namespace Gala {
     }
 
     public static int main (string[] args) {
+        if (SessionSettings.should_set_xdg_current_desktop ()) {
+            // Ensure we present ourselves as Pantheon so we pick up the right GSettings
+            // overrides
+            Environment.set_variable ("XDG_CURRENT_DESKTOP", "Pantheon", true);
+        }
+
         GLib.Intl.setlocale (LocaleCategory.ALL, "");
         GLib.Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
         GLib.Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -118,6 +118,11 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
             }
         }
 
+        if (!SessionSettings.should_animate_panels ()) {
+            starting_panels = 0;
+            return;
+        }
+
         starting_panels = protocol_clients.length;
     }
 

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -102,6 +102,15 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
             }
 
             try {
+                var type = key_file.get_string (group, "session-type");
+                if (type != SessionSettings.get_shell_clients_type ()) {
+                    continue;
+                }
+            } catch (Error e) {
+                warning ("Failed to check session type for client %s, assuming it should be launched: %s", group, e.message);
+            }
+
+            try {
                 var args = key_file.get_string_list (group, "args");
                 protocol_clients += new ManagedClient (wm.get_display (), args);
             } catch (Error e) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -139,6 +139,10 @@ namespace Gala {
 
             show_stage ();
 
+            if (SessionSettings.should_fade_in ()) {
+                fade_in.begin ();
+            }
+
             init_a11y ();
 
             AccessDialog.watch_portal ();
@@ -416,6 +420,22 @@ namespace Gala {
                 display.get_context ().notify_ready ();
                 return GLib.Source.REMOVE;
             });
+        }
+
+        private async void fade_in () {
+            var fade_in_actor = new Clutter.Actor () {
+                background_color = { 0, 0, 0, 255 },
+            };
+            fade_in_actor.add_constraint (new Clutter.BindConstraint (stage, SIZE, 0));
+            stage.add_child (fade_in_actor);
+
+            /* TODO: We might want to wait another second before we start the fade otherwise it's not really visible */
+
+            var transition_builder = new TransitionBuilder (fade_in_actor, 1000, EASE);
+            transition_builder.add_property ("opacity", 0u);
+            yield transition_builder.run ();
+
+            stage.remove_child (fade_in_actor);
         }
 
         private void init_a11y () {


### PR DESCRIPTION
With some minimal changes we can support running gala as the compositor for the greeter and given the many things gala has to do these days I think this is probably the way to go (e.g. also on screen keyboard, input methods, etc.)

To keep a nice overview of things that are different between the different session types I decided to introduce a `SessionSettings` namespace that actually has meaningful options like `should_blur_background`, `should_fade_in`, etc instead of having the appropriate places just query the session type and then decide what to do. IMO it's good to keep this overview instead of having to go hunt through all files and also it's easy to adjust how we get the session type etc., but I'd like to hear other opinions. Or if there are other ideas for how to handle these differences between the session types I'd be happy to hear them.

This already works with #elementary/greeter#878 but it still needs a bit of polish.