### PR TITLE
Fix Clutter.Settings.get_default is deprecated warning

### DIFF
--- a/vapi/mutter-clutter.vapi
+++ b/vapi/mutter-clutter.vapi
@@ -6991,7 +6991,9 @@ namespace Clutter {
 	public sealed class Settings : GLib.Object {
 		[CCode (has_construct_function = false)]
 		protected Settings ();
+#if HAS_MUTTER47
 		[Version (deprecated = true)]
+#endif
 		public static unowned Clutter.Settings get_default ();
 		[NoAccessorMethod]
 		public int dnd_drag_threshold { get; set; }


### PR DESCRIPTION
It was deprecated in https://gitlab.gnome.org/GNOME/mutter/-/commit/1abbfb5ed271765d73f5950fc7212c416ad9087c