### PR TITLE
WindowMenu: Use unique bus name

### DIFF
--- a/daemon-gtk3/DBus.vala
+++ b/daemon-gtk3/DBus.vala
@@ -32,8 +32,8 @@ public class Gala.Daemon.DBus : GLib.Object {
             return;
         }
 
-        var menu_model = DBusMenuModel.get (connection, "org.pantheon.gala", "/io/elementary/gala/window_menu");
-        var action_group = DBusActionGroup.get (connection, "org.pantheon.gala", "/io/elementary/gala/window_menu");
+        var menu_model = DBusMenuModel.get (connection, "io.elementary.gala.WindowMenu", "/io/elementary/gala/WindowMenu");
+        var action_group = DBusActionGroup.get (connection, "io.elementary.gala.WindowMenu", "/io/elementary/gala/WindowMenu");
 
         window_menu = new Gtk.Menu.from_model (menu_model);
         window_menu.insert_action_group ("window-menu", action_group);

--- a/daemon/DBus.vala
+++ b/daemon/DBus.vala
@@ -75,8 +75,8 @@ public class Gala.Daemon.DBus : GLib.Object {
             return;
         }
 
-        var menu_model = DBusMenuModel.get (connection, "io.elementary.gala", "/io/elementary/gala/WindowMenu");
-        var action_group = DBusActionGroup.get (connection, "io.elementary.gala", "/io/elementary/gala/WindowMenu");
+        var menu_model = DBusMenuModel.get (connection, "io.elementary.gala.WindowMenu", "/io/elementary/gala/WindowMenu");
+        var action_group = DBusActionGroup.get (connection, "io.elementary.gala.WindowMenu", "/io/elementary/gala/WindowMenu");
 
         window_menu = new Gtk.PopoverMenu.from_model (menu_model) {
             halign = START,

--- a/src/Misc/WindowMenuManager.vala
+++ b/src/Misc/WindowMenuManager.vala
@@ -54,7 +54,7 @@ public class Gala.WindowMenuManager : Object {
 
         menu = new Menu ();
 
-        Bus.own_name (SESSION, "io.elementary.gala", NONE, null, on_name_acquired, null);
+        Bus.own_name (SESSION, "io.elementary.gala.WindowMenu", NONE, null, on_name_acquired, null);
     }
 
     private void on_name_acquired (DBusConnection connection, string name) {


### PR DESCRIPTION
We currently do Bus.own_name with the same name in two places causing one to loose the name (DBus.vala prints a warning on every start). Everything is still working and all exported objects are still there and functioning but I think it's better to not rely on that. 
So now we have two options:
- have DBus.vala export the menu and action group
- use another bus name

I went with the second option because it keeps everything neatly contained in the WindowMenuManager and also regarding naming conventions this is how e.g. mutter (and most others?) do it (mutter uses a matching bus name for every object it exports).
I don't have much of an opinion here so we can also go with the first option :shrug: 

While here fix an oversight in the gtk3 daemon where old object paths were used.