### PR TITLE
Release 8.5.1

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -27,6 +27,19 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.5.1" date="2026-05-12" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Fixed a frequent crash with multi monitor setups</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/gala/issues/2839">Semi-crash crash when alt-tabbing from secondary monitor to the first</issue>
+      </issues>
+    </release>
+
     <release version="8.5.0" date="2026-05-04" urgency="medium">
       <description>
         <p>Improvements:</p>
@@ -190,7 +203,7 @@
         <issue url="https://github.com/elementary/gala/issues/2415">Wrong animation origin for windows on display 2 on workspace overview</issue>
       </issues>
     </release>
-  
+
     <release version="8.2.2" date="2025-05-17" urgency="medium">
       <description>
         <p>Improvements:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gala',
     'vala',
-    version: '8.5.0',
+    version: '8.5.1',
     meson_version: '>= 0.59.0',
     license: 'GPL3',
     default_options: [


### PR DESCRIPTION
For #2840 
This fixes a 100% of the time crash on multi monitor setups when alt tabbing, see #2844, #2839, etc.

Note that this also includes #2805 which probably introduces #2842 which brings two questions:
- Should this be 8.6.0 since it is a pretty noticeable feature?
- Should we revert, release and then add it again?