### PR TITLE
Move window type methods to ManagedClient

### DIFF
--- a/src/Misc/DaemonManager.vala
+++ b/src/Misc/DaemonManager.vala
@@ -32,11 +32,7 @@ public class Gala.DaemonManager : GLib.Object {
         client = new ManagedClient (display, args);
 
         client.window_created.connect ((window) => {
-#if HAS_MUTTER49
-            window.set_type (DOCK);
-#elif HAS_MUTTER46
-            client.wayland_client.make_dock (window);
-#endif
+            ManagedClient.make_dock (window);
             window.notify["title"].connect ((obj, pspec) => handle_daemon_window ((Meta.Window) obj));
         });
     }
@@ -67,11 +63,7 @@ public class Gala.DaemonManager : GLib.Object {
                 break;
 
             case "MODAL":
-#if HAS_MUTTER49
-                window.set_type (Meta.WindowType.DOCK);
-#elif HAS_MUTTER46
-                client.wayland_client.make_dock (window);
-#endif
+                ManagedClient.make_dock (window);
                 window.move_frame (false, 0, 0);
                 window.make_above ();
                 window.stick ();

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -15,7 +15,7 @@ public class Gala.ManagedClient : Object {
 
     public Meta.Display display { private get; construct; }
     public string[] args { private get; construct; }
-    
+
     private static Gee.List<unowned ManagedClient> instances = new Gee.LinkedList<unowned ManagedClient> (null);
     private Meta.WaylandClient? wayland_client;
     private Subprocess? subprocess;
@@ -52,7 +52,7 @@ public class Gala.ManagedClient : Object {
             start_x.begin ();
         }
     }
-    
+
     public static void make_dock (Meta.Window window) {
 #if HAS_MUTTER49
         window.set_type (Meta.WindowType.DOCK);
@@ -94,7 +94,7 @@ public class Gala.ManagedClient : Object {
         xdisplay.change_property (x_window, atom, X.XA_ATOM, 32, X.PropMode.Replace, (uchar[]) dock_atom, 1);
     }
 #endif
-    
+
     public static void make_desktop (Meta.Window window) {
 #if HAS_MUTTER49
         window.set_type (Meta.WindowType.DESKTOP);

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -16,12 +16,16 @@ public class Gala.ManagedClient : Object {
     public Meta.Display display { private get; construct; }
     public string[] args { private get; construct; }
     
-    private static Gee.List<ManagedClient> instances = new Gee.LinkedList<ManagedClient> (null);
+    private static Gee.List<unowned ManagedClient> instances = new Gee.LinkedList<unowned ManagedClient> (null);
     private Meta.WaylandClient? wayland_client;
     private Subprocess? subprocess;
 
     public ManagedClient (Meta.Display display, string[] args) {
         Object (display: display, args: args);
+    }
+
+    ~ManagedClient () {
+        instances.remove (this);
     }
 
     construct {

--- a/src/ShellClients/ManagedClient.vala
+++ b/src/ShellClients/ManagedClient.vala
@@ -13,11 +13,11 @@
 public class Gala.ManagedClient : Object {
     public signal void window_created (Meta.Window window);
 
-    public Meta.Display display { get; construct; }
-    public string[] args { get; construct; }
-
-    public Meta.WaylandClient? wayland_client { get; private set; }
-
+    public Meta.Display display { private get; construct; }
+    public string[] args { private get; construct; }
+    
+    private static Gee.List<ManagedClient> instances = new Gee.LinkedList<ManagedClient> (null);
+    private Meta.WaylandClient? wayland_client;
     private Subprocess? subprocess;
 
     public ManagedClient (Meta.Display display, string[] args) {
@@ -25,6 +25,8 @@ public class Gala.ManagedClient : Object {
     }
 
     construct {
+        instances.add (this);
+
         if (Meta.Util.is_wayland_compositor ()) {
             start_wayland.begin ();
 
@@ -46,6 +48,73 @@ public class Gala.ManagedClient : Object {
             start_x.begin ();
         }
     }
+    
+    public static void make_dock (Meta.Window window) {
+#if HAS_MUTTER49
+        window.set_type (Meta.WindowType.DOCK);
+#else
+        if (Meta.Util.is_wayland_compositor ()) {
+            make_dock_wayland (window);
+        } else {
+            make_dock_x11 (window);
+        }
+#endif
+    }
+
+#if !HAS_MUTTER49
+    private static void make_dock_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
+        foreach (var client in instances) {
+            if (client.wayland_client.owns_window (window)) {
+#if HAS_MUTTER46
+                client.wayland_client.make_dock (window);
+#endif
+                break;
+            }
+        }
+    }
+
+    private static void make_dock_x11 (Meta.Window window) requires (!Meta.Util.is_wayland_compositor ()) {
+        unowned var x11_display = window.display.get_x11_display ();
+
+#if HAS_MUTTER46
+        var x_window = x11_display.lookup_xwindow (window);
+#else
+        var x_window = window.get_xwindow ();
+#endif
+        // gtk3's gdk_x11_window_set_type_hint() is used as a reference
+        unowned var xdisplay = x11_display.get_xdisplay ();
+        var atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE", false);
+        var dock_atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE_DOCK", false);
+
+        // 32 is format
+        xdisplay.change_property (x_window, atom, X.XA_ATOM, 32, X.PropMode.Replace, (uchar[]) dock_atom, 1);
+    }
+#endif
+    
+    public static void make_desktop (Meta.Window window) {
+#if HAS_MUTTER49
+        window.set_type (Meta.WindowType.DESKTOP);
+#else
+        if (Meta.Util.is_wayland_compositor ()) {
+            make_desktop_wayland (window);
+        } else {
+            critical ("Making desktop window on X11 is not supported.");
+        }
+#endif
+    }
+
+#if !HAS_MUTTER49
+    private static void make_desktop_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
+        foreach (var client in instances) {
+            if (client.wayland_client.owns_window (window)) {
+#if HAS_MUTTER46
+                client.wayland_client.make_desktop (window);
+#endif
+                break;
+            }
+        }
+    }
+#endif
 
     private async void start_wayland () {
         var subprocess_launcher = new GLib.SubprocessLauncher (INHERIT_FDS);

--- a/src/ShellClients/NotificationsClient.vala
+++ b/src/ShellClients/NotificationsClient.vala
@@ -21,11 +21,7 @@ public class Gala.NotificationsClient : Object {
             window.set_data (NOTIFICATION_DATA_KEY, true);
             window.make_above ();
             window.stick ();
-#if HAS_MUTTER49
-            window.set_type (Meta.WindowType.DOCK);
-#elif HAS_MUTTER46
-            client.wayland_client.make_dock (window);
-#endif
+            ManagedClient.make_dock (window);
         });
     }
 }

--- a/src/ShellClients/ShellClientsManager.vala
+++ b/src/ShellClients/ShellClientsManager.vala
@@ -138,82 +138,13 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
         }
     }
 
-    private void make_dock (Meta.Window window) {
-#if HAS_MUTTER49
-        window.set_type (Meta.WindowType.DOCK);
-#else
-        if (Meta.Util.is_wayland_compositor ()) {
-            make_dock_wayland (window);
-        } else {
-            make_dock_x11 (window);
-        }
-#endif
-    }
-
-#if !HAS_MUTTER49
-    private void make_dock_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
-        foreach (var client in protocol_clients) {
-            if (client.wayland_client.owns_window (window)) {
-#if HAS_MUTTER46
-                client.wayland_client.make_dock (window);
-#endif
-                break;
-            }
-        }
-    }
-
-    private void make_dock_x11 (Meta.Window window) requires (!Meta.Util.is_wayland_compositor ()) {
-        unowned var x11_display = wm.get_display ().get_x11_display ();
-
-#if HAS_MUTTER46
-        var x_window = x11_display.lookup_xwindow (window);
-#else
-        var x_window = window.get_xwindow ();
-#endif
-        // gtk3's gdk_x11_window_set_type_hint() is used as a reference
-        unowned var xdisplay = x11_display.get_xdisplay ();
-        var atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE", false);
-        var dock_atom = xdisplay.intern_atom ("_NET_WM_WINDOW_TYPE_DOCK", false);
-
-        // (X.Atom) 4 is XA_ATOM
-        // 32 is format
-        // 0 means replace
-        xdisplay.change_property (x_window, atom, (X.Atom) 4, 32, 0, (uchar[]) dock_atom, 1);
-    }
-#endif
-
-    private void make_desktop (Meta.Window window) {
-#if HAS_MUTTER49
-        window.set_type (Meta.WindowType.DESKTOP);
-#else
-        if (Meta.Util.is_wayland_compositor ()) {
-            make_desktop_wayland (window);
-        } else {
-            critical ("Making desktop window on X11 is not supported.");
-        }
-#endif
-    }
-
-#if !HAS_MUTTER49
-    private void make_desktop_wayland (Meta.Window window) requires (Meta.Util.is_wayland_compositor ()) {
-        foreach (var client in protocol_clients) {
-            if (client.wayland_client.owns_window (window)) {
-#if HAS_MUTTER46
-                client.wayland_client.make_desktop (window);
-#endif
-                break;
-            }
-        }
-    }
-#endif
-
     public void set_anchor (Meta.Window window, Pantheon.Desktop.Anchor anchor) {
         if (window in panel_windows) {
             panel_windows[window].anchor = anchor;
             return;
         }
 
-        make_dock (window);
+        ManagedClient.make_dock (window);
         // TODO: Return if requested by window that's not a trusted client?
 
         panel_windows[window] = new PanelWindow (wm, window, anchor);
@@ -273,7 +204,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
 
     public void request_visible_in_multitasking_view (Meta.Window window) {
         if (!(window in panel_windows)) {
-            warning ("Set anchor for window before visible in mutltiasking view.");
+            warning ("Set anchor for window before visible in multitasking view.");
             return;
         }
 
@@ -316,7 +247,7 @@ public class Gala.ShellClientsManager : Object, GestureTarget {
     }
 
     public void make_greeter (Meta.Window window) {
-        make_desktop (window);
+        ManagedClient.make_desktop (window);
 
         wm.override_window_group (window, LOCK_SCREEN);
     }


### PR DESCRIPTION
I think it makes sense to move it here until we require Mutter 49. Removes checking for mutter version across the codebase. In the future this will allow us to easily replace `ManagedClient.make_dock (window)` with `window.set_type (DOCK)`