### PR TITLE
Fix notifications on X11

### DIFF
--- a/lib/TransitionBuilder.vala
+++ b/lib/TransitionBuilder.vala
@@ -48,17 +48,28 @@ public class Gala.TransitionBuilder : Object {
         group.add_transition (property_transition);
     }
 
-    public async void run () {
+    /**
+     * Runs the transitions added to #this. Returns true if the transitions
+     * fully completed and false if they were somehow interrupted (e.g.
+     * the actor was destroyed or remove all transitions was called).
+     */
+    public async bool run () {
         if (!Meta.Prefs.get_gnome_animations ()) {
-            return;
+            return true;
         }
 
-        var stopped_handler_id = group.stopped.connect (() => run.callback ());
+        bool is_finished = false;
+        var stopped_handler_id = group.stopped.connect ((_is_finished) => {
+            is_finished = _is_finished;
+            run.callback ();
+        });
 
         actor.add_transition (Uuid.string_random (), group);
 
         yield;
 
         group.disconnect (stopped_handler_id);
+
+        return is_finished;
     }
 }

--- a/src/Misc/NotificationStack.vala
+++ b/src/Misc/NotificationStack.vala
@@ -163,7 +163,7 @@ public class Gala.NotificationStack : Object {
         }
     }
 
-    public async void destroy_notification (Meta.WindowActor notification) {
+    public async bool destroy_notification (Meta.WindowActor notification) {
         notifications.remove (notification);
         update_positions ();
 
@@ -171,7 +171,7 @@ public class Gala.NotificationStack : Object {
         builder.add_property ("opacity", 0u);
         builder.add_property ("x", notification.x + stack_width);
 
-        yield builder.run ();
+        return yield builder.run ();
     }
 
     /**

--- a/src/WindowManager.vala
+++ b/src/WindowManager.vala
@@ -1155,7 +1155,15 @@ namespace Gala {
 
                 default:
                     if (NotificationStack.is_notification (window)) {
-                        yield notification_stack.destroy_notification (actor);
+                        if (!(yield notification_stack.destroy_notification (actor)) && window.window_type == NOTIFICATION) {
+                            /* This is a workaround for X11. On X11 notifications actually get the window type
+                               notification which is according to mutter not allowed to have any destroy animations.
+                               Therefore if the destroy animation didn't finish this means it was interrupted probably
+                               because mutter destroyed the actor already so don't call destroy_completed
+                               because that would lead to a use after free. */
+                            destroying.remove (actor);
+                            return;
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
Fixes #2919 

Use rebase to merge then we can easily revert the second commit which is the X11 workaround while keeping the first which might come in handy later.