### PR TITLE
 Implement tests for src

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-gala_bin_sources = files(
+gala_bin_base_sources = files(
     'BlurManager.vala',
     'DBus.vala',
     'DBusAccelerator.vala',
@@ -8,7 +8,6 @@ gala_bin_sources = files(
     'InternalUtils.vala',
     'KeyboardManager.vala',
     'LockScreenManager.vala',
-    'Main.vala',
     'NotificationsManager.vala',
     'NotificationStack.vala',
     'PantheonShell.vala',
@@ -74,6 +73,10 @@ gala_bin_sources = files(
     'Widgets/WindowOverview.vala',
     'Widgets/WindowSwitcher/WindowSwitcher.vala',
     'Widgets/WindowSwitcher/WindowSwitcherIcon.vala',
+)
+
+gala_bin_sources = gala_bin_base_sources + files(
+    'Main.vala',
 )
 
 gala_bin = executable(

--- a/tests/TestRunner.vala
+++ b/tests/TestRunner.vala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+namespace Gala.TestRunner {
+    private Type[]? test_types;
+
+    public void register_test (Type type) {
+        assert (type.is_a (typeof (TestCase)));
+
+        if (test_types == null) {
+            test_types = {};
+        }
+
+        test_types += type;
+    }
+
+    public int run (string[] args) {
+        var test_name = args[1];
+
+        var test_case = get_test_case (test_name);
+
+        if (test_case == null) {
+            warning ("TestCase %s not found", test_name);
+            return 1;
+        }
+
+        return test_case.run (args);
+    }
+
+    private TestCase? get_test_case (string name) {
+        foreach (var type in test_types) {
+            if (type.name () == name) {
+                return (TestCase) Object.new (type);
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/lib/Main.vala
+++ b/tests/lib/Main.vala
@@ -5,32 +5,10 @@
 
 namespace Gala {
     public int main (string[] args) {
-        var test_name = args[1];
-
-        var test_case = get_test_case (test_name);
-
-        if (test_case == null) {
-            warning ("TestCase %s not found", test_name);
-            return 1;
-        }
-
-        return test_case.run (args);
-    }
-
-    private TestCase? get_test_case (string name) {
-        Type[] test_types = {
-            typeof (GestureControllerTest),
-            typeof (PropertyTargetTest),
-            typeof (SetupTest),
-            typeof (SwipeTriggerTest),
-        };
-
-        foreach (var type in test_types) {
-            if (type.name () == name) {
-                return (TestCase) Object.new (type);
-            }
-        }
-
-        return null;
+        TestRunner.register_test (typeof (GestureControllerTest));
+        TestRunner.register_test (typeof (PropertyTargetTest));
+        TestRunner.register_test (typeof (SetupTest));
+        TestRunner.register_test (typeof (SwipeTriggerTest));
+        return TestRunner.run (args);
     }
 }

--- a/tests/lib/meson.build
+++ b/tests/lib/meson.build
@@ -1,30 +1,29 @@
-tests = [
+lib_tests = [
     'GestureControllerTest',
     'PropertyTargetTest',
     'SetupTest',
     'SwipeTriggerTest',
 ]
 
-test_sources = []
-foreach test : tests
-    test_sources += test + '.vala'
+lib_test_sources = []
+foreach test : lib_tests
+    lib_test_sources += test + '.vala'
 endforeach
 
-lib_test_sources = [
+lib_test_sources += [
     'Main.vala'
 ]
 
-test_executable = executable(
-    'io.elementary.gala.tests',
+lib_test_executable = executable(
+    'io.elementary.gala.lib-tests',
     common_test_sources,
     lib_test_sources,
-    test_sources,
     gala_lib_sources,
     dependencies: gala_base_dep,
     install: false,
 )
 
-foreach test : tests
-    test(test, test_executable, args: 'Gala' + test, suite: ['Gala', 'Gala/lib'], is_parallel: false)
+foreach test : lib_tests
+    test(test, lib_test_executable, args: 'Gala' + test, suite: ['Gala', 'Gala/lib'], is_parallel: false)
 endforeach
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,3 +5,4 @@ common_test_sources = files(
 )
 
 subdir('lib')
+subdir('src')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,7 @@
 common_test_sources = files(
     'MutterTestCase.vala',
     'TestCase.vala',
+    'TestRunner.vala',
 )
 
 subdir('lib')

--- a/tests/src/Main.vala
+++ b/tests/src/Main.vala
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+namespace Gala {
+    public int main (string[] args) {
+        TestRunner.register_test (typeof (TransitionBuilderTest));
+        return TestRunner.run (args);
+    }
+}

--- a/tests/src/TransitionBuilderTest.vala
+++ b/tests/src/TransitionBuilderTest.vala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 elementary, Inc. (https://elementary.io)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Authored by: Leonhard Kargl <leo.kargl@proton.me>
+ */
+
+public class Gala.TransitionBuilderTest : MutterTestCase {
+    construct {
+        add_test ("test not ran", test_not_ran);
+    }
+
+    private void test_not_ran () {
+        var actor = new Clutter.Actor ();
+        var builder = new TransitionBuilder (actor, 500, EASE);
+
+        assert_finalize_object<TransitionBuilder> (ref builder);
+        assert_finalize_object<Clutter.Actor> (ref actor);
+    }
+}

--- a/tests/src/meson.build
+++ b/tests/src/meson.build
@@ -1,0 +1,27 @@
+src_tests = [
+    'TransitionBuilderTest'
+]
+
+src_test_sources = []
+foreach test : src_tests
+    src_test_sources += test + '.vala'
+endforeach
+
+src_test_sources += [
+    'Main.vala'
+]
+
+src_test_executable = executable(
+    'io.elementary.gala.src-tests',
+    common_test_sources,
+    src_test_sources,
+    gala_bin_base_sources,
+    config_header,
+    dependencies: [gala_base_dep, gala_dep, pantheon_desktop_shell_dep],
+    install: false,
+)
+
+foreach test : src_tests
+    test(test, src_test_executable, args: 'Gala' + test, suite: ['Gala', 'Gala/src'], is_parallel: false)
+endforeach
+


### PR DESCRIPTION
Add a `TestRunner` where we register the test types instead of doing it manually in main.
Add a simple test for the transitionbuilder that makes sure it gets freed even it's not run.