### PR TITLE
Tests: avoid recompiling libgala for each test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,14 @@ jobs:
       env:
         DESTDIR: out
       run: |
-        meson build -Ddocumentation=true -Dtests=true
-        ninja -C build
-        ninja -C build install
+        meson setup build --prefix=/usr -Ddocumentation=true
+        cd build
+        ninja install
+    - name: Build Tests
+      run: |
+        cd build
+        meson configure -Dtests=true
+        ninja install
     - name: Prepare Test Environment
       run: |
         mkdir -p -m 700 ${{ github.workspace }}/runtime-dir

--- a/lib/Gestures/Backends/GestureBackend.vala
+++ b/lib/Gestures/Backends/GestureBackend.vala
@@ -1,11 +1,15 @@
 /*
- * Copyright 2025 elementary, Inc. (https://elementary.io)
+ * Copyright 2025-2026 elementary, Inc. (https://elementary.io)
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  * Authored by: Leonhard Kargl <leo.kargl@proton.me>
  */
 
+#if TESTS
+public interface Gala.GestureBackend : Object {
+#else
 private interface Gala.GestureBackend : Object {
+#endif
     public signal bool on_gesture_detected (Gesture gesture, uint32 timestamp);
     public signal void on_begin (double percentage, uint64 time);
     public signal void on_update (double percentage, uint64 time);

--- a/lib/Gestures/Gesture.vala
+++ b/lib/Gestures/Gesture.vala
@@ -20,7 +20,11 @@ namespace Gala {
     /**
      * Physical direction of the gesture. This direction doesn't follow natural scroll preferences.
      */
+#if TESTS
+    public enum GestureDirection {
+#else
     private enum GestureDirection {
+#endif
         UNKNOWN = 0,
 
         // GestureType.SWIPE and GestureType.SCROLL
@@ -59,7 +63,11 @@ namespace Gala {
         }
     }
 
+#if TESTS
+    public class Gesture {
+#else
     private class Gesture {
+#endif
         public Clutter.EventType type;
         public GestureDirection direction;
         public int fingers;

--- a/lib/Gestures/GestureController.vala
+++ b/lib/Gestures/GestureController.vala
@@ -119,7 +119,11 @@ public class Gala.GestureController : Object {
         trigger.enable_backends (this);
     }
 
+#if TESTS
+    public void enable_backend (GestureBackend backend) {
+#else
     internal void enable_backend (GestureBackend backend) {
+#endif
         backend.on_gesture_detected.connect (gesture_detected);
         backend.on_begin.connect (gesture_begin);
         backend.on_update.connect (gesture_update);

--- a/lib/Gestures/Triggers/GestureTrigger.vala
+++ b/lib/Gestures/Triggers/GestureTrigger.vala
@@ -10,6 +10,11 @@
  * the necessary backends for the type of gesture.
  */
 public interface Gala.GestureTrigger : Object {
+#if TESTS
+    public abstract bool triggers (Gesture gesture);
+    public abstract void enable_backends (GestureController controller);
+#else
     internal abstract bool triggers (Gesture gesture);
     internal abstract void enable_backends (GestureController controller);
+#endif
 }

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -76,7 +76,7 @@ config_h = configure_file(
     install_dir: join_paths(get_option('datadir'), 'vala', 'vapi')
 )
 
-gala_dep = declare_dependency(link_with: [gala_lib], include_directories: include_directories('.'))
+gala_lib_dep = declare_dependency(link_with: [gala_lib], include_directories: include_directories('.'))
 
 pkg.generate(
     gala_lib,

--- a/meson.build
+++ b/meson.build
@@ -168,6 +168,11 @@ if vala.version().version_compare('>= 0.56.17')
     vala_flags += ['--define', 'VALA_0_56_17']
 endif
 
+if get_option('tests')
+	vala_flags += ['--define', 'TESTS']
+endif
+
+
 add_project_arguments(vala_flags, language: 'vala')
 add_project_link_arguments(['-Wl,-rpath,@0@'.format(mutter_typelib_dir)], language: 'c')
 

--- a/plugins/pip/meson.build
+++ b/plugins/pip/meson.build
@@ -7,7 +7,7 @@ gala_pip_sources = files(
 gala_pip_lib = shared_library(
     'gala-pip',
     gala_pip_sources,
-    dependencies: [gala_dep, gala_base_dep],
+    dependencies: [gala_lib_dep, gala_base_dep],
     install: true,
     install_dir: plugins_dir,
     install_rpath: mutter_typelib_dir,

--- a/plugins/template/meson.build
+++ b/plugins/template/meson.build
@@ -5,7 +5,7 @@ gala_template_sources = files(
 gala_template_lib = shared_library(
     'gala-template',
     gala_template_sources,
-    dependencies: [gala_dep, gala_base_dep],
+    dependencies: [gala_lib_dep, gala_base_dep],
     install: false,
     install_dir: plugins_dir,
     install_rpath: mutter_typelib_dir,

--- a/src/meson.build
+++ b/src/meson.build
@@ -76,7 +76,7 @@ gala_bin = executable(
     'gala',
     gala_bin_sources,
     config_header,
-    dependencies: [gala_dep, gala_base_dep, pantheon_desktop_shell_dep],
+    dependencies: [gala_lib_dep, gala_base_dep, pantheon_desktop_shell_dep],
     install_rpath: mutter_typelib_dir,
     install: true,
 )

--- a/tests/lib/meson.build
+++ b/tests/lib/meson.build
@@ -9,8 +9,7 @@ foreach test : tests
         test,
         '@0@.vala'.format(test),
         common_test_sources,
-        gala_lib_sources,
-        dependencies: gala_base_dep,
+        dependencies: [gala_lib_dep, gala_base_dep],
         install: false,
     )
 


### PR DESCRIPTION
Reuse libgala library instead of compiling a test + libgala into every test executable.

Because of this change I introduced a TESTS preprocessor variable to expose needed internal parts of the library to the tests.

This should significantly speed up compilation for large numbers of tests.