### PR TITLE
Add a workflow that checks for missing and invalid files in POTFILES

### DIFF
--- a/.github/workflows/check-potfiles.sh
+++ b/.github/workflows/check-potfiles.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+missing=0
+invalid=0
+
+git ls-files | grep -E '\.(vala|desktop.in|metainfo.xml.in)$' | while read -r file; do
+    if grep -q -E '\b((_|C_|N_)\(|ngettext \()' "$file"; then
+        if ! grep -q "^$file$" po/POTFILES; then
+            echo "Missing from POTFILES: $file"
+            missing=1
+        fi
+    fi
+done
+
+while IFS= read -r file; do
+    if [[ -z "$file" ]]; then
+        continue
+    fi
+
+    if [[ ! -f "$file" ]]; then
+        echo "Found in POTFILES but missing: $file"
+        invalid=1
+    fi
+done < po/POTFILES
+
+exit $((missing || invalid))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,3 +103,14 @@ jobs:
         io.elementary.vala-lint -d plugins
         io.elementary.vala-lint -d src
         io.elementary.vala-lint -d tests
+
+  potfiles:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v6
+
+      - name: Check POTFILES
+        run: bash .github/workflows/check-potfiles.sh
+

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,6 +3,7 @@ daemon/IBus/CandidateArea.vala
 daemon/IBus/CandidateBox.vala
 daemon/IBus/IBusCandidateWindow.vala
 daemon/IBus/IBusService.vala
+daemon/OSK/Window/Keyboard/KeyButton.vala
 daemon/DBus.vala
 daemon/DisplayConfig.vala
 daemon/Main.vala
@@ -65,6 +66,7 @@ lib/Constants.vala
 lib/DragDropAction.vala
 lib/Plugin.vala
 lib/SessionSettings.vala
+lib/TransitionBuilder.vala
 lib/Utils.vala
 lib/WindowManager.vala
 
@@ -151,6 +153,5 @@ src/InternalUtils.vala
 src/Main.vala
 src/PantheonShell.vala
 src/SuperScrollAction.vala
-src/TransitionBuilder.vala
 src/WindowListModel.vala
 src/WindowManager.vala


### PR DESCRIPTION
I always forget to update them. 
This is taken from flatpak: https://github.com/flatpak/flatpak/blob/main/.github/workflows/check-potfiles.yml and the corresponding script but I simplified it a lot. I know very little bash so lmk if something looks off.

It looks for .vala, .desktop.in and .metainfo.xml.in files and if they contain _( it checks whether they are in the POTFILES

Then it looks through all POTFILES and checks if they exist

First commit adds the check and I confirmed that it fails. Second commit fixes the potfiles and now it passes.