### PR TITLE
BackgroundBlurEffect: Dont update actor size in construct

### DIFF
--- a/lib/Effects/BackgroundBlurEffect.vala
+++ b/lib/Effects/BackgroundBlurEffect.vala
@@ -112,7 +112,6 @@ public class Gala.BackgroundBlurEffect : Clutter.Effect {
         round_actor_size_location = round_pipeline.get_uniform_location ("actor_size");
 
         update_clip_radius ();
-        update_actor_size ();
 
         notify["monitor-scale"].connect (update_clip_radius);
     }


### PR DESCRIPTION
When we construct a background blur effect we don't have an actor yet, we only get it once we are attached to an actor in the set_actor virtual method. This means we try to access the width/height of a null actor leading to two warnings every time a background blur effect is constructed.

Since update_actor_size () is called in set_actor anyways I think we can just remove it.