### PR TITLE
Daemon: Fix dbus name

### DIFF
--- a/daemon/Main.vala
+++ b/daemon/Main.vala
@@ -8,7 +8,7 @@ public class Gala.Daemon.Application : Gtk.Application {
     private OSKManager osk_manager;
 
     public Application () {
-        Object (application_id: "io.elementary.desktop.gala-daemon");
+        Object (application_id: "org.pantheon.gala.daemon");
     }
 
     construct {
@@ -31,6 +31,9 @@ public class Gala.Daemon.Application : Gtk.Application {
         var app_provider = new Gtk.CssProvider ();
         app_provider.load_from_resource ("/io/elementary/desktop/gala-daemon/gala-daemon.css");
         Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), app_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        var icon_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
+        icon_theme.add_resource_path ("/io/elementary/desktop/gala-daemon/icons");
     }
 
     public override void activate () {


### PR DESCRIPTION
Fixes WindowMenu, BackgroundMenu and daemon monitor labels not working.

In #2881 the daemon app id was changed to `io.elementary.desktop.gala-daemon`. But it seems the app id is used to determine the name of the default dbus connection. Therefore the dbus interface was now provided on the bus name `io.elementary.desktop.gala-daemon`. So since also others (the display plug) use this interface revert to the old name for now and add the gresource search path manually to the icon theme. I'd be all for doing a big rename across gala and consumers regarding dbus names, app ids etc. for OS 9 but I want to get this quick fix in.