### PR TITLE
Show windows that are on all workspaces in the multitasking view

### DIFF
--- a/src/Misc/WindowListener.vala
+++ b/src/Misc/WindowListener.vala
@@ -54,7 +54,6 @@ public class Gala.WindowListener : Object {
     }
 
     public signal void window_workspace_changed (Meta.Window window);
-    public signal void window_on_all_workspaces_changed (Meta.Window window);
     public signal void window_maximized_changed (Meta.Window window) {
         WindowGeometry window_geometry = {};
         window_geometry.inner = window.get_frame_rect ();
@@ -86,9 +85,6 @@ public class Gala.WindowListener : Object {
             case "maximized-horizontally":
             case "maximized-vertically":
                 window_maximized_changed (window);
-                break;
-            case "on-all-workspaces":
-                window_on_all_workspaces_changed (window);
                 break;
             case "fullscreen":
                 window_fullscreen_changed (window);

--- a/src/Widgets/MultitaskingView/StaticWindowContainer.vala
+++ b/src/Widgets/MultitaskingView/StaticWindowContainer.vala
@@ -4,7 +4,7 @@
  */
 
 /**
- * Holds clones of static windows (e.g. on all workspaces or being moved)
+ * Holds clones of static windows (e.g. grabbed or being moved)
  * in the multitasking view and fades them out while opening the multitasking view.
  * The window container use this to know whether a window became static (they shouldn't show it anymore)
  * or isn't static anymore (they have to show it now).
@@ -29,8 +29,6 @@ public class Gala.StaticWindowContainer : Widget {
     construct {
         display.grab_op_begin.connect (on_grab_op_begin);
         display.grab_op_end.connect (on_grab_op_end);
-
-        WindowListener.get_default ().window_on_all_workspaces_changed.connect (on_all_workspaces_changed);
     }
 
     private void on_grab_op_begin (Meta.Window window, Meta.GrabOp op) {
@@ -45,14 +43,6 @@ public class Gala.StaticWindowContainer : Widget {
     private void on_grab_op_end (Meta.Window window, Meta.GrabOp op) {
         grabbed_window = null;
         check_window_changed (window);
-    }
-
-    private void on_all_workspaces_changed (Meta.Window window) {
-        // We have to wait for shell clients here
-        Idle.add (() => {
-            check_window_changed (window);
-            return Source.REMOVE;
-        });
     }
 
     public void notify_window_moving (Meta.Window window) {
@@ -83,7 +73,7 @@ public class Gala.StaticWindowContainer : Widget {
 
         if (!is_static && clone != null) {
             remove_child (clone);
-        } else if (is_static && !window.on_all_workspaces && clone == null) {
+        } else if (is_static && clone == null) {
             add_child (new StaticWindowClone (window));
         }
 
@@ -91,6 +81,6 @@ public class Gala.StaticWindowContainer : Widget {
     }
 
     public bool is_static (Meta.Window window) {
-        return window == grabbed_window || window == moving_window || window.on_all_workspaces;
+        return window == grabbed_window || window == moving_window;
     }
 }


### PR DESCRIPTION
Currently they just disappear as soon as the multitasking view is opened or workspaces are being switched. This looks weird and also blocks you from interacting with the window in the multitasking view.

So instead show them like normal windows but on every workspace. I think this makes more sense than just hiding it. Maybe we could even change the label in the window menu from "Always on visible workspace"  to something like "Show on all workspaces" and then it would make even more sense to the user.

The only alternative I could think off would be to treat it like a window that is currently moved between workspaces e.g. via the gesture. I.e. when switching workspaces just keep it at its current position and when opening the multitasking view fade it out. That's a bit more complicated to implement (but not that bad, I had a working prototype a while back somewhere) but more importantly IMO is that you wouldn't have access to managing it in the multitasking view. And I personally use pretty much exclusively the multitasking view for switching between open windows on a workspace which I couldn't do then. 

If we want to go with this here an open question would be whether we want to allow drag and drop in the multitasking view. Currently it is handled IMO quite logically that when you drag it to another workspace `on_all_workspaces` is unset and it's once again a normal window on the workspace you moved it to. 