### PR TITLE
Tests: Use a single executable

### DIFF
--- a/tests/TestCase.vala
+++ b/tests/TestCase.vala
@@ -12,12 +12,10 @@
 public abstract class Gala.TestCase : Object {
     public delegate void TestMethod ();
 
-    public string name { get; construct; }
-
     private GLib.TestSuite suite;
 
     construct {
-        suite = new GLib.TestSuite (name);
+        suite = new GLib.TestSuite (get_type ().name ());
     }
 
     public int run (string[] args) {

--- a/tests/lib/GestureControllerTest.vala
+++ b/tests/lib/GestureControllerTest.vala
@@ -93,10 +93,6 @@ public class Gala.GestureControllerTest : MutterTestCase {
     private GestureController controller;
     private MockTarget target;
 
-    public GestureControllerTest () {
-        Object (name: "GestureControllerTest");
-    }
-
     construct {
         add_test ("Test basic propagation", test_basic_propagation);
         add_test ("Test two immediate gotos", test_two_immediate_gotos);
@@ -200,8 +196,4 @@ public class Gala.GestureControllerTest : MutterTestCase {
 
         run_main_loop ();
     }
-}
-
-public int main (string[] args) {
-    return new Gala.GestureControllerTest ().run (args);
 }

--- a/tests/lib/Main.vala
+++ b/tests/lib/Main.vala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+namespace Gala {
+    public int main (string[] args) {
+        var test_name = args[1];
+
+        var test_case = get_test_case (test_name);
+
+        if (test_case == null) {
+            warning ("TestCase %s not found", test_name);
+            return 1;
+        }
+
+        return test_case.run (args);
+    }
+
+    private TestCase? get_test_case (string name) {
+        Type[] test_types = {
+            typeof (GestureControllerTest),
+            typeof (PropertyTargetTest),
+            typeof (SetupTest),
+            typeof (SwipeTriggerTest),
+        };
+
+        foreach (var type in test_types) {
+            if (type.name () == name) {
+                return (TestCase) Object.new (type);
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/lib/PropertyTargetTest.vala
+++ b/tests/lib/PropertyTargetTest.vala
@@ -12,10 +12,6 @@ public class Gala.PropertyTargetTest : TestCase {
     private MockObject? target;
     private PropertyTarget? default_int_prop_target;
 
-    public PropertyTargetTest () {
-        Object (name: "PropertyTarget");
-    }
-
     construct {
         add_test ("simple propagation", test_simple_propagation);
         add_test ("double propagation", test_double_propagation);
@@ -150,8 +146,4 @@ public class Gala.PropertyTargetTest : TestCase {
         assert_finalize_object<PropertyTarget> (ref default_int_prop_target);
         assert_finalize_object<MockObject> (ref target);
     }
-}
-
-public int main (string[] args) {
-    return new Gala.PropertyTargetTest ().run (args);
 }

--- a/tests/lib/SetupTest.vala
+++ b/tests/lib/SetupTest.vala
@@ -12,10 +12,6 @@
  * and allows us to interact with it, e.g. by creating a Clutter actor.
  */
 public class Gala.SetupTest : MutterTestCase {
-    public SetupTest () {
-        Object (name: "SetupTest");
-    }
-
     construct {
         add_test ("Test setup successful", test_setup_successful);
         add_test ("Test main loop", test_main_loop);
@@ -87,8 +83,4 @@ public class Gala.SetupTest : MutterTestCase {
         Test.message ("Got %d frames", frames);
         assert_cmpint (frames, GT, 0);
     }
-}
-
-public int main (string[] args) {
-    return new Gala.SetupTest ().run (args);
 }

--- a/tests/lib/SwipeTriggerTest.vala
+++ b/tests/lib/SwipeTriggerTest.vala
@@ -9,10 +9,6 @@ public class Gala.SwipeTriggerTest : MutterTestCase {
     private Clutter.Actor? actor;
     private SwipeTrigger? trigger;
 
-    public SwipeTriggerTest () {
-        Object (name: "SwipeTriggerTest");
-    }
-
     construct {
         add_test ("Test finalize trigger first", test_finalize_trigger_first);
         add_test ("Test finalize actor first", test_finalize_actor_first);
@@ -55,8 +51,4 @@ public class Gala.SwipeTriggerTest : MutterTestCase {
 
         assert_finalize_object (ref trigger);
     }
-}
-
-public int main (string[] args) {
-    return new Gala.SwipeTriggerTest ().run (args);
 }

--- a/tests/lib/meson.build
+++ b/tests/lib/meson.build
@@ -5,15 +5,26 @@ tests = [
     'SwipeTriggerTest',
 ]
 
+test_sources = []
 foreach test : tests
-    test_executable = executable(
-        test,
-        '@0@.vala'.format(test),
-        common_test_sources,
-        gala_lib_sources,
-        dependencies: gala_base_dep,
-        install: false,
-    )
-
-    test(test, test_executable, suite: ['Gala', 'Gala/lib'], is_parallel: false)
+    test_sources += test + '.vala'
 endforeach
+
+lib_test_sources = [
+    'Main.vala'
+]
+
+test_executable = executable(
+    'io.elementary.gala.tests',
+    common_test_sources,
+    lib_test_sources,
+    test_sources,
+    gala_lib_sources,
+    dependencies: gala_base_dep,
+    install: false,
+)
+
+foreach test : tests
+    test(test, test_executable, args: 'Gala' + test, suite: ['Gala', 'Gala/lib'], is_parallel: false)
+endforeach
+


### PR DESCRIPTION
Supersedes and closes #2835 

This achieves the same performance boost but makes sure the tests can only be run isolated.
Most notably having the run method an instance method of a test case makes sure of that.

I know that this might be pedantic but the meta context stuff is quite fragile and it took a while to get it working so I think having it with as many guardrails as possible is probably for the better.