### PR TITLE
Fix 2 warnings

### DIFF
--- a/lib/Drawing/Color.vala
+++ b/lib/Drawing/Color.vala
@@ -142,7 +142,7 @@ namespace Gala.Drawing {
         *
         * If you would like to deserialize the A, R, G and B values from the integer without
         * creating a new instance of {@link Gala.Drawing.Color}, you can use the available
-        * //*_from_int// static method collection such as {@link Gala.Drawing.Color.alpha_from_int}.
+        * *_from_int static method collection such as {@link Gala.Drawing.Color.alpha_from_int}.
         *
         * @param color the integer specifying the color
         */

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -58,10 +58,6 @@ namespace Gala {
          */
         public Meta.BackgroundGroup background_group { get; protected set; }
 
-#if !HAS_MUTTER48
-        private Meta.PluginInfo info;
-#endif
-
         private LayoutManager layout_manager;
 
         public ScreenSaverManager? screensaver { get; private set; }
@@ -111,11 +107,6 @@ namespace Gala {
         private Gee.Map<Meta.Window, WindowGroup> overridden_window_group = new Gee.HashMap<Meta.Window, WindowGroup> ();
 
         construct {
-#if !HAS_MUTTER48
-            info = Meta.PluginInfo () {name = "Gala", version = Config.VERSION, author = "Gala Developers",
-                license = "GPLv3", description = "A nice elementary window manager"};
-#endif
-
             behavior_settings = new GLib.Settings ("io.elementary.desktop.wm.behavior");
 
             //Make it start watching the settings daemon bus
@@ -1346,11 +1337,5 @@ namespace Gala {
         public override Meta.InhibitShortcutsDialog create_inhibit_shortcuts_dialog (Meta.Window window) {
             return new InhibitShortcutsDialog (window_tracker.get_app_for_window (window), window);
         }
-
-#if !HAS_MUTTER48
-        public override unowned Meta.PluginInfo? plugin_info () {
-            return info;
-        }
-#endif
     }
 }


### PR DESCRIPTION
Fixes these 2 warnings:

```
warning: "/*" within comment [-Wcomment]
warning: function returns address of local variable [-Wreturn-local-addr]
```

I removed plugin_info as it is unused in mutter for 10 years https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4104