### PR TITLE
Scale down maximized windows when moving them between workspaces

### DIFF
--- a/src/Widgets/MultitaskingView/StaticWindowClone.vala
+++ b/src/Widgets/MultitaskingView/StaticWindowClone.vala
@@ -26,5 +26,45 @@ public class Gala.StaticWindowClone : Widget {
 
         window_actor.bind_property ("x", this, "x", SYNC_CREATE);
         window_actor.bind_property ("y", this, "y", SYNC_CREATE);
+
+        set_pivot_point (0.5f, 0.5f);
+
+        window.notify["maximized-horizontally"].connect (on_maximized_changed);
+        window.notify["maximized-vertically"].connect (on_maximized_changed);
+        on_maximized_changed ();
+    }
+
+    public override void update_progress (GestureAction action, double progress) {
+        if (action == SWITCH_WORKSPACE && window.maximized_horizontally && window.maximized_vertically) {
+            /* When moving a maximized window between workspaces the user can't see the animation
+               because it is completely covered by the window. Therefore the user has no indication
+               that something is actually happening. Solve this by scaling the window down a bit so
+               that the user can see the animation. */
+
+            /* We want the final value (`inverted`) to run between integer
+               values from 0 to 1 at the half way point back to 0. */
+            var normalized_progress = progress - Math.floor (progress);
+            var absolute = (normalized_progress - 0.5).abs () * 2;
+            var inverted = 1.0 - absolute;
+
+            /* Then apply an exponential ease so that we get small very fast and only
+               very late big again. This way the user sees most of the transition
+               animation which carries the info that we are actually switching workspaces */
+            var expo_eased = inverted == 1.0 ? 1.0 : 1.0 - Math.pow (2, -10 * inverted);
+
+            var scale = 1.0 - (0.25 * expo_eased);
+            set_scale (scale, scale);
+        }
+    }
+
+    private void on_maximized_changed () {
+        clear_effects ();
+
+        if (window.maximized_horizontally && window.maximized_vertically) {
+            var monitor_scale = window.display.get_monitor_scale (window.get_monitor ());
+            add_effect (new ShadowEffect ("window", monitor_scale));
+        } else {
+            set_scale (1.0, 1.0);
+        }
     }
 }


### PR DESCRIPTION
When moving a maximized window between workspaces (e.g. via the gesture or via the keyboard shortcut) the user can't see the animation because it is completely covered by the window. Therefore the user has no indication that something is actually happening. Solve this by scaling the window down a bit so that the user can see the animation.

Fixes #2799

IMO this works pretty well with gestures and with keyboard shortcuts if we move only one workspace (even though it's already a bit fast in that case). But it gets quite jarring when moving over multiple workspace via keyboard shortcuts (super + alt + number of workspace you want to move to). This can be seen at the end of the video. The reason for this is, that since with the gesture we don't know on which workspace we will end up we scale down and back up between every workspace. However in the case where you switch over multiple workspace via shortcut the same time that is usually used for scaling down and back up once is now used to scale down and backup as many times as workspace you switch over. 
So ig this is better than no indication at all for now but if somebody has ideas to improve this or completely different ideas I'd be very happy about them :)
I will probably do some experiments in trying to differentiate the cases and when switching via shortcuts only scale down and up once no matter how many workspace you switch over which should fix the jarring in that case. But in general I'd be happy about some feedback regarding the general direction.

[Kooha-2026-08-14-16-03-46.webm](https://github.com/user-attachments/assets/d56cad5c-1f55-4021-b3df-5ca4878ef0c2)
