### PR TITLE
HideTracker: Guard against accessing invalid pointer

### DIFF
--- a/src/ShellClients/HideTracker.vala
+++ b/src/ShellClients/HideTracker.vala
@@ -14,7 +14,7 @@ public class Gala.HideTracker : Object {
     public signal void show ();
 
     public Meta.Display display { get; construct; }
-    public unowned PanelWindow panel { get; construct; }
+    public unowned PanelWindow? panel { get; construct; }
 
     private static GLib.Settings behavior_settings;
 
@@ -37,6 +37,10 @@ public class Gala.HideTracker : Object {
 
     construct {
         panel.window.unmanaging.connect_after (() => {
+            /* The window was unmanaged so the panel will be freed because we only hold a weak reference,
+               therefore set it to null to avoid a dangling pointer */
+            panel = null;
+
             // The timeouts hold refs on us so we stay connected to signal handlers that might
             // access the panel which was already freed. To prevent that make sure we reset
             // the timeouts so that we get freed immediately
@@ -49,6 +53,10 @@ public class Gala.HideTracker : Object {
         unowned var cursor_tracker = display.get_cursor_tracker ();
 #endif
         cursor_tracker.position_invalidated.connect (() => {
+            if (panel == null) {
+                return;
+            }
+
             var has_pointer = panel.window.has_pointer ();
 
             if (hovered != has_pointer) {
@@ -72,6 +80,10 @@ public class Gala.HideTracker : Object {
 
     private void on_window_created (Meta.Window new_window) {
         InternalUtils.wait_for_window_actor (new_window, (new_window_actor) => {
+            if (panel == null) {
+                return;
+            }
+
             if (!panel.window.is_ancestor_of_transient (new_window_actor.meta_window)) {
                 return;
             }
@@ -87,6 +99,10 @@ public class Gala.HideTracker : Object {
     }
 
     private void check_trigger_conditions () {
+        if (panel == null) {
+            return;
+        }
+
         if (hovered || has_transients || panel.window.has_focus ()) {
             trigger_show ();
         } else {
@@ -119,6 +135,10 @@ public class Gala.HideTracker : Object {
     }
 
     private void setup_barrier () {
+        if (panel == null) {
+            return;
+        }
+
         var monitor_geom = display.get_monitor_geometry (display.get_primary_monitor ());
         var scale = Utils.get_ui_scaling_factor (display, display.get_primary_monitor ());
         var offset = Utils.scale_to_int (BARRIER_OFFSET, scale);
@@ -174,7 +194,7 @@ public class Gala.HideTracker : Object {
 
     private void on_barrier_triggered () {
         // Showing panels in fullscreen is broken in X11
-        if (InternalUtils.get_x11_in_fullscreen (display)) {
+        if (InternalUtils.get_x11_in_fullscreen (display) || panel == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #2859 

@garaevdi could you try if this fixes the crash for you?

Because I think your backtrace points more towards
https://github.com/elementary/gala/blob/f183e1648451ccaf1a232c78ea4ac15265dd796f/src/ShellClients/HideTracker.vala#L112

Also I think that not positionedwindow.window is null but rather the positionedwindow itself was already freed because the hidetracker only holds an unowned reference on it. The HideTracker however isn't freed because it is captured by the wait for window actor callback.

With this PR we guard against accessing that reference if the window was unmanaged.

For now I hope this should fix it but we had this problem in the past a few times so I think I'll follow up some time by just passing the meta.window and the anchor instead of the whole panelwindow to avoid having to hold an unowned reference.