### PR TITLE
MutterTestCase: Explicitly filter expected fatal warning

### DIFF
--- a/tests/MutterTestCase.vala
+++ b/tests/MutterTestCase.vala
@@ -56,13 +56,25 @@ public abstract class Gala.MutterTestCase : Gala.TestCase {
     }
 
     public override void set_up () {
-        Test.log_set_fatal_handler ((domain, level, message) => {
-            /* Mutter sends a fatal log when failing to connect to colord but that doesn't matter for us */
-            Test.message ("Got fatal log, not aborting");
-            return false;
-        });
+        Test.log_set_fatal_handler (fatal_log_handler);
 
         main_loop = new MainLoop (null, false);
+    }
+
+    /**
+     * Override this method if you need to ignore certain fatal logs instead
+     * of manually calling log_set_fatal_handler.
+     * Also make sure to chain up to this implementation otherwise the test
+     * will probably fail.
+     */
+    protected virtual bool fatal_log_handler (string? domain, LogLevelFlags level, string message) {
+        if (domain == "libmutter" && FLAG_FATAL in level && "Failed to connect to colord daemon" in message) {
+            /* Mutter sends a fatal log when failing to connect to colord but that doesn't matter for us */
+            Test.message ("Got expected fatal colord log, not aborting");
+            return false;
+        }
+
+        return true;
     }
 
     public override void tear_down () {

--- a/tests/lib/GestureControllerTest.vala
+++ b/tests/lib/GestureControllerTest.vala
@@ -121,7 +121,9 @@ public class Gala.GestureControllerTest : MutterTestCase {
     }
 
     public override void tear_down () {
-        stage.remove_child (target.actor);
+        if (target != null) {
+            stage.remove_child (target.actor);
+        }
 
         backend = null;
         controller = null;


### PR DESCRIPTION
Currently we ignore all fatal warnings but that's not what we want. We only want to ignore a specific fatal warning and make sure unexpected fatal warnings will still fail the tests. This required a fix for a test that only passed because a fatal warning was ignored. 
The implementation also makes sure to allow custom filtering of more fatal warnings by overriding a virtual method.