### PR TITLE
ModalProxy: Explicitly allow window groups

### DIFF
--- a/lib/WindowManager.vala
+++ b/lib/WindowManager.vala
@@ -38,6 +38,12 @@ namespace Gala {
         MEDIA_KEYS
     }
 
+    public enum WindowGroup {
+        DESKTOP_SHELL,
+        MODAL,
+        OVERLAY,
+    }
+
     /**
      * A minimal class mostly used to identify your call to {@link WindowManager.push_modal} and used
      * to end your modal mode again with {@link WindowManager.pop_modal}
@@ -46,6 +52,7 @@ namespace Gala {
         public Clutter.Grab? grab { get; set; }
 
         private ModalActions allowed_actions;
+        private WindowGroup[] allowed_window_groups;
 
         public ModalProxy () {
         }
@@ -56,6 +63,14 @@ namespace Gala {
 
         public bool filter_action (ModalActions action) {
             return !(action in allowed_actions);
+        }
+
+        public void allow_window_groups (WindowGroup[] window_groups) requires (grab == null) {
+            allowed_window_groups = window_groups;
+        }
+
+        public bool is_window_group_allowed (WindowGroup window_group) {
+            return window_group in allowed_window_groups;
         }
     }
 

--- a/src/Widgets/ModalGroup.vala
+++ b/src/Widgets/ModalGroup.vala
@@ -14,6 +14,8 @@
  * instead to {@link window_group}.
  */
 public class Gala.ModalGroup : Clutter.Actor {
+    private const WindowGroup[] ALLOWED_WINDOW_GROUPS = { MODAL, OVERLAY };
+
     public WindowManager wm { private get; construct; }
     public ShellClientsManager shell_clients { private get; construct; }
 
@@ -71,6 +73,7 @@ public class Gala.ModalGroup : Clutter.Actor {
             visible = true;
             modal_proxy = wm.push_modal (this, false);
             modal_proxy.allow_actions (ZOOM | LOCATE_POINTER | SCREENSHOT | SCREENSHOT_AREA | SCREENSHOT_WINDOW);
+            modal_proxy.allow_window_groups (ALLOWED_WINDOW_GROUPS);
         }
 
         if (dimmed.size == 1) {

--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -22,6 +22,7 @@
  */
 public class Gala.MultitaskingView : Root, RootTarget, ActivatableComponent {
     public const int ANIMATION_DURATION = 250;
+    private const WindowGroup[] ALLOWED_WINDOW_GROUPS = { DESKTOP_SHELL, OVERLAY };
 
     private GestureController workspaces_gesture_controller;
     private GestureController multitasking_gesture_controller;
@@ -234,6 +235,7 @@ public class Gala.MultitaskingView : Root, RootTarget, ActivatableComponent {
 
             modal_proxy = wm.push_modal (get_stage (), false);
             modal_proxy.allow_actions (MULTITASKING_VIEW | SWITCH_WORKSPACE | ZOOM | LOCATE_POINTER | MEDIA_KEYS | SCREENSHOT | SCREENSHOT_AREA);
+            modal_proxy.allow_window_groups (ALLOWED_WINDOW_GROUPS);
         } else if (action == MULTITASKING_VIEW) {
             DragDropAction.cancel_all_by_id ("multitaskingview-window");
         }

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -18,12 +18,6 @@
 
 namespace Gala {
     public class WindowManagerGala : Meta.Plugin, WindowManager {
-        public enum WindowGroup {
-            DESKTOP_SHELL,
-            MODAL,
-            OVERLAY,
-        }
-
         private const string OPEN_MULTITASKING_VIEW = "dbus-send --session --dest=org.pantheon.gala --print-reply /org/pantheon/gala org.pantheon.gala.PerformAction int32:1";
         private const string OPEN_APPLICATIONS_MENU = "io.elementary.wingpanel --toggle-indicator=app-launcher";
 
@@ -721,10 +715,16 @@ namespace Gala {
         private void on_focus_window_changed () {
             unowned var display = get_display ();
 
-            if (!is_modal () || modal_stack.peek_head ().grab != null || display.focus_window == null ||
-                ShellClientsManager.get_instance ().is_shell_window (display.focus_window)
-            ) {
+            if (!is_modal () || modal_stack.peek_head ().grab != null || display.focus_window == null) {
                 return;
+            }
+
+            if (overridden_window_group.has_key (display.focus_window)) {
+                var overridden_group = overridden_window_group[display.focus_window];
+
+                if (modal_stack.peek_head ().is_window_group_allowed (overridden_group)) {
+                    return;
+                }
             }
 
             display.unset_input_focus (display.get_current_time ());


### PR DESCRIPTION
While a non grabbed modal proxy is active we currently just allow any shell window to receive input focus.
This has the problem that e.g. when a modal window like the polkit dialog is active and then a desktop shell window tries to get focus (e.g. wingpanel reasks for your wifi password) it will give focus to that window which might not be immediately apparent. This will be especially noticeable with the lock screen so this also serves as preparation for #2854 
With this PR we need to explicitly allow window groups to be able to receive focus. 