### PR TITLE
MultitaskingView: Only grab focus on ws switch if we are open

### DIFF
--- a/src/Widgets/MultitaskingView/MultitaskingView.vala
+++ b/src/Widgets/MultitaskingView/MultitaskingView.vala
@@ -307,10 +307,12 @@ public class Gala.MultitaskingView : Root, RootTarget {
                     target_workspace.activate (display.get_current_time ());
                 }
 
-                /* Activating a workspace will set the input focus to the stage so recapture it
+                /* Activating a workspace will set the input focus to the stage so recapture it if we are open
                    (Gala.Root will automatically recapture it if we try to move the focus but we want
                    it right away for escape to work) */
-                grab_key_focus ();
+                if (opened) {
+                    grab_key_focus ();
+                }
 
                 break;
 


### PR DESCRIPTION
A commit can happen even when we are not open anytime that a workspace was reordered, added or removed. In those cases we don't want to grab focus because that will cause the focused window to stop receiving keyboard input.

A particular case where this was a problem was when moving windows via a gesture or the keyboard shortcut. There when the animation is over we call thaw_remove on the workspace manager and because a window
was moved from a workspace chances are high we will get a new one or one will be removed. In that case the window would immediately stop receiving keyboard
input even though it still appears focused.

Fixes #2884 