### PR TITLE
NotificationStack: Use transition builder for destroy animation

### DIFF
--- a/src/Misc/NotificationStack.vala
+++ b/src/Misc/NotificationStack.vala
@@ -163,17 +163,15 @@ public class Gala.NotificationStack : Object {
         }
     }
 
-    public void destroy_notification (Meta.WindowActor notification) {
-        notification.save_easing_state ();
-        notification.set_easing_duration (Utils.get_animation_duration (AnimationDuration.CLOSE));
-        notification.set_easing_mode (Clutter.AnimationMode.EASE_IN_QUAD);
-        notification.opacity = 0;
-
-        notification.x += stack_width;
-        notification.restore_easing_state ();
-
+    public async void destroy_notification (Meta.WindowActor notification) {
         notifications.remove (notification);
         update_positions ();
+
+        var builder = new TransitionBuilder (notification, AnimationDuration.CLOSE, EASE_IN_QUAD);
+        builder.add_property ("opacity", 0u);
+        builder.add_property ("x", notification.x + stack_width);
+
+        yield builder.run ();
     }
 
     /**

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1143,30 +1143,7 @@ namespace Gala {
         }
 
         public override void destroy (Meta.WindowActor actor) {
-            unowned var window = actor.get_meta_window ();
-
             actor.remove_all_transitions ();
-
-            if (NotificationStack.is_notification (window)) {
-                if (Meta.Prefs.get_gnome_animations ()) {
-                    destroying.add (actor);
-                }
-
-                notification_stack.destroy_notification (actor);
-
-                if (Meta.Prefs.get_gnome_animations ()) {
-                    ulong destroy_handler_id = 0UL;
-                    destroy_handler_id = actor.transitions_completed.connect (() => {
-                        actor.disconnect (destroy_handler_id);
-                        destroying.remove (actor);
-                        destroy_completed (actor);
-                    });
-                } else {
-                    destroy_completed (actor);
-                }
-
-                return;
-            }
 
             animate_destroy.begin (actor);
         }
@@ -1202,6 +1179,9 @@ namespace Gala {
                     break;
 
                 default:
+                    if (NotificationStack.is_notification (window)) {
+                        yield notification_stack.destroy_notification (actor);
+                    }
                     break;
             }
 


### PR DESCRIPTION
This saves a bunch of code in the WindowManager because we don't have to do some special stuff anymore when dealing with destroying notifications.