### PR TITLE
WindowMenu:  Fix move/resize actions

### DIFF
--- a/src/Misc/WindowMenuManager.vala
+++ b/src/Misc/WindowMenuManager.vala
@@ -180,11 +180,27 @@ public class Gala.WindowMenuManager : Object {
     }
 
     private void on_move (SimpleAction action, Variant? parameters) {
-        wm.perform_action (START_MOVE_CURRENT);
+        begin_grab_op (KEYBOARD_MOVING);
     }
 
     private void on_resize (SimpleAction action, Variant? parameters) {
-        wm.perform_action (START_RESIZE_CURRENT);
+        begin_grab_op (KEYBOARD_RESIZING_UNKNOWN);
+    }
+
+    private void begin_grab_op (Meta.GrabOp op) {
+#if HAS_MUTTER49
+        var device = Clutter.get_default_backend ().get_pointer_sprite (wm.stage);
+#else
+        var device = Clutter.get_default_backend ().get_default_seat ().get_pointer ();
+#endif
+
+        current_window.begin_grab_op (
+            op, device,
+#if !HAS_MUTTER49
+            null,
+#endif
+            wm.get_display ().get_current_time (), null
+        );
     }
 
     private void on_maximize (SimpleAction action, Variant? parameters) {

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -605,35 +605,6 @@ namespace Gala {
             });
         }
 
-        private void set_grab_trigger (Meta.Window window, Meta.GrabOp op) {
-            var proxy = push_modal (stage, true);
-
-            ulong handler = 0;
-            handler = stage.captured_event.connect ((event) => {
-                if (event.get_type () == MOTION || event.get_type () == ENTER ||
-                    event.get_type () == TOUCHPAD_HOLD || event.get_type () == TOUCH_BEGIN) {
-                    window.begin_grab_op (
-                        op,
-                        null,
-#if !HAS_MUTTER49
-                        event.get_event_sequence (),
-#endif
-                        event.get_time ()
-                        , null
-                    );
-                } else if (event.get_type () == LEAVE) {
-                    /* We get leave emitted when beginning a grab op, so we have
-                       to filter it in order to avoid disconnecting and popping twice */
-                    return Clutter.EVENT_PROPAGATE;
-                }
-
-                pop_modal (proxy);
-                stage.disconnect (handler);
-
-                return Clutter.EVENT_PROPAGATE;
-            });
-        }
-
         /**
          * {@inheritDoc}
          */
@@ -672,12 +643,10 @@ namespace Gala {
                         current.minimize ();
                     break;
                 case ActionType.START_MOVE_CURRENT:
-                    if (current != null && current.allows_move ())
-                        set_grab_trigger (current, KEYBOARD_MOVING);
+                    warning ("Action START_MOVE_CURRENT is deprecated");
                     break;
                 case ActionType.START_RESIZE_CURRENT:
-                    if (current != null && current.allows_resize ())
-                        set_grab_trigger (current, KEYBOARD_RESIZING_UNKNOWN);
+                    warning ("Action START_RESIZE_CURRENT is deprecated");
                     break;
                 case ActionType.TOGGLE_ALWAYS_ON_TOP_CURRENT:
                     if (current == null)


### PR DESCRIPTION
The issue was that we didn't provide a device when calling `window.begin_grab_op`.

While here I used the opportunity to move the logic to the WindowMenuManager. Since there we now know for which window we are showing the window menu we don't have to do the workaround with set_grab_trigger and instead can begin the grab op immediately. 
This brings the little UX improvement that now after you click the move menu item your cursor immediately jumps to the center of the window and becomes the move cursor whereas with the old version (if it would work) it would only do that once you move the cursor a bit which might be confusing for users.

Since I don't think anybody else uses these actions via dbus I deprecated them and removed the related code from window manager.