### PR TITLE
Release 8.6.0

### DIFF
--- a/data/gala.metainfo.xml.in
+++ b/data/gala.metainfo.xml.in
@@ -27,6 +27,24 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.6.0" date="2026-08-30" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Show transient windows over their parents in the multitasking view</li>
+          <li>Added a brand new on screen keyboard for the secure session</li>
+          <li>Screenshotting a window now includes open menus</li>
+          <li>On touchscreens swiping up from the bottom will now open the multitasking view</li>
+          <li>Fixed various edge cases that could lead to glitches with minimize and maximize animations</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/gala/issues/2727">Task switcher is very sensitive to mouse movement</issue>
+        <issue url="https://github.com/elementary/gala/issues/824">"Current window" doesn't include children like popovers</issue>
+      </issues>
+    </release>
+
     <release version="8.5.1" date="2026-05-12" urgency="medium">
       <description>
         <p>Improvements:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('gala',
     'vala',
-    version: '8.5.1',
+    version: '8.6.0',
     meson_version: '>= 0.59.0',
     license: 'GPL3',
     default_options: [


### PR DESCRIPTION
I think gala is in a pretty good state right now so let's do one last release for OS 8 with quite a few goodies and after a week or two allow requiring OS 9.

I think now is a good time to do this so that we can focus on OS 9. E.g. I have just upgraded my main system to OS 9 so I won't be able to test any gala changes on older mutter. Things like wingpanel and granite are OS 9 exclusive now as well so I think it makes sense :)